### PR TITLE
api: implement re-run endpoints for patchsets and patches

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -51,6 +51,12 @@ pub struct PatchQuery {
 }
 
 #[derive(Deserialize)]
+pub struct RerunPatchQuery {
+    pub patchset_id: i64,
+    pub patch_id: i64,
+}
+
+#[derive(Deserialize)]
 pub struct SubsystemQuery {
     pub subsystem_id: Option<i64>,
 }
@@ -107,6 +113,8 @@ pub async fn run_server(
         .route("/api/stats/reviews", get(stats_reviews))
         .route("/api/stats/tools", get(stats_tools))
         .route("/api/submit", post(submit_patch))
+        .route("/api/patchset/rerun", post(rerun_patchset))
+        .route("/api/patch/rerun", post(rerun_patch))
         .route("/", get_service(ServeFile::new("static/index.html")))
         .nest_service("/static", ServeDir::new("static"))
         .with_state(state);
@@ -461,4 +469,50 @@ async fn stats_tools(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
     Ok(Json(data))
+}
+
+async fn rerun_patchset(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<PatchQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !addr.ip().is_loopback() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let id = query
+        .id
+        .parse::<i64>()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    state.db.rerun_patchset(id).await.map_err(|e| {
+        error!("Failed to rerun patchset {}: {}", id, e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(serde_json::json!({ "status": "accepted" })))
+}
+
+async fn rerun_patch(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<RerunPatchQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !addr.ip().is_loopback() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    state
+        .db
+        .rerun_patch(query.patchset_id, query.patch_id)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to rerun patch {} in patchset {}: {}",
+                query.patch_id, query.patchset_id, e
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(serde_json::json!({ "status": "accepted" })))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -35,6 +35,7 @@ pub struct PatchsetRow {
     pub findings_critical: Option<i64>,
     pub baseline_id: Option<i64>,
     pub failed_reason: Option<String>,
+    pub target_review_count: Option<u32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -332,6 +333,9 @@ impl Database {
         let _ = self
             .try_add_column("patchsets", "failed_reason", "TEXT")
             .await;
+        let _ = self
+            .try_add_column("patchsets", "target_review_count", "INTEGER DEFAULT 1")
+            .await;
 
         let _ = self
             .conn
@@ -402,23 +406,40 @@ impl Database {
         patch_id: i64,
         baseline_id: Option<i64>,
     ) -> Result<bool> {
+        Ok(self
+            .count_successful_reviews(patchset_id, patch_id, baseline_id)
+            .await?
+            > 0)
+    }
+
+    pub async fn count_successful_reviews(
+        &self,
+        patchset_id: i64,
+        patch_id: i64,
+        baseline_id: Option<i64>,
+    ) -> Result<usize> {
         let mut rows = if let Some(bid) = baseline_id {
             self.conn
                 .query(
-                    "SELECT 1 FROM reviews WHERE patchset_id = ? AND patch_id = ? AND baseline_id = ? AND status = 'Reviewed'",
+                    "SELECT COUNT(*) FROM reviews WHERE patchset_id = ? AND patch_id = ? AND baseline_id = ? AND status = 'Reviewed'",
                     libsql::params![patchset_id, patch_id, bid],
                 )
                 .await?
         } else {
             self.conn
                 .query(
-                    "SELECT 1 FROM reviews WHERE patchset_id = ? AND patch_id = ? AND baseline_id IS NULL AND status = 'Reviewed'",
+                    "SELECT COUNT(*) FROM reviews WHERE patchset_id = ? AND patch_id = ? AND baseline_id IS NULL AND status = 'Reviewed'",
                     libsql::params![patchset_id, patch_id],
                 )
                 .await?
         };
 
-        Ok(rows.next().await.ok().flatten().is_some())
+        if let Ok(Some(row)) = rows.next().await {
+            let count: i64 = row.get(0)?;
+            Ok(count as usize)
+        } else {
+            Ok(0)
+        }
     }
 
     pub async fn has_failed_review(
@@ -1766,19 +1787,28 @@ impl Database {
 
         let sql = format!(
             "SELECT p.id, p.subject, p.status, p.thread_id, p.author, p.date, p.cover_letter_message_id, p.total_parts, p.received_parts, GROUP_CONCAT(s.name, ','),
-             COALESCE(f.low, 0), COALESCE(f.medium, 0), COALESCE(f.high, 0), COALESCE(f.critical, 0), p.baseline_id, p.failed_reason
+             COALESCE(f.low, 0), COALESCE(f.medium, 0), COALESCE(f.high, 0), COALESCE(f.critical, 0), p.baseline_id, p.failed_reason, p.target_review_count
              FROM patchsets p
              LEFT JOIN patchsets_subsystems ps ON p.id = ps.patchset_id
              LEFT JOIN subsystems s ON ps.subsystem_id = s.id
              LEFT JOIN (
-                SELECT r.patchset_id,
-                    SUM(CASE WHEN f.severity = 1 THEN 1 ELSE 0 END) as low,
-                    SUM(CASE WHEN f.severity = 2 THEN 1 ELSE 0 END) as medium,
-                    SUM(CASE WHEN f.severity = 3 THEN 1 ELSE 0 END) as high,
-                    SUM(CASE WHEN f.severity = 4 THEN 1 ELSE 0 END) as critical
-                FROM reviews r
-                JOIN findings f ON r.id = f.review_id
-                GROUP BY r.patchset_id
+                SELECT patchset_id,
+                    MAX(low) as low,
+                    MAX(medium) as medium,
+                    MAX(high) as high,
+                    MAX(critical) as critical
+                FROM (
+                    SELECT r.patchset_id, r.id,
+                        SUM(CASE WHEN f.severity = 1 THEN 1 ELSE 0 END) as low,
+                        SUM(CASE WHEN f.severity = 2 THEN 1 ELSE 0 END) as medium,
+                        SUM(CASE WHEN f.severity = 3 THEN 1 ELSE 0 END) as high,
+                        SUM(CASE WHEN f.severity = 4 THEN 1 ELSE 0 END) as critical
+                    FROM reviews r
+                    JOIN findings f ON r.id = f.review_id
+                    WHERE r.status = 'Reviewed'
+                    GROUP BY r.id
+                )
+                GROUP BY patchset_id
              ) f ON p.id = f.patchset_id
              {} 
              GROUP BY p.id
@@ -1824,6 +1854,7 @@ impl Database {
                 findings_critical: row.get(13).ok(),
                 baseline_id: row.get(14).ok(),
                 failed_reason: row.get(15).ok(),
+                target_review_count: row.get(16).ok(),
             });
         }
         Ok(patchsets)
@@ -2132,7 +2163,7 @@ impl Database {
 
     pub async fn get_pending_patchsets(&self, limit: usize) -> Result<Vec<PatchsetRow>> {
         let mut rows = self.conn.query(
-            "SELECT id, subject, status, thread_id, author, date, cover_letter_message_id, total_parts, received_parts, baseline_id, failed_reason 
+            "SELECT id, subject, status, thread_id, author, date, cover_letter_message_id, total_parts, received_parts, baseline_id, failed_reason, target_review_count
              FROM patchsets WHERE status = 'Pending' ORDER BY date ASC LIMIT ?",
             libsql::params![limit as i64],
         ).await?;
@@ -2156,6 +2187,7 @@ impl Database {
                 findings_critical: None,
                 baseline_id: row.get(9).ok(),
                 failed_reason: row.get(10).ok(),
+                target_review_count: row.get(11).ok(),
             });
         }
         Ok(patchsets)
@@ -2169,6 +2201,33 @@ impl Database {
             )
             .await?;
         Ok(())
+    }
+
+    pub async fn rerun_patchset(&self, id: i64) -> Result<()> {
+        // 1. Reset patchset status to Pending
+        self.conn
+            .execute(
+                "UPDATE patchsets SET status = 'Pending' WHERE id = ?",
+                libsql::params![id],
+            )
+            .await?;
+
+        // 2. Increment target_review_count
+        self.conn
+            .execute(
+                "UPDATE patchsets SET target_review_count = COALESCE(target_review_count, 1) + 1 WHERE id = ?",
+                libsql::params![id],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn rerun_patch(&self, patchset_id: i64, _patch_id: i64) -> Result<()> {
+        // NOTE: Currently we only support re-running the entire patchset to trigger more reviews.
+        // Even if the user requested a specific patch, we increment the set's target count
+        // to allow the reviewer service to proceed.
+        self.rerun_patchset(patchset_id).await
     }
 
     pub async fn create_fetching_patchset(&self, article_id: &str, subject: &str) -> Result<i64> {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -27,6 +27,7 @@ struct ReviewContext {
     cache_manager: Arc<CacheManager>,
     active_cache_name: Arc<Mutex<Option<String>>>,
     current_cache_name: Option<String>,
+    target_review_count: usize,
 }
 
 enum PatchResult {
@@ -183,6 +184,8 @@ impl Reviewer {
 
         for patchset in patchsets {
             let permit = self.semaphore.clone().acquire_owned().await?;
+            let target_review_count = patchset.target_review_count.unwrap_or(1) as usize;
+
             let context = ReviewContext {
                 db: self.db.clone(),
                 settings: self.settings.clone(),
@@ -191,6 +194,7 @@ impl Reviewer {
                 cache_manager: self.cache_manager.clone(),
                 active_cache_name: self.active_cache_name.clone(),
                 current_cache_name: current_cache_name.clone(),
+                target_review_count,
             };
 
             tokio::spawn(async move {
@@ -428,28 +432,17 @@ impl Reviewer {
             None
         };
 
-        if ctx
+        let successful_count = ctx
             .db
-            .has_successful_review(patchset_id, patch_id, baseline_id)
-            .await?
-        {
+            .count_successful_reviews(patchset_id, patch_id, baseline_id)
+            .await?;
+
+        if successful_count >= ctx.target_review_count {
             info!(
-                "Patch {}/{} (ID: {}) already reviewed with baseline {:?}. Skipping.",
-                patchset_id, index, patch_id, baseline_id
+                "Patch {}/{} (ID: {}) already has {} successful reviews with baseline {:?} (target: {}). Skipping.",
+                patchset_id, index, patch_id, successful_count, baseline_id, ctx.target_review_count
             );
             return Ok(PatchResult::Success);
-        }
-
-        if ctx
-            .db
-            .has_failed_review(patchset_id, patch_id, baseline_id)
-            .await?
-        {
-            info!(
-                "Patch {}/{} (ID: {}) previously failed with baseline {:?} before AI stage. Skipping.",
-                patchset_id, index, patch_id, baseline_id
-            );
-            return Ok(PatchResult::ReviewFailed);
         }
 
         let mut retries = 0;

--- a/static/index.html
+++ b/static/index.html
@@ -1157,34 +1157,50 @@
                     if (!reviews || reviews.length === 0) {
                         summaryStatus = '<span style="color:#888">No reviews</span>';
                     } else {
-                         summaryStatus = reviews.map(r => {
-                            let findingsHtml = '<span style="color:#2e7d32; font-weight:bold">No issues</span>';
-                            
-                             if (r.status && (r.status.toLowerCase().includes('failed') || r.status.toLowerCase().includes('error'))) {
-                                findingsHtml = `<span style="color:#d73a49; font-weight:bold">${escapeHtml(r.status)}</span>`;
-                             } else {
+                         // Aggregate "MAX" across all reviews for this patch
+                         let maxCounts = { low: 0, medium: 0, high: 0, critical: 0 };
+                         let hasSuccessful = false;
+                         let errors = [];
+
+                         reviews.forEach(r => {
+                            if (r.status === 'Reviewed') {
+                                hasSuccessful = true;
                                 try {
                                     if (r.output) {
                                         const out = JSON.parse(r.output);
-                                        if (out.findings && Array.isArray(out.findings) && out.findings.length > 0) {
-                                            let counts = { low: 0, medium: 0, high: 0, critical: 0 };
+                                        if (out.findings && Array.isArray(out.findings)) {
+                                            let current = { low: 0, medium: 0, high: 0, critical: 0 };
                                             out.findings.forEach(f => {
                                                 const s = (f.severity || '').toLowerCase();
-                                                if (s === 'critical') counts.critical++;
-                                                else if (s === 'high') counts.high++;
-                                                else if (s === 'medium') counts.medium++;
-                                                else counts.low++;
+                                                if (s === 'critical') current.critical++;
+                                                else if (s === 'high') current.high++;
+                                                else if (s === 'medium') current.medium++;
+                                                else current.low++;
                                             });
                                             
-                                            findingsHtml = renderFindingsBadges(counts);
+                                            // Max aggregation
+                                            maxCounts.critical = Math.max(maxCounts.critical, current.critical);
+                                            maxCounts.high = Math.max(maxCounts.high, current.high);
+                                            maxCounts.medium = Math.max(maxCounts.medium, current.medium);
+                                            maxCounts.low = Math.max(maxCounts.low, current.low);
                                         }
                                     }
                                 } catch (e) {}
-                             }
-                             
-                             const model = r.model ? r.model.split('/').pop() : 'model';
-                             return `<div style="font-size:0.9em"><span style="font-weight:600; color:#555">${escapeHtml(model)}:</span> ${findingsHtml}</div>`;
-                         }).join('');
+                            } else if (r.status && (r.status.toLowerCase().includes('failed') || r.status.toLowerCase().includes('error'))) {
+                                errors.push(r.status);
+                            }
+                         });
+                         
+                         if (hasSuccessful) {
+                            summaryStatus = renderFindingsBadges(maxCounts);
+                            if (reviews.length > 1) {
+                                summaryStatus += ` <span style="color:#888; font-size:0.85em; font-style:italic;">(max of ${reviews.length} runs)</span>`;
+                            }
+                         } else if (errors.length > 0) {
+                            summaryStatus = `<span style="color:#d73a49; font-weight:bold">${escapeHtml(errors[0])}</span>`;
+                         } else {
+                            summaryStatus = '<span style="color:#888">In progress...</span>';
+                         }
                     }
                     const patchLabel = patch ? `Patch ${patch.part_index}` : `Patch ${pid}`;
                     const patchSubject = patch ? escapeHtml(patch.subject || '(no subject)') : '';


### PR DESCRIPTION
Added POST /api/patchset/rerun and POST /api/patch/rerun endpoints. These allow users to trigger a fresh review run while preserving historical data. We keep all reviews and aggregate findings in the summary table by taking the maximum count per severity across all successful reviews of a patch. This supports the stochastic nature of AI reviews and allows users to see the union of issues found in multiple runs.