### PR TITLE
Add hwmon and I2C specific subsystem patterns

### DIFF
--- a/third_party/prompts/kernel/subsystem/hwmon.md
+++ b/third_party/prompts/kernel/subsystem/hwmon.md
@@ -1,0 +1,25 @@
+# Hardware Monitoring Subsystem Details
+
+## Coding style
+
+- Code must follow guildelines in `Documentation/hwmon/submitting-patches.rst`.
+
+## Arithmetic
+
+- Check for overflows and underflows in arithmetc calculations
+
+- Check for field overflows in bit field operations
+
+## API
+
+- New drivers must use `hwmon_device_register_with_info()` or
+  `devm_hwmon_device_register_with_info()` to register with the
+  hardware monitoring subsystem.
+
+- The hardware monitoring subsystem core serializes sysfs operations
+  for attributes registered with the `info` parameter of
+  `hwmon_device_register_with_info()` and
+  `devm_hwmon_device_register_with_info()`.
+  Drivers must implement locking required for interrupt handling and for
+  attributes registered by any other means. Drivers should use `hwmon_lock()`
+  and `hwmon_unlock()` for this purpose.

--- a/third_party/prompts/kernel/subsystem/i2c.md
+++ b/third_party/prompts/kernel/subsystem/i2c.md
@@ -1,0 +1,7 @@
+# I2C Client Details
+
+## API
+
+- debugfs entries attached to the `debugfs` object in `struct i2c_client` are
+  cleaned up by the I2C subsystem core in the device removal function after
+  calling the driver remove function and before releasing device resources.


### PR DESCRIPTION
Needed to avoid false positive feedback for both subsystems.