### PR TITLE
docs: update Claude model to sonnet-4-6 with 1M context window

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Running an automated review system like Sashiko can be computationally expensive
     ```toml
     [ai]
     provider = "claude"
-    model = "claude-sonnet-4-5"
-    max_input_tokens = 180000
+    model = "claude-sonnet-4-6"
+    max_input_tokens = 950000
 
     [ai.claude]
     prompt_caching = true
@@ -131,7 +131,7 @@ Running an automated review system like Sashiko can be computationally expensive
     - Automatic prompt caching (5-minute TTL) reduces costs for repeated context
     - Full tool/function calling support for git operations
     - Automatic retry logic for rate limits and API overload
-    - 200K context window for claude-sonnet-4-5 (use max_input_tokens = 180000 for safety margin)
+    - 1M context window for claude-sonnet-4-6 (use max_input_tokens = 950000 for safety margin)
 
 3.  **Build**:
     ```bash


### PR DESCRIPTION
## Summary
- Update README Claude example from `claude-sonnet-4-5` to `claude-sonnet-4-6`
- Increase `max_input_tokens` from 180000 to 950000 to reflect the 1M context window now available in sonnet-4-6 (GA March 2026)
- Update context window note from 200K to 1M

Previously the README example capped Claude at 180K tokens — about 18% of the now-available context window. Users following the docs were leaving most of Claude's capacity on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)