### PR TITLE
feat: add token budgets to abort runaway reviews

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1455,10 +1455,10 @@ async fn run_review_tool(
                                                 total_output_tokens_used += usage.completion_tokens;
                                                 let token_budget = settings.review.max_total_tokens;
                                                 if token_budget > 0 && total_tokens_used > token_budget {
-                                                    error!("Token budget exceeded: {} uncached tokens used > {} limit — aborting review",
+                                                    error!("Token budget exceeded: {} uncached input + output tokens used > {} limit — aborting review",
                                                         total_tokens_used, token_budget);
                                                     return Err(anyhow::anyhow!(
-                                                        "Token budget exceeded: {} uncached tokens used (limit: {})",
+                                                        "Token budget exceeded: {} uncached input + output tokens used (limit: {})",
                                                         total_tokens_used, token_budget
                                                     ));
                                                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -153,8 +153,11 @@ pub struct ReviewSettings {
     pub max_files_touched: usize,
     #[serde(default)]
     pub ignore_files: Vec<String>,
-    /// Maximum cumulative uncached tokens (input + output) across all turns in a single review.
-    /// Conservative default; set to 0 to disable.
+    /// Maximum cumulative non-cached tokens (uncached input + output) across all turns in a
+    /// single review. Cached input tokens are excluded because they cost ~10x less and don't
+    /// reflect runaway model behaviour. At Sonnet 4.6 pricing ($3/M uncached input, $15/M
+    /// output) the 5M default costs roughly $15–75 depending on input/output mix; a typical
+    /// 7-stage review uses ~300–500k tokens total. Set to 0 to disable.
     #[serde(default = "default_max_total_tokens")]
     pub max_total_tokens: usize,
     /// Maximum cumulative output tokens across all turns in a single review.


### PR DESCRIPTION
## Summary

- Adds two independent cumulative token limits to `[review]` config:
  - `max_total_tokens`: uncached input + output tokens across all turns (default 5M). Cached tokens are excluded as they cost ~10x less and don't reflect runaway model behaviour.
  - `max_total_output_tokens`: output tokens only across all turns (default 500K). Tracked separately since output costs ~5x more than input.
- Both limits abort the review with a clear error message if exceeded; set to 0 to disable either.
- Adds `review_tool_override` to `ReviewSettings` (serde-skipped) so tests can inject a custom binary path without touching config files.
- Includes unit tests covering both budget paths.

## Motivation

Long-running reviews with tool-heavy stages can consume unexpectedly large token counts. These limits provide a safety valve without requiring manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)