### PR TITLE
worker: prevent truncator panic on out-of-bounds focus range

### DIFF
--- a/src/worker/tools.rs
+++ b/src/worker/tools.rs
@@ -17,7 +17,7 @@ use crate::ai::{
     AiTool,
     gemini::{FunctionDeclaration, Tool},
 };
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, ensure};
 use grep::printer::StandardBuilder;
 use grep::regex::RegexMatcher;
 use grep::searcher::{BinaryDetection, SearcherBuilder};
@@ -331,8 +331,16 @@ impl ToolBox {
         let path = self.validate_path(path_str, &self.worktree_path)?;
         let content = fs::read_to_string(path).await?;
 
+        if let (Some(s), Some(e)) = (start_line, end_line) {
+            ensure!(s <= e, "Invalid range: start_line ({s}) > end_line ({e})");
+        }
+
         let lines: Vec<&str> = content.lines().collect();
         let total_lines = lines.len();
+
+        let start_line = start_line.map(|s| s.clamp(1, total_lines));
+        // No need to clamp start against end — the earlier validation already guarantees start <= end
+        let end_line = end_line.map(|e| e.clamp(1, total_lines));
 
         if mode == "smart" {
             let focus = match (start_line, end_line) {


### PR DESCRIPTION
When the AI requested line ranges beyond the file length (e.g., lines 600-650 on a 190-line file), truncate_code would clamp end_focus but not start_focus, resulting in a slice where start > end and causing a panic in truncator.rs.

Add range validation in read_single_file:
- Reject requests where start_line > end_line
- Clamp focus range to file bounds after construction