### PR TITLE
feat: fail fast on non-retryable errors in stage retry loop

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -22,6 +22,7 @@ use crate::email_router::{Action as EmailAction, EmailRouter};
 use crate::git_ops::{GitWorktree, ensure_remote, get_commit_hash};
 use crate::settings::Settings;
 use crate::utils::redact_secret;
+use crate::worker::prompts::ReviewError;
 use anyhow::Result;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -1518,19 +1519,19 @@ async fn run_review_tool(
                                                 if token_budget > 0 && total_tokens_used > token_budget {
                                                     error!("Token budget exceeded: {} uncached input + output tokens used > {} limit — aborting review",
                                                         total_tokens_used, token_budget);
-                                                    return Err(anyhow::anyhow!(
-                                                        "Token budget exceeded: {} uncached input + output tokens used (limit: {})",
-                                                        total_tokens_used, token_budget
-                                                    ));
+                                                    return Err(ReviewError::BudgetExceeded(
+                                                        format!("Token budget exceeded: {} uncached input + output tokens used (limit: {})",
+                                                            total_tokens_used, token_budget)
+                                                    ).into());
                                                 }
                                                 let output_budget = settings.review.max_total_output_tokens;
                                                 if output_budget > 0 && total_output_tokens_used > output_budget {
                                                     error!("Output token budget exceeded: {} output tokens used > {} limit — aborting review",
                                                         total_output_tokens_used, output_budget);
-                                                    return Err(anyhow::anyhow!(
-                                                        "Output token budget exceeded: {} output tokens used (limit: {})",
-                                                        total_output_tokens_used, output_budget
-                                                    ));
+                                                    return Err(ReviewError::BudgetExceeded(
+                                                        format!("Output token budget exceeded: {} output tokens used (limit: {})",
+                                                            total_output_tokens_used, output_budget)
+                                                    ).into());
                                                 }
                                             }
                                             if let Some(tool_calls) = &p.tool_calls {

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -15,6 +15,23 @@
 use crate::ai::{AiMessage, AiProvider, AiRequest, AiResponseFormat, AiRole};
 use crate::worker::tools::ToolBox;
 use anyhow::{Context, Result};
+
+/// Typed errors that must not be silently retried.
+#[derive(Debug, thiserror::Error)]
+pub enum ReviewError {
+    /// The AI exceeded its per-review turn limit.  Retrying with the same
+    /// limit will just hit the cap again — fail fast.
+    #[error("Max interactions exceeded")]
+    LimitExceeded,
+    /// A token budget was exceeded.  Retrying wastes tokens for no gain.
+    #[error("Token budget exceeded: {0}")]
+    BudgetExceeded(String),
+    /// The AI produced output that failed format validation.  The retry
+    /// should use an augmented prompt that reminds the model of the
+    /// violated constraint rather than repeating the identical request.
+    #[error("Format validation failed: {0}")]
+    FormatRejection(String),
+}
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -785,14 +802,16 @@ Example:
                             }
                         }
                         Err(e) => {
+                            // Fail fast for non-retryable errors — retrying would
+                            // likely just hit the same limit again.
+                            if e.downcast_ref::<ReviewError>().is_some() {
+                                warn!("Stage {} hit non-retryable error: {}", stage, e);
+                                return Err(e);
+                            }
                             warn!(
                                 "Stage {} AI execution failed (inner attempt {}/{}): {}",
                                 stage, inner_attempts, max_inner_attempts, e
                             );
-                            // If the underlying AI execution fails (e.g. timeout, API error),
-                            // we probably shouldn't just keep retrying the augmented prompt,
-                            // but we let the inner loop exhaust to keep it simple, or we can break.
-                            // We will let it exhaust the inner loop.
                         }
                     }
                 }
@@ -1226,7 +1245,7 @@ Example:
             }
         }
 
-        Err(anyhow::anyhow!("Max interactions exceeded"))
+        Err(ReviewError::LimitExceeded.into())
     }
 }
 
@@ -1483,5 +1502,45 @@ mod tests {
                 "unexpected error: {e}"
             ),
         }
+    }
+
+    // ReviewError tests
+
+    #[test]
+    fn test_limit_exceeded_downcasts_as_review_error() {
+        let err: anyhow::Error = ReviewError::LimitExceeded.into();
+        assert!(
+            err.downcast_ref::<ReviewError>().is_some(),
+            "LimitExceeded must downcast to ReviewError so the retry loop can fail fast"
+        );
+    }
+
+    #[test]
+    fn test_budget_exceeded_downcasts_as_review_error() {
+        let err: anyhow::Error =
+            ReviewError::BudgetExceeded("1000 tokens used (limit: 500)".to_string()).into();
+        assert!(
+            err.downcast_ref::<ReviewError>().is_some(),
+            "BudgetExceeded must downcast to ReviewError so the retry loop can fail fast"
+        );
+    }
+
+    #[test]
+    fn test_generic_error_does_not_downcast_as_review_error() {
+        let err: anyhow::Error = anyhow::anyhow!("transient JSON parse failure");
+        assert!(
+            err.downcast_ref::<ReviewError>().is_none(),
+            "Plain anyhow errors must NOT match ReviewError so they remain retryable"
+        );
+    }
+
+    #[test]
+    fn test_format_rejection_downcasts_as_review_error() {
+        let err: anyhow::Error =
+            ReviewError::FormatRejection("contains markdown code blocks".to_string()).into();
+        assert!(
+            err.downcast_ref::<ReviewError>().is_some(),
+            "FormatRejection must downcast to ReviewError"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add typed `ReviewError` enum (`LimitExceeded`, `BudgetExceeded`, `FormatRejection`) so the stage retry loop can distinguish structural failures from transient ones
- Non-retryable errors propagate immediately via `downcast_ref::<ReviewError>()` instead of wasting retry attempts
- All other errors (JSON parse failures, empty responses, network blips) remain retryable up to `max_attempts`

This is complementary to 86cd23e (which disabled the outer retry loop for patch application errors) — this PR adds fine-grained error classification to the inner stage retry loop.

## Test plan
- [x] `cargo check` passes after rebase on main
- [x] Unit tests for `ReviewError` downcast behavior (4 tests: LimitExceeded, BudgetExceeded, FormatRejection, generic error)
- [ ] Run a review that hits token budget — verify immediate abort instead of retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)