### PR TITLE
feat: add file_path and line_number to findings

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -128,6 +128,8 @@ pub struct Finding {
     pub severity: Severity,
     pub severity_explanation: Option<String>,
     pub problem: String,
+    pub file_path: Option<String>,
+    pub line_number: Option<i64>,
 }
 
 pub struct EmailOutboxRow {
@@ -483,13 +485,13 @@ impl Database {
             .conn
             .execute("ALTER TABLE findings RENAME COLUMN message TO problem", ())
             .await;
+        // Re-add file_path and line_number for structured finding locations
+        // (needed by API consumers like Gerrit for inline comments)
         let _ = self
-            .conn
-            .execute("ALTER TABLE findings DROP COLUMN file_path", ())
+            .try_add_column("findings", "file_path", "TEXT")
             .await;
         let _ = self
-            .conn
-            .execute("ALTER TABLE findings DROP COLUMN line_number", ())
+            .try_add_column("findings", "line_number", "INTEGER")
             .await;
 
         let _ = self.migrate_tool_usages().await;
@@ -781,13 +783,15 @@ impl Database {
     pub async fn create_finding(&self, finding: Finding) -> Result<()> {
         self.conn
             .execute(
-                "INSERT INTO findings (review_id, severity, severity_explanation, problem)
-             VALUES (?, ?, ?, ?)",
+                "INSERT INTO findings (review_id, severity, severity_explanation, problem, file_path, line_number)
+             VALUES (?, ?, ?, ?, ?, ?)",
                 libsql::params![
                     finding.review_id,
                     finding.severity as i32,
                     finding.severity_explanation,
                     finding.problem,
+                    finding.file_path,
+                    finding.line_number,
                 ],
             )
             .await?;
@@ -847,12 +851,20 @@ impl Database {
 
                     let severity = Severity::from_str(severity_str);
 
+                    let file_path = f
+                        .get("file_path")
+                        .and_then(|s| s.as_str())
+                        .map(|s| s.to_string());
+                    let line_number = f.get("line_number").and_then(|n| n.as_i64());
+
                     let _ = self
                         .create_finding(Finding {
                             review_id,
                             severity,
                             severity_explanation,
                             problem,
+                            file_path,
+                            line_number,
                         })
                         .await;
                 }
@@ -2475,6 +2487,9 @@ impl Database {
             .await?;
 
         if let Ok(Some(r)) = rows.next().await {
+            // Fetch structured findings for this review
+            let findings = self.get_findings_for_review(id).await.unwrap_or_default();
+
             Ok(Some(serde_json::json!({
                 "id": r.get::<i64>(0)?,
                 "model": r.get::<Option<String>>(1).ok(),
@@ -2497,10 +2512,42 @@ impl Database {
                 "tokens_out": r.get::<Option<u32>>(16).ok(),
                 "patch_id": r.get::<Option<i64>>(17).ok(),
                 "tokens_cached": r.get::<Option<u32>>(18).ok(),
+                "findings": findings,
             })))
         } else {
             Ok(None)
         }
+    }
+
+    pub async fn get_findings_for_review(&self, review_id: i64) -> Result<Vec<serde_json::Value>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT id, severity, severity_explanation, problem, file_path, line_number
+                 FROM findings WHERE review_id = ? ORDER BY severity DESC, id ASC",
+                libsql::params![review_id],
+            )
+            .await?;
+
+        let mut findings = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            let severity_int: i32 = row.get(1)?;
+            let severity_str = match severity_int {
+                4 => "Critical",
+                3 => "High",
+                2 => "Medium",
+                _ => "Low",
+            };
+            findings.push(serde_json::json!({
+                "id": row.get::<i64>(0)?,
+                "severity": severity_str,
+                "severity_explanation": row.get::<Option<String>>(2).ok(),
+                "problem": row.get::<Option<String>>(3).ok(),
+                "file_path": row.get::<Option<String>>(4).ok(),
+                "line_number": row.get::<Option<i64>>(5).ok(),
+            }));
+        }
+        Ok(findings)
     }
 
     pub async fn get_latest_review_for_patchset(

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1089,6 +1089,10 @@ impl Reviewer {
                                         let severity_explanation = f["severity_explanation"]
                                             .as_str()
                                             .map(|s| s.to_string());
+                                        let file_path = f["file_path"]
+                                            .as_str()
+                                            .map(|s| s.to_string());
+                                        let line_number = f["line_number"].as_i64();
 
                                         let _ = ctx
                                             .db
@@ -1097,6 +1101,8 @@ impl Reviewer {
                                                 severity,
                                                 severity_explanation,
                                                 problem,
+                                                file_path,
+                                                line_number,
                                             })
                                             .await;
                                     }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -123,6 +123,8 @@ CREATE TABLE IF NOT EXISTS findings (
     severity_explanation TEXT,
     problem TEXT,
     suggestion TEXT,
+    file_path TEXT,
+    line_number INTEGER,
     FOREIGN KEY(review_id) REFERENCES reviews(id)
 );
 CREATE INDEX IF NOT EXISTS idx_findings_review_id ON findings(review_id);

--- a/tests/findings_sum_test.rs
+++ b/tests/findings_sum_test.rs
@@ -132,6 +132,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::Low,
         severity_explanation: Some("low1".into()),
         problem: "low1".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();
@@ -140,6 +142,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::Low,
         severity_explanation: Some("low2".into()),
         problem: "low2".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();
@@ -148,6 +152,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::High,
         severity_explanation: Some("high1".into()),
         problem: "high1".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();
@@ -158,6 +164,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::Low,
         severity_explanation: Some("low3".into()),
         problem: "low3".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();
@@ -166,6 +174,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::Critical,
         severity_explanation: Some("crit1".into()),
         problem: "crit1".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();
@@ -174,6 +184,8 @@ async fn test_findings_sum_across_patches() {
         severity: Severity::Critical,
         severity_explanation: Some("crit2".into()),
         problem: "crit2".into(),
+        file_path: None,
+        line_number: None,
     })
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

Re-add optional `file_path` and `line_number` fields to the Finding struct and API response. These were removed in f8f6434 during the findings schema refactor, but are needed by API consumers that post findings as inline comments at specific code locations (e.g., Gerrit, GitHub review bots).

### Changes

- **Finding struct**: `file_path: Option<String>`, `line_number: Option<i64>`
- **schema.sql**: Add columns to `CREATE TABLE findings`
- **Migration**: Replace `DROP COLUMN` with `try_add_column` (handles both fresh and existing DBs)
- **create_finding()**: Insert the new fields
- **reviewer.rs**: Parse `file_path`/`line_number` from AI JSON output
- **get_review_details() API**: New `"findings"` array in response with structured finding data including locations
- **get_findings_for_review()**: New query method
- **Test fixtures**: Updated with `file_path: None, line_number: None`

### Design decisions

- Fields are `Option` — fully backward compatible. Existing reviews and the LKML inline-review flow are unaffected.
- The AI is not yet instructed to populate these fields (that's a separate prompt change, can be gated by a setting like `require_finding_locations`).
- The `"findings"` array in the API response enables any consumer to programmatically access structured findings without parsing the inline review text.

## Test plan
- [x] `cargo check` passes
- [x] Existing test fixtures compile with new fields (all `None`)
- [ ] Verify migration works on existing DB (adds columns without data loss)
- [ ] Verify `/api/review/<id>` response includes `"findings"` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)