### PR TITLE
feat: add Gerrit review backend with ingest

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -137,6 +137,7 @@ pub struct AppState {
     patchsets_count_cache: AsyncCache<usize>,
     patchsets_homepage_cache: AsyncCache<Vec<crate::db::PatchsetRow>>,
     messages_homepage_cache: AsyncCache<Vec<crate::db::MessageRow>>,
+    gerrit_client: Option<Arc<crate::gerrit::GerritClient>>,
 }
 
 #[derive(Deserialize)]
@@ -219,6 +220,24 @@ pub enum SubmitRequest {
     Thread {
         msgid: String,
     },
+    /// Submit a Gerrit change for review. Sashiko fetches the change,
+    /// reviews it, and (if [gerrit] is configured) posts findings back.
+    Gerrit {
+        /// Gerrit change number (e.g. 64591).
+        change_number: u64,
+        /// Override the Gerrit URL from settings.
+        #[serde(default)]
+        gerrit_url: Option<String>,
+        /// Override the local git repo path for fetching.
+        #[serde(default)]
+        repo: Option<String>,
+        /// Post findings back to Gerrit after review (default: true if [gerrit] configured).
+        #[serde(default)]
+        post_back: Option<bool>,
+        /// Include a Code-Review vote when posting back.
+        #[serde(default)]
+        vote: Option<bool>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -235,6 +254,7 @@ pub async fn run_server(
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
+    gerrit_client: Option<Arc<crate::gerrit::GerritClient>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(AppState {
         db,
@@ -252,6 +272,7 @@ pub async fn run_server(
         patchsets_count_cache: AsyncCache::new(Duration::from_secs(30)),
         patchsets_homepage_cache: AsyncCache::new(Duration::from_secs(10)),
         messages_homepage_cache: AsyncCache::new(Duration::from_secs(10)),
+        gerrit_client,
     });
 
     let app = Router::new()
@@ -268,6 +289,7 @@ pub async fn run_server(
         .route("/api/submit", post(submit_patch))
         .route("/api/patchset/rerun", post(rerun_patchset))
         .route("/api/patch/rerun", post(rerun_patch))
+        .route("/api/gerrit/post", post(post_to_gerrit))
         .route("/", get_service(ServeFile::new("static/index.html")))
         .nest_service("/static", ServeDir::new("static"))
         .with_state(state);
@@ -439,7 +461,80 @@ async fn submit_patch(
 
             Ok(Json(SubmitResponse {
                 status: "accepted".to_string(),
-                id, // The client might expect this ID
+                id,
+            }))
+        }
+        SubmitRequest::Gerrit {
+            change_number,
+            gerrit_url: _,
+            repo,
+            post_back: _,
+            vote: _,
+        } => {
+            let gerrit = state.gerrit_client.as_ref().ok_or_else(|| {
+                error!("Gerrit submit requires [gerrit] configuration in Settings.toml");
+                StatusCode::SERVICE_UNAVAILABLE
+            })?;
+
+            // 1. Fetch change details from Gerrit
+            let change = gerrit.get_change_detail(change_number).await.map_err(|e| {
+                error!("Failed to fetch Gerrit change {}: {}", change_number, e);
+                StatusCode::BAD_GATEWAY
+            })?;
+
+            let (fetch_url, fetch_ref, _ps_number, _commit_sha) =
+                gerrit.extract_fetch_info(&change, change_number).map_err(|e| {
+                    error!("Failed to extract fetch info for change {}: {}", change_number, e);
+                    StatusCode::BAD_GATEWAY
+                })?;
+
+            // 2. Fetch into local repo
+            let repo_path = repo.as_deref().unwrap_or("third_party/linux");
+            let sha = gerrit
+                .fetch_into_repo(repo_path, &fetch_url, &fetch_ref)
+                .await
+                .map_err(|e| {
+                    error!("Failed to git fetch Gerrit change {}: {}", change_number, e);
+                    StatusCode::INTERNAL_SERVER_ERROR
+                })?;
+
+            let id = sha.clone();
+            info!(
+                "Gerrit change {} fetched as {}, submitting for review",
+                change_number, &sha[..12.min(sha.len())]
+            );
+
+            // 3. Create placeholder and submit for review (same as Remote flow)
+            if let Err(e) = state
+                .db
+                .create_fetching_patchset(
+                    &id,
+                    &format!(
+                        "Gerrit change {} ({}): {}",
+                        change_number, change.project, change.subject
+                    ),
+                    None,
+                    None,
+                )
+                .await
+            {
+                error!("Failed to create placeholder patchset: {}", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+
+            let req = FetchRequest {
+                repo_url: None,
+                commit_hash: sha,
+            };
+
+            if let Err(e) = state.fetch_sender.send(req).await {
+                error!("Failed to send fetch request to queue: {}", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+
+            Ok(Json(SubmitResponse {
+                status: "accepted".to_string(),
+                id,
             }))
         }
     }
@@ -913,4 +1008,83 @@ async fn rerun_patch(
         })?;
 
     Ok(Json(serde_json::json!({ "status": "accepted" })))
+}
+
+// --- Gerrit backend ---
+
+#[derive(Deserialize)]
+struct GerritPostRequest {
+    /// Sashiko review ID to post findings from.
+    review_id: i64,
+    /// Gerrit change identifier (number, Change-Id, or project~branch~Change-Id).
+    change_id: String,
+    /// Gerrit revision (patchset SHA or number).
+    revision_id: String,
+    /// Include a Code-Review vote based on severity (overrides settings).
+    #[serde(default)]
+    vote: Option<bool>,
+}
+
+async fn post_to_gerrit(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<GerritPostRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let gerrit = state.gerrit_client.as_ref().ok_or_else(|| {
+        tracing::error!("Gerrit backend not configured (add [gerrit] to Settings.toml)");
+        StatusCode::SERVICE_UNAVAILABLE
+    })?;
+
+    let findings = state
+        .db
+        .get_findings_for_review(req.review_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch findings for review {}: {}", req.review_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let gerrit_findings: Vec<crate::gerrit::GerritFinding> = findings
+        .iter()
+        .map(|f| crate::gerrit::GerritFinding {
+            severity: crate::db::Severity::from_str(
+                f.get("severity").and_then(|v| v.as_str()).unwrap_or("Low"),
+            ),
+            problem: f
+                .get("problem")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            severity_explanation: f
+                .get("severity_explanation")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            file_path: f
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            line_number: f.get("line_number").and_then(|v| v.as_i64()),
+        })
+        .collect();
+
+    let include_vote = req.vote.unwrap_or(false);
+
+    gerrit
+        .post_review(&req.change_id, &req.revision_id, &gerrit_findings, include_vote)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to post to Gerrit: {}", e);
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    let located = gerrit_findings
+        .iter()
+        .filter(|f| f.file_path.is_some() && f.line_number.is_some())
+        .count();
+
+    Ok(Json(serde_json::json!({
+        "status": "posted",
+        "findings": gerrit_findings.len(),
+        "inline_comments": located,
+        "change_id": req.change_id,
+    })))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -107,6 +107,17 @@ pub enum Severity {
     Critical = 4,
 }
 
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Severity::Critical => write!(f, "Critical"),
+            Severity::High => write!(f, "High"),
+            Severity::Medium => write!(f, "Medium"),
+            Severity::Low => write!(f, "Low"),
+        }
+    }
+}
+
 impl Severity {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
@@ -2548,6 +2559,39 @@ impl Database {
         } else {
             Ok(None)
         }
+    }
+
+    /// Fetch structured findings for a review, returned as JSON values.
+    /// Each finding includes severity, problem, severity_explanation, file_path, line_number.
+    pub async fn get_findings_for_review(&self, review_id: i64) -> Result<Vec<serde_json::Value>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT id, severity, severity_explanation, problem, file_path, line_number
+                 FROM findings WHERE review_id = ? ORDER BY severity DESC, id ASC",
+                libsql::params![review_id],
+            )
+            .await?;
+
+        let mut findings = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            let severity_int: i32 = row.get(1)?;
+            let severity_str = match severity_int {
+                4 => "Critical",
+                3 => "High",
+                2 => "Medium",
+                _ => "Low",
+            };
+            findings.push(serde_json::json!({
+                "id": row.get::<i64>(0)?,
+                "severity": severity_str,
+                "severity_explanation": row.get::<Option<String>>(2).ok(),
+                "problem": row.get::<Option<String>>(3).ok(),
+                "file_path": row.get::<Option<String>>(4).ok(),
+                "line_number": row.get::<Option<i64>>(5).ok(),
+            }));
+        }
+        Ok(findings)
     }
 
     pub async fn get_latest_review_for_patchset(

--- a/src/gerrit.rs
+++ b/src/gerrit.rs
@@ -1,0 +1,518 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Gerrit review backend — posts sashiko findings as inline comments.
+//!
+//! When `[gerrit]` is configured in Settings.toml, completed reviews are
+//! automatically posted back to the originating Gerrit change as inline
+//! comments with a cover message summarizing the findings.
+//!
+//! # Configuration
+//!
+//! ```toml
+//! [gerrit]
+//! url = "https://review.example.com"
+//! username = "sashiko"
+//! password = "http-password"       # Gerrit HTTP password (not SSH key)
+//! # project = "lustre-release"     # optional: restrict to one project
+//! # dry_run = false                # optional: log but don't post (default: false)
+//! ```
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::{debug, error, info, warn};
+
+use crate::db::Severity;
+use crate::settings::GerritSettings;
+
+/// A single inline comment to post on a Gerrit change.
+#[derive(Debug, Clone, Serialize)]
+struct InlineComment {
+    path: String,
+    line: i64,
+    message: String,
+    unresolved: bool,
+}
+
+/// Gerrit "set review" request body.
+/// See: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-review
+#[derive(Debug, Serialize)]
+struct SetReviewInput {
+    message: String,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    comments: HashMap<String, Vec<CommentInput>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    labels: HashMap<String, i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CommentInput {
+    line: i64,
+    message: String,
+    unresolved: Option<bool>,
+}
+
+/// A structured finding ready for Gerrit posting.
+#[derive(Debug, Clone)]
+pub struct GerritFinding {
+    pub severity: Severity,
+    pub problem: String,
+    pub severity_explanation: Option<String>,
+    pub file_path: Option<String>,
+    pub line_number: Option<i64>,
+}
+
+/// Severity -> Code-Review vote mapping.
+fn severity_vote(severity: &Severity) -> i32 {
+    match severity {
+        Severity::Critical => -2,
+        Severity::High => -1,
+        Severity::Medium | Severity::Low => 0,
+    }
+}
+
+/// Details about a Gerrit change needed for fetching and posting back.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChangeInfo {
+    pub project: String,
+    pub subject: String,
+    pub current_revision: Option<String>,
+    #[serde(default)]
+    pub revisions: HashMap<String, RevisionInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RevisionInfo {
+    #[serde(rename = "_number")]
+    pub number: Option<u32>,
+    #[serde(default)]
+    pub fetch: HashMap<String, FetchInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FetchInfo {
+    pub url: String,
+    #[serde(rename = "ref")]
+    pub fetch_ref: String,
+}
+
+/// Gerrit REST client for fetching changes and posting review results.
+pub struct GerritClient {
+    client: Client,
+    settings: GerritSettings,
+}
+
+impl GerritClient {
+    pub fn new(settings: GerritSettings) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("Failed to build HTTP client for Gerrit")?;
+
+        info!(
+            "Gerrit backend configured: {} (dry_run={})",
+            settings.url, settings.dry_run
+        );
+
+        Ok(Self { client, settings })
+    }
+
+    /// Get the URL configured for this Gerrit instance.
+    pub fn url(&self) -> &str {
+        &self.settings.url
+    }
+
+    /// Fetch change details from Gerrit REST API.
+    ///
+    /// Returns the change info including the current revision's fetch ref,
+    /// which is needed to `git fetch` the change into a local repo.
+    pub async fn get_change_detail(&self, change_number: u64) -> Result<ChangeInfo> {
+        let url = format!(
+            "{}/a/changes/{}?o=CURRENT_REVISION&o=DOWNLOAD_COMMANDS",
+            self.settings.url.trim_end_matches('/'),
+            change_number
+        );
+
+        debug!("Fetching Gerrit change detail: {}", url);
+
+        let resp = self
+            .client
+            .get(&url)
+            .basic_auth(&self.settings.username, Some(&self.settings.password))
+            .send()
+            .await
+            .context("Failed to fetch change detail from Gerrit")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Gerrit returned HTTP {} for change {}: {}",
+                status,
+                change_number,
+                body.chars().take(300).collect::<String>()
+            );
+        }
+
+        // Gerrit prefixes JSON responses with )]}'
+        let body = resp.text().await?;
+        let json_body = body
+            .strip_prefix(")]}'")
+            .map(|s| s.trim_start())
+            .unwrap_or(&body);
+
+        let change: ChangeInfo =
+            serde_json::from_str(json_body).context("Failed to parse Gerrit change detail")?;
+
+        info!(
+            "Gerrit change {}: project={}, subject={}",
+            change_number, change.project, change.subject
+        );
+
+        Ok(change)
+    }
+
+    /// Extract the fetch ref and URL from a ChangeInfo.
+    ///
+    /// Returns (fetch_url, fetch_ref, patchset_number, commit_sha).
+    pub fn extract_fetch_info(
+        &self,
+        change: &ChangeInfo,
+        change_number: u64,
+    ) -> Result<(String, String, u32, String)> {
+        let current_rev = change
+            .current_revision
+            .as_deref()
+            .context("Change has no current revision")?;
+
+        let rev_data = change
+            .revisions
+            .get(current_rev)
+            .context("Current revision not found in revisions map")?;
+
+        let patchset_number = rev_data.number.unwrap_or(1);
+
+        // Try fetch protocols in preference order
+        let (fetch_url, fetch_ref) = ["anonymous http", "http", "ssh"]
+            .iter()
+            .find_map(|protocol| {
+                rev_data.fetch.get(*protocol).map(|fi| {
+                    (fi.url.clone(), fi.fetch_ref.clone())
+                })
+            })
+            .unwrap_or_else(|| {
+                // Construct manually
+                let change_str = change_number.to_string();
+                let suffix = if change_str.len() >= 2 {
+                    &change_str[change_str.len() - 2..]
+                } else {
+                    &change_str
+                };
+                let fetch_ref = format!(
+                    "refs/changes/{}/{}/{}",
+                    suffix, change_number, patchset_number
+                );
+                let fetch_url = format!(
+                    "{}/{}",
+                    self.settings.url.trim_end_matches('/'),
+                    change.project
+                );
+                (fetch_url, fetch_ref)
+            });
+
+        info!(
+            "Gerrit change {} ps{}: ref={}, sha={}",
+            change_number,
+            patchset_number,
+            fetch_ref,
+            &current_rev[..12.min(current_rev.len())]
+        );
+
+        Ok((fetch_url, fetch_ref, patchset_number, current_rev.to_string()))
+    }
+
+    /// Fetch a Gerrit change into a local git repository.
+    ///
+    /// Runs `git fetch <url> <ref>` and returns the FETCH_HEAD SHA.
+    pub async fn fetch_into_repo(
+        &self,
+        repo_path: &str,
+        fetch_url: &str,
+        fetch_ref: &str,
+    ) -> Result<String> {
+        info!("Fetching {} {} into {}", fetch_url, fetch_ref, repo_path);
+
+        let output = tokio::process::Command::new("git")
+            .args(["fetch", fetch_url, fetch_ref])
+            .current_dir(repo_path)
+            .output()
+            .await
+            .context("Failed to run git fetch")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git fetch failed: {}", stderr);
+        }
+
+        let sha_output = tokio::process::Command::new("git")
+            .args(["rev-parse", "FETCH_HEAD"])
+            .current_dir(repo_path)
+            .output()
+            .await
+            .context("Failed to run git rev-parse FETCH_HEAD")?;
+
+        if !sha_output.status.success() {
+            anyhow::bail!("git rev-parse FETCH_HEAD failed");
+        }
+
+        let sha = String::from_utf8_lossy(&sha_output.stdout).trim().to_string();
+        info!("Fetched commit: {}", &sha[..12.min(sha.len())]);
+        Ok(sha)
+    }
+
+    /// Post review findings to a Gerrit change.
+    ///
+    /// `change_id` can be a change number, Change-Id, or "project~branch~Change-Id".
+    /// `revision_id` is the patchset commit SHA or patchset number.
+    pub async fn post_review(
+        &self,
+        change_id: &str,
+        revision_id: &str,
+        findings: &[GerritFinding],
+        include_vote: bool,
+    ) -> Result<()> {
+        let (comments, summary) = self.findings_to_review(findings);
+
+        let mut labels = HashMap::new();
+        if include_vote && !findings.is_empty() {
+            let worst_vote = findings
+                .iter()
+                .map(|f| severity_vote(&f.severity))
+                .min()
+                .unwrap_or(0);
+            if worst_vote != 0 {
+                labels.insert("Code-Review".to_string(), worst_vote);
+            }
+        }
+
+        let input = SetReviewInput {
+            message: summary,
+            comments,
+            labels,
+            tag: Some("autogenerated:sashiko".to_string()),
+        };
+
+        if self.settings.dry_run {
+            let comment_count: usize = input.comments.values().map(|v| v.len()).sum();
+            info!(
+                "Gerrit dry-run: would post {} inline comment(s) to {}/{}",
+                comment_count, change_id, revision_id
+            );
+            debug!("Gerrit dry-run payload: {}", serde_json::to_string_pretty(&input)?);
+            return Ok(());
+        }
+
+        let url = format!(
+            "{}/a/changes/{}/revisions/{}/review",
+            self.settings.url.trim_end_matches('/'),
+            change_id,
+            revision_id
+        );
+
+        let comment_count: usize = input.comments.values().map(|v| v.len()).sum();
+        info!(
+            "Posting {} inline comment(s) to Gerrit: {}",
+            comment_count, url
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .basic_auth(&self.settings.username, Some(&self.settings.password))
+            .json(&input)
+            .send()
+            .await
+            .context("Failed to send review to Gerrit")?;
+
+        let status = resp.status();
+        if status.is_success() {
+            info!(
+                "Successfully posted review to Gerrit change {} (HTTP {})",
+                change_id, status
+            );
+            Ok(())
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            error!(
+                "Gerrit returned HTTP {}: {}",
+                status,
+                body.chars().take(500).collect::<String>()
+            );
+            anyhow::bail!("Gerrit review post failed: HTTP {}", status)
+        }
+    }
+
+    /// Convert findings into Gerrit comment format + summary message.
+    fn findings_to_review(
+        &self,
+        findings: &[GerritFinding],
+    ) -> (HashMap<String, Vec<CommentInput>>, String) {
+        let mut comments: HashMap<String, Vec<CommentInput>> = HashMap::new();
+        let mut unlocated: Vec<String> = Vec::new();
+
+        for f in findings {
+            let mut msg_parts = vec![format!("[{}] {}", f.severity, f.problem)];
+            if let Some(ref explanation) = f.severity_explanation {
+                msg_parts.push(format!("\nReasoning: {}", explanation));
+            }
+            let message = msg_parts.join("");
+
+            if let (Some(path), Some(line)) = (&f.file_path, f.line_number) {
+                comments
+                    .entry(path.clone())
+                    .or_default()
+                    .push(CommentInput {
+                        line,
+                        message,
+                        unresolved: Some(matches!(f.severity, Severity::High | Severity::Critical)),
+                    });
+            } else {
+                unlocated.push(format!(
+                    "- [{}] {}",
+                    f.severity,
+                    f.problem.chars().take(200).collect::<String>()
+                ));
+            }
+        }
+
+        // Build summary
+        let mut summary_parts = vec![
+            "Sashiko Automated Review".to_string(),
+            "=".repeat(25),
+        ];
+
+        if findings.is_empty() {
+            summary_parts.push("No issues found.".to_string());
+        } else {
+            let mut counts: HashMap<String, usize> = HashMap::new();
+            for f in findings {
+                *counts.entry(format!("{}", f.severity)).or_default() += 1;
+            }
+            let count_str: Vec<String> = counts
+                .iter()
+                .map(|(sev, count)| format!("{} {}", count, sev))
+                .collect();
+            summary_parts.push(format!(
+                "Found {} issue(s): {}",
+                findings.len(),
+                count_str.join(", ")
+            ));
+        }
+
+        if !unlocated.is_empty() {
+            summary_parts.push(String::new());
+            summary_parts.push("General findings (no specific file location):".to_string());
+            summary_parts.extend(unlocated);
+        }
+
+        (comments, summary_parts.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_severity_votes() {
+        assert_eq!(severity_vote(&Severity::Critical), -2);
+        assert_eq!(severity_vote(&Severity::High), -1);
+        assert_eq!(severity_vote(&Severity::Medium), 0);
+        assert_eq!(severity_vote(&Severity::Low), 0);
+    }
+
+    #[test]
+    fn test_findings_to_review_empty() {
+        let settings = GerritSettings {
+            url: "https://review.example.com".to_string(),
+            username: "test".to_string(),
+            password: "test".to_string(),
+            project: None,
+            dry_run: false,
+            vote: false,
+        };
+        let client = GerritClient::new(settings).unwrap();
+        let (comments, summary) = client.findings_to_review(&[]);
+        assert!(comments.is_empty());
+        assert!(summary.contains("No issues found"));
+    }
+
+    #[test]
+    fn test_findings_to_review_with_location() {
+        let settings = GerritSettings {
+            url: "https://review.example.com".to_string(),
+            username: "test".to_string(),
+            password: "test".to_string(),
+            project: None,
+            dry_run: false,
+            vote: false,
+        };
+        let client = GerritClient::new(settings).unwrap();
+        let findings = vec![GerritFinding {
+            severity: Severity::High,
+            problem: "Use after free in foo()".to_string(),
+            severity_explanation: Some("Buffer freed on line 10, used on line 15".to_string()),
+            file_path: Some("fs/lustre/llite/file.c".to_string()),
+            line_number: Some(15),
+        }];
+        let (comments, summary) = client.findings_to_review(&findings);
+        assert_eq!(comments.len(), 1);
+        assert!(comments.contains_key("fs/lustre/llite/file.c"));
+        let file_comments = &comments["fs/lustre/llite/file.c"];
+        assert_eq!(file_comments.len(), 1);
+        assert_eq!(file_comments[0].line, 15);
+        assert!(file_comments[0].message.contains("Use after free"));
+        assert_eq!(file_comments[0].unresolved, Some(true)); // High severity
+        assert!(summary.contains("1 issue(s)"));
+    }
+
+    #[test]
+    fn test_findings_to_review_unlocated() {
+        let settings = GerritSettings {
+            url: "https://review.example.com".to_string(),
+            username: "test".to_string(),
+            password: "test".to_string(),
+            project: None,
+            dry_run: false,
+            vote: false,
+        };
+        let client = GerritClient::new(settings).unwrap();
+        let findings = vec![GerritFinding {
+            severity: Severity::Medium,
+            problem: "Missing error handling".to_string(),
+            severity_explanation: None,
+            file_path: None,
+            line_number: None,
+        }];
+        let (comments, summary) = client.findings_to_review(&findings);
+        assert!(comments.is_empty()); // No location = no inline comment
+        assert!(summary.contains("General findings"));
+        assert!(summary.contains("Missing error handling"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod email_policy;
 pub mod email_router;
 pub mod events;
 pub mod fetcher;
+pub mod gerrit;
 pub mod git_ops;
 pub mod ingestor;
 pub mod inspector;

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,6 +516,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let allow_all_submit = cli.enable_unsafe_all_submit;
     let smtp_enabled = settings.smtp.is_some();
     let dry_run = settings.smtp.as_ref().map(|s| s.dry_run).unwrap_or(false);
+
+    // Initialize review backend clients (Gerrit)
+    let gerrit_client = settings
+        .gerrit
+        .as_ref()
+        .and_then(|gs| {
+            sashiko::gerrit::GerritClient::new(gs.clone())
+                .map(|c| std::sync::Arc::new(c))
+                .map_err(|e| error!("Failed to initialize Gerrit client: {}", e))
+                .ok()
+        });
+
     tokio::spawn(async move {
         if let Err(e) = sashiko::api::run_server(
             api_settings,
@@ -525,6 +537,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             allow_all_submit,
             smtp_enabled,
             dry_run,
+            gerrit_client,
         )
         .await
         {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -246,12 +246,30 @@ fn default_log_level() -> String {
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct GerritSettings {
+    pub url: String,
+    pub username: String,
+    pub password: String,
+    /// Restrict to a specific Gerrit project (optional).
+    #[serde(default)]
+    pub project: Option<String>,
+    /// Log what would be posted but don't actually post (default: false).
+    #[serde(default)]
+    pub dry_run: bool,
+    /// Include a Code-Review vote based on findings severity (default: false).
+    #[serde(default)]
+    pub vote: bool,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct Settings {
     #[serde(default = "default_log_level")]
     pub log_level: String,
     pub database: DatabaseSettings,
     pub nntp: NntpSettings,
     pub smtp: Option<SmtpSettings>,
+    pub gerrit: Option<GerritSettings>,
     pub mailing_lists: MailingListsSettings,
     pub ai: AiSettings,
     pub server: ServerSettings,


### PR DESCRIPTION
## Gerrit review backend — ingest + output

Adds native Gerrit integration: submit a change number, sashiko fetches it, reviews it, and can post findings back as inline comments.

### Ingest
`POST /api/submit {"type":"gerrit", "change_number": 64591}`
- Fetches change details from Gerrit REST API (project, revision, fetch ref)
- `git fetch` the change into the local repo
- Submits into existing review pipeline (same as Remote flow)

### Output
`POST /api/gerrit/post` — post a completed review's findings as inline comments
- Findings → inline comments with file/line targeting
- Severity-based Code-Review voting (Critical=-2, High=-1, Medium/Low=0)
- `autogenerated:sashiko` tag on posted reviews
- HTTP basic auth, dry_run mode

### Configuration
```toml
# Optional — only needed if you want Gerrit integration
[gerrit]
url = "https://review.example.com"
username = "sashiko"
password = "http-password"
# dry_run = true
```

Disabled when `[gerrit]` section is absent — zero impact on existing deployments.

GitHub backend removed per review feedback (untested). Rebased on current main.

### Context
I have a working external Gerrit bridge (`gc sashiko-review` in my gerrit-cli tool) that orchestrates this flow from outside sashiko. This PR moves it inside so anyone running sashiko gets Gerrit support out of the box.

### Test plan
- [x] `cargo check` passes
- [x] Unit tests for finding→comment conversion, severity mapping
- [ ] Integration test with real Gerrit instance (I can do this)