### PR TITLE
[RFC] ai: Add AWS Bedrock provider via Converse API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ default-run = "sashiko"
 [dependencies]
 anyhow = "1.0.100"
 async-trait = "0.1.89"
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = "1"
+aws-smithy-types = "1"
 axum = "0.8.8"
 chrono = "0.4.43"
 clap = { version = "4.5.54", features = ["derive", "env"] }

--- a/README.md
+++ b/README.md
@@ -133,6 +133,40 @@ Running an automated review system like Sashiko can be computationally expensive
     - Automatic retry logic for rate limits and API overload
     - 1M context window for claude-sonnet-4-6 (use max_input_tokens = 950000 for safety margin)
 
+    ### AWS Bedrock Setup
+
+    Sashiko supports AWS Bedrock via the Converse API, which works with any Bedrock-hosted model (Claude, Llama, Mistral, etc.).
+
+    **Prerequisites**: Enable model access in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/) for your desired model and region.
+
+    **Configure AWS credentials** using any standard method:
+    ```bash
+    # Option 1: Environment variables
+    export AWS_ACCESS_KEY_ID="..."
+    export AWS_SECRET_ACCESS_KEY="..."
+    export AWS_REGION="us-east-1"
+
+    # Option 2: AWS CLI profile (~/.aws/credentials)
+    aws configure
+    ```
+
+    **Update Settings.toml**:
+    ```toml
+    [ai]
+    provider = "bedrock"
+    model = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+    max_input_tokens = 950000
+
+    [ai.bedrock]
+    region = "us-east-1"  # Optional, falls back to AWS SDK defaults
+    ```
+
+    **Features**:
+    - Uses the Converse API — works with any Bedrock-hosted model
+    - No API key needed — uses standard AWS IAM authentication
+    - Supports cross-region inference profiles (e.g., `us.anthropic.claude-*`)
+    - Full tool/function calling support for git operations
+
 3.  **Build**:
     ```bash
     cargo build --release

--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -1,0 +1,560 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ai::token_budget::TokenBudget;
+use crate::ai::{
+    AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
+};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock, Tool,
+    ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock, ToolSpecification,
+    ToolUseBlock,
+};
+use aws_smithy_types::{Document, Number};
+use std::collections::HashMap;
+use tracing::info;
+
+// --- serde_json::Value <-> aws_smithy_types::Document conversion ---
+
+fn json_to_document(value: &serde_json::Value) -> Document {
+    match value {
+        serde_json::Value::Null => Document::Null,
+        serde_json::Value::Bool(b) => Document::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(u) = n.as_u64() {
+                Document::Number(Number::PosInt(u))
+            } else if let Some(i) = n.as_i64() {
+                Document::Number(Number::NegInt(i))
+            } else {
+                Document::Number(Number::Float(n.as_f64().unwrap_or(0.0)))
+            }
+        }
+        serde_json::Value::String(s) => Document::String(s.clone()),
+        serde_json::Value::Array(arr) => {
+            Document::Array(arr.iter().map(json_to_document).collect())
+        }
+        serde_json::Value::Object(obj) => {
+            let map: HashMap<String, Document> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_document(v)))
+                .collect();
+            Document::Object(map)
+        }
+    }
+}
+
+fn document_to_json(doc: &Document) -> serde_json::Value {
+    match doc {
+        Document::Null => serde_json::Value::Null,
+        Document::Bool(b) => serde_json::Value::Bool(*b),
+        Document::Number(n) => match n {
+            Number::PosInt(u) => serde_json::json!(*u),
+            Number::NegInt(i) => serde_json::json!(*i),
+            Number::Float(f) => serde_json::json!(*f),
+        },
+        Document::String(s) => serde_json::Value::String(s.clone()),
+        Document::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(document_to_json).collect())
+        }
+        Document::Object(obj) => {
+            let map: serde_json::Map<String, serde_json::Value> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), document_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}
+
+// --- Bedrock client ---
+
+pub struct BedrockClient {
+    client: tokio::sync::OnceCell<Client>,
+    region: Option<String>,
+    model_id: String,
+    context_window_size: usize,
+}
+
+impl BedrockClient {
+    pub fn new(model_id: String, region: Option<String>) -> Self {
+        let context_window_size = if model_id.contains("claude") {
+            200_000
+        } else {
+            128_000
+        };
+
+        Self {
+            client: tokio::sync::OnceCell::new(),
+            region,
+            model_id,
+            context_window_size,
+        }
+    }
+
+    async fn get_client(&self) -> &Client {
+        self.client
+            .get_or_init(|| async {
+                let mut config_loader = aws_config::from_env();
+                if let Some(r) = &self.region {
+                    config_loader = config_loader.region(aws_config::Region::new(r.clone()));
+                }
+                let sdk_config = config_loader.load().await;
+                Client::new(&sdk_config)
+            })
+            .await
+    }
+}
+
+// --- Request translation ---
+
+struct ConverseParams {
+    messages: Vec<Message>,
+    system: Option<Vec<SystemContentBlock>>,
+    tool_config: Option<ToolConfiguration>,
+    inference_config: Option<InferenceConfiguration>,
+}
+
+/// Translate Sashiko's generic AiRequest into Bedrock Converse API parameters.
+fn translate_request(request: &AiRequest) -> Result<ConverseParams> {
+    let system = request
+        .system
+        .as_ref()
+        .map(|s| vec![SystemContentBlock::Text(s.clone())]);
+
+    let mut messages: Vec<Message> = Vec::new();
+
+    // We need to merge consecutive Tool messages into a single User message
+    // because Bedrock requires alternating user/assistant turns.
+    let mut pending_tool_results: Vec<ContentBlock> = Vec::new();
+
+    let flush_tool_results =
+        |pending: &mut Vec<ContentBlock>, messages: &mut Vec<Message>| -> Result<()> {
+            if pending.is_empty() {
+                return Ok(());
+            }
+            let mut builder = Message::builder().role(ConversationRole::User);
+            for block in pending.drain(..) {
+                builder = builder.content(block);
+            }
+            messages.push(
+                builder
+                    .build()
+                    .context("Failed to build tool result message")?,
+            );
+            Ok(())
+        };
+
+    for msg in &request.messages {
+        match msg.role {
+            AiRole::System => {} // handled above
+            AiRole::User => {
+                flush_tool_results(&mut pending_tool_results, &mut messages)?;
+                let text = msg.content.clone().unwrap_or_default();
+                messages.push(
+                    Message::builder()
+                        .role(ConversationRole::User)
+                        .content(ContentBlock::Text(text))
+                        .build()
+                        .context("Failed to build user message")?,
+                );
+            }
+            AiRole::Assistant => {
+                flush_tool_results(&mut pending_tool_results, &mut messages)?;
+                let mut builder = Message::builder().role(ConversationRole::Assistant);
+                if let Some(text) = &msg.content {
+                    builder = builder.content(ContentBlock::Text(text.clone()));
+                }
+                if let Some(tool_calls) = &msg.tool_calls {
+                    for call in tool_calls {
+                        let input_doc = json_to_document(&call.arguments);
+                        builder = builder.content(ContentBlock::ToolUse(
+                            ToolUseBlock::builder()
+                                .tool_use_id(&call.id)
+                                .name(&call.function_name)
+                                .input(input_doc)
+                                .build()
+                                .context("Failed to build tool use block")?,
+                        ));
+                    }
+                }
+                messages.push(
+                    builder
+                        .build()
+                        .context("Failed to build assistant message")?,
+                );
+            }
+            AiRole::Tool => {
+                let tool_call_id = msg
+                    .tool_call_id
+                    .as_ref()
+                    .context("Tool message missing tool_call_id")?;
+                let result_text = msg.content.clone().unwrap_or_else(|| "{}".to_string());
+                pending_tool_results.push(ContentBlock::ToolResult(
+                    ToolResultBlock::builder()
+                        .tool_use_id(tool_call_id)
+                        .content(ToolResultContentBlock::Text(result_text))
+                        .build()
+                        .context("Failed to build tool result block")?,
+                ));
+            }
+        }
+    }
+    flush_tool_results(&mut pending_tool_results, &mut messages)?;
+
+    let tool_config = request.tools.as_ref().and_then(|tools| {
+        if tools.is_empty() {
+            return None;
+        }
+        let bedrock_tools: Vec<Tool> = tools
+            .iter()
+            .filter_map(|t| {
+                let schema_doc = json_to_document(&t.parameters);
+                Some(Tool::ToolSpec(
+                    ToolSpecification::builder()
+                        .name(&t.name)
+                        .description(&t.description)
+                        .input_schema(ToolInputSchema::Json(schema_doc))
+                        .build()
+                        .ok()?,
+                ))
+            })
+            .collect();
+        ToolConfiguration::builder()
+            .set_tools(Some(bedrock_tools))
+            .build()
+            .ok()
+    });
+
+    let inference_config = {
+        let mut builder = InferenceConfiguration::builder().max_tokens(4096);
+        if let Some(temp) = request.temperature {
+            builder = builder.temperature(temp);
+        }
+        Some(builder.build())
+    };
+
+    Ok(ConverseParams {
+        messages,
+        system,
+        tool_config,
+        inference_config,
+    })
+}
+
+/// Translate Bedrock Converse API response into Sashiko's generic AiResponse.
+fn translate_response(
+    output: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
+) -> Result<AiResponse> {
+    let mut text_parts = Vec::new();
+    let mut tool_calls = Vec::new();
+
+    if let Some(aws_sdk_bedrockruntime::types::ConverseOutput::Message(ref msg)) = output.output {
+        for block in msg.content() {
+            match block {
+                ContentBlock::Text(t) => text_parts.push(t.clone()),
+                ContentBlock::ToolUse(tu) => {
+                    let args = document_to_json(tu.input());
+                    tool_calls.push(ToolCall {
+                        id: tu.tool_use_id().to_string(),
+                        function_name: tu.name().to_string(),
+                        arguments: args,
+                        thought_signature: None,
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let usage = output.usage.as_ref().map(|u| AiUsage {
+        prompt_tokens: u.input_tokens() as usize,
+        completion_tokens: u.output_tokens() as usize,
+        total_tokens: (u.input_tokens() + u.output_tokens()) as usize,
+        cached_tokens: None,
+    });
+
+    Ok(AiResponse {
+        content: if text_parts.is_empty() {
+            None
+        } else {
+            Some(text_parts.join(""))
+        },
+        thought: None,
+        tool_calls: if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        },
+        usage,
+    })
+}
+
+fn estimate_tokens_generic(request: &AiRequest) -> usize {
+    let mut total = 0;
+    if let Some(system) = &request.system {
+        total += TokenBudget::estimate_tokens(system);
+    }
+    for msg in &request.messages {
+        if let Some(content) = &msg.content {
+            total += TokenBudget::estimate_tokens(content);
+        }
+        if let Some(tool_calls) = &msg.tool_calls {
+            for call in tool_calls {
+                total += TokenBudget::estimate_tokens(&call.function_name);
+                total += TokenBudget::estimate_tokens(&call.arguments.to_string());
+            }
+        }
+    }
+    if let Some(tools) = &request.tools {
+        for tool in tools {
+            total += TokenBudget::estimate_tokens(&tool.name);
+            total += TokenBudget::estimate_tokens(&tool.description);
+            total += TokenBudget::estimate_tokens(&tool.parameters.to_string());
+        }
+    }
+    total
+}
+
+#[async_trait]
+impl AiProvider for BedrockClient {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let params = translate_request(&request)?;
+
+        let resp = self
+            .get_client()
+            .await
+            .converse()
+            .model_id(&self.model_id)
+            .set_messages(Some(params.messages))
+            .set_system(params.system)
+            .set_tool_config(params.tool_config)
+            .set_inference_config(params.inference_config)
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) => r,
+            Err(e) => {
+                let is_throttle = format!("{e:?}").contains("ThrottlingException");
+                if is_throttle {
+                    tracing::warn!("Bedrock throttled, waiting 30s before retry...");
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                }
+                return Err(anyhow::anyhow!("Bedrock Converse API error: {e:#}"));
+            }
+        };
+
+        let usage_str = resp
+            .usage
+            .as_ref()
+            .map(|u| format!("in={}, out={}", u.input_tokens(), u.output_tokens()))
+            .unwrap_or_else(|| "unknown".to_string());
+        info!("Bedrock response received. Tokens: {}", usage_str);
+
+        translate_response(&resp)
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        estimate_tokens_generic(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            model_name: self.model_id.clone(),
+            context_window_size: self.context_window_size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{AiMessage, AiRequest, AiRole, AiTool, ToolCall};
+    use serde_json::json;
+
+    fn make_request(messages: Vec<AiMessage>) -> AiRequest {
+        AiRequest {
+            system: None,
+            messages,
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    #[test]
+    fn test_json_document_roundtrip() {
+        let original = json!({
+            "name": "test",
+            "count": 42,
+            "negative": -7,
+            "ratio": 3.14,
+            "active": true,
+            "nothing": null,
+            "tags": ["a", "b"],
+            "nested": {"x": 1}
+        });
+        let doc = json_to_document(&original);
+        let back = document_to_json(&doc);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn test_translate_system_and_user() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("Hello!".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.system = Some("You are helpful.".to_string());
+        req.temperature = Some(0.5);
+
+        let params = translate_request(&req)?;
+
+        let sys = params.system.unwrap();
+        assert_eq!(sys.len(), 1);
+        if let SystemContentBlock::Text(t) = &sys[0] {
+            assert_eq!(t, "You are helpful.");
+        } else {
+            panic!("Expected Text system block");
+        }
+
+        assert_eq!(params.messages.len(), 1);
+        assert_eq!(params.messages[0].role(), &ConversationRole::User);
+        if let ContentBlock::Text(t) = &params.messages[0].content()[0] {
+            assert_eq!(t, "Hello!");
+        } else {
+            panic!("Expected Text content block");
+        }
+
+        let ic = params.inference_config.unwrap();
+        assert_eq!(ic.temperature(), Some(0.5));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_assistant_with_tool_calls() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::Assistant,
+            content: Some("Let me check.".to_string()),
+            thought: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".to_string(),
+                function_name: "git_log".to_string(),
+                arguments: json!({"n": 5}),
+                thought_signature: None,
+            }]),
+            tool_call_id: None,
+        }]);
+
+        let params = translate_request(&req)?;
+        let content = params.messages[0].content();
+        assert_eq!(content.len(), 2);
+
+        if let ContentBlock::Text(t) = &content[0] {
+            assert_eq!(t, "Let me check.");
+        } else {
+            panic!("Expected Text block");
+        }
+
+        if let ContentBlock::ToolUse(tu) = &content[1] {
+            assert_eq!(tu.tool_use_id(), "call_1");
+            assert_eq!(tu.name(), "git_log");
+            assert_eq!(document_to_json(tu.input()), json!({"n": 5}));
+        } else {
+            panic!("Expected ToolUse block");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_tool_result() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::Tool,
+            content: Some("commit abc123".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: Some("call_1".to_string()),
+        }]);
+
+        let params = translate_request(&req)?;
+        assert_eq!(params.messages.len(), 1);
+        assert_eq!(params.messages[0].role(), &ConversationRole::User);
+
+        if let ContentBlock::ToolResult(tr) = &params.messages[0].content()[0] {
+            assert_eq!(tr.tool_use_id(), "call_1");
+        } else {
+            panic!("Expected ToolResult block");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_tools() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.tools = Some(vec![AiTool {
+            name: "read_file".to_string(),
+            description: "Read a file".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"path": {"type": "string"}}
+            }),
+        }]);
+
+        let params = translate_request(&req)?;
+        let tools = params.tool_config.unwrap().tools().to_vec();
+        assert_eq!(tools.len(), 1);
+
+        if let Tool::ToolSpec(spec) = &tools[0] {
+            assert_eq!(spec.name(), "read_file");
+            assert_eq!(spec.description(), Some("Read a file"));
+        } else {
+            panic!("Expected ToolSpec");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_empty_tools_omitted() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.tools = Some(vec![]);
+
+        let params = translate_request(&req)?;
+        assert!(params.tool_config.is_none());
+
+        Ok(())
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -191,9 +191,15 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
             Ok(Arc::new(claude::ClaudeClient::new(model, enable_caching)))
         }
         "stdio-claude" => Ok(Arc::new(claude::StdioClaudeClient)),
+        "bedrock" => {
+            let model = settings.ai.model.clone();
+            let region = settings.ai.bedrock.as_ref().and_then(|b| b.region.clone());
+            Ok(Arc::new(bedrock::BedrockClient::new(model, region)))
+        }
         p => bail!("Unsupported AI provider: {}", p),
     }
 }
+pub mod bedrock;
 pub mod claude;
 pub mod gemini;
 pub mod proxy;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -109,6 +109,14 @@ pub struct GeminiSettings {
     pub explicit_prompt_caching: bool,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct BedrockSettings {
+    /// AWS region for Bedrock API calls (e.g. "us-east-1").
+    /// If omitted, uses the standard AWS SDK default chain.
+    pub region: Option<String>,
+}
+
 fn default_prompt_caching() -> bool {
     true
 }
@@ -129,6 +137,7 @@ pub struct AiSettings {
     // Provider-specific settings
     pub claude: Option<ClaudeSettings>,
     pub gemini: Option<GeminiSettings>,
+    pub bedrock: Option<BedrockSettings>,
 }
 
 fn default_temperature() -> f32 {

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -880,7 +880,10 @@ Example:
             }
 
             if review_inline_text.is_empty() {
-                return Err(anyhow::anyhow!("Stage 9 failed to generate a valid LKML report after {} attempts.", max_retries));
+                return Err(anyhow::anyhow!(
+                    "Stage 9 failed to generate a valid LKML report after {} attempts.",
+                    max_retries
+                ));
             }
         }
 


### PR DESCRIPTION
Add support for AWS Bedrock as an LLM provider, enabling Sashiko to use any Bedrock-hosted model (Claude, Llama, Mistral, etc.) through the unified Converse API.

Implementation:
- New BedrockClient in src/ai/bedrock.rs implementing the AiProvider trait with full message translation, tool calling, and token usage reporting.
- Manual serde_json::Value <-> aws_smithy_types::Document conversion since the AWS SDK does not provide built-in conversion between these types.
- Tool results are sent as User role messages with ToolResult content blocks, matching the Converse API contract.
- Context window size defaults to 200K for Claude models and 128K for others; users can override via max_input_tokens in Settings.toml.
- Authentication uses the standard AWS credential chain (env vars, ~/.aws/credentials, instance profiles) — no API key needed.

Configuration:
- New BedrockSettings struct with optional region field in Settings.toml.
- Provider registered as "bedrock" in the create_provider factory.

Testing:
- 6 unit tests covering JSON/Document round-trip conversion, system prompt and user message translation, assistant tool call mapping, tool result handling, tool definition translation, and empty tools edge case.