### PR TITLE
Draft: RFC - Continuously Deploy Rust Documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Rust Docs to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: fedora
+    steps:
+      - name: Install dependencies
+        run: dnf install -y gcc git openssl-devel pkg-config rustup
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: |
+          rustup-init --default-toolchain stable -y
+          . "$HOME/.cargo/env"
+
+      - name: Build documentation
+        run: cargo doc --no-deps
+
+      - name: Prepare public directory
+        run: |
+          mkdir public
+          cp -r target/doc/* ./public/
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=sashiko\">" > ./public/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: fedora
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR is (hopefully) first in many to improve this project's existing documentation.

One of rust's powerful native features is [cargo doc](https://doc.rust-lang.org/cargo/commands/cargo-doc.html), a wrapper for [rustdoc](https://doc.rust-lang.org/rustdoc/) which can render [documentation comments](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html?highlight=comments#making-useful-documentation-comments) (and many other things) into an indexable, viewable webpage.

Since this is a rust project, it makes sense to continuously update and publish the `main` branch's rustdocs to the currently unoccupied github pages namespace.

Therefore, create a pages action that will deploy the output of `cargo doc` to an acceptable location for github pages.