### PR TITLE
.github/workflows: remove the --quiet arg in cargo-fmt

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo-clippy && cargo-fmt
-        run: |
-          cargo clippy --all-targets --all-features --  -D warnings
-          cargo fmt --all --quiet -- --check
+      - name: Run cargo-clippy
+        run: cargo clippy --all-targets --all-features --  -D warnings
+      - name: Run cargo-fmt
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Having CI fail due to a formatting error can be problematic when said
error is not propagated to the user.

Break up the rust potion of the linting phase into two sections, and
remove the quiet argument so that it shows up in the workflow logs.

Signed-off-by: derekbarbosa <derekasobrab@gmail.com>
