### PR TITLE
prompts: Update I2C subsystem prompt

### DIFF
--- a/third_party/prompts/kernel/subsystem/i2c.md
+++ b/third_party/prompts/kernel/subsystem/i2c.md
@@ -3,5 +3,6 @@
 ## API
 
 - debugfs entries attached to the `debugfs` object in `struct i2c_client` are
-  cleaned up by the I2C subsystem core in the device removal function after
-  calling the driver remove function and before releasing device resources.
+  cleaned up by the I2C subsystem core in the client device removal function
+  after calling the client driver remove function and before releasing client
+  device resources allocated with devres functions.


### PR DESCRIPTION
Clarify when the I2C subsystem removes the debugfs entries attached to the I2C device to avoid false UAF reports.