### PR TITLE
prompts: hwmon: enums are lower case

### DIFF
--- a/third_party/prompts/kernel/subsystem/hwmon.md
+++ b/third_party/prompts/kernel/subsystem/hwmon.md
@@ -4,6 +4,9 @@
 
 - Code must follow guildelines in `Documentation/hwmon/submitting-patches.rst`.
 
+- enum values in this subsystem are traditionally lowercase.
+  Uppercase is permitted, but not mandatory.
+
 ## Arithmetic
 
 - Check for overflows and underflows in arithmetc calculations


### PR DESCRIPTION
enum values in the hwmon subsystem are traditionally lower case. Tell the agent.