### PR TITLE
ci: relax Signed-off-by validation and cleanup workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,26 +19,6 @@ jobs:
           AFTER="${{ github.event.after }}"
           ZERO="0000000000000000000000000000000000000000"
           if [ "$BEFORE" = "$ZERO" ] || [ -z "$BEFORE" ]; then
-            echo "New branch or invalid before sha, checking latest commit."
-            COMMIT_RANGE="$AFTER~1..$AFTER"
-          else
-            COMMIT_RANGE="$BEFORE..$AFTER"
-          fi
-
-          echo "Checking commits in range: $COMMIT_RANGE"
-          for commit in $(git rev-list $COMMIT_RANGE --no-merges); do
-            AUTHOR_NAME=$(git log -1 --format='%an' $commit)
-            AUTHOR_EMAIL=$(git log -1 --format='%ae' $commit)
-            EXPECTED_SOB="Signed-off-by: $AUTHOR_NAME <$AUTHOR_EMAIL>"
-            if ! git log -1 --format='%b' $commit | \
-              grep -q "^$EXPECTED_SOB"; then
-              echo "ERROR: DCO mismatch in commit $commit"
-              echo "Expected: $EXPECTED_SOB"
-              exit 1
-            fi
-          done
-
-          echo "All commits have valid matching sign-offs!"
             RANGE="$AFTER~1..$AFTER"
           else
             RANGE="$BEFORE..$AFTER"

--- a/scripts/check-sob.sh
+++ b/scripts/check-sob.sh
@@ -14,13 +14,16 @@ fi
 echo "Checking Developer Certificate of Origin (S-O-B) in range: $RANGE"
 
 for commit in $(git rev-list "$RANGE" --no-merges); do
-    AUTHOR_NAME=$(git log -1 --format='%an' "$commit")
-    AUTHOR_EMAIL=$(git log -1 --format='%ae' "$commit")
-    EXPECTED_SOB="Signed-off-by: $AUTHOR_NAME <$AUTHOR_EMAIL>"
+    AUTHOR_NAME=$(git log -1 --format="%an" "$commit")
+    AUTHOR_EMAIL=$(git log -1 --format="%ae" "$commit")
     
-    if ! git log -1 --format='%b' "$commit" | grep -q "^$EXPECTED_SOB"; then
+    # We allow the SOB to match either the author's name or the author's email.
+    # This handles cases where a developer might use different emails for different
+    # environments but the same name, or vice-versa.
+    if ! git log -1 --format="%b" "$commit" | grep -qEi "^Signed-off-by: ($AUTHOR_NAME <|.* <$AUTHOR_EMAIL>)"; then
         echo "ERROR: DCO mismatch in commit $commit"
-        echo "Expected: $EXPECTED_SOB"
+        echo "Author: $AUTHOR_NAME <$AUTHOR_EMAIL>"
+        echo "Commit message must contain a Signed-off-by tag matching the author's name or email."
         exit 1
     fi
 done


### PR DESCRIPTION
Relax the SOB check in scripts/check-sob.sh to allow a match on either
the author's name or the author's email. This prevents false negatives
when a developer uses different email addresses for commits and
sign-offs.

Additionally, simplify the push-main.yml workflow by removing duplicated
SOB validation logic and delegating it to just sob.

Co-authored-by: Gemini CLI <noreply@google.com>
Signed-off-by: derekbarbosa <derekasobrab@gmail.com>
