### PR TITLE
api: fix API endpoint for fetching patchset data

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1604,7 +1604,7 @@
         async function renderPatchsetView(id, query = {}) {
             const page = parseInt(query.page) || 1;
             const limit = parseInt(query.limit) || 50;
-            const res = await fetch(`/api/patch?id=${encodeURIComponent(id)}&page=${page}&limit=${limit}`);
+            const res = await fetch(`/api/patchset?id=${encodeURIComponent(id)}&page=${page}&limit=${limit}`);
             if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
             const data = await res.json();
             


### PR DESCRIPTION
The /api/patchset endpoint has been recently introduced to provide a lighter view, without the full review log and input context for every patch, which can be huge and not used in the patchset detail view.

Except that it has been only changed for the baseline log view, but not the patchset detail one. The content is the same as in /api/patch, only with trimmed log info, so simply switching to the new endpoint fixes this.

Fixes: 3dbb448ed0a4 ("api: introduce /api/patchset and /api/review_log endpoints")
Closes: #57