### PR TITLE
Update README with "just" targets and needed prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,25 @@ git commit -s
 
 ## Development
 
+This project uses [just](https://github.com/casey/just) as a task runner. Install it and run targets from the repo root:
+
+```bash
+# Install just (pick one)
+cargo install just          # via cargo
+sudo apt install just       # Debian/Ubuntu
+
+# See all available targets
+just
+
+# Common usage
+just lint                   # clippy + fmt + yamllint
+just test                   # cargo test --release
+just check-pr               # sob + lint + test (full PR suite)
+just check-all              # PR suite + integration tests
+just sob                    # check Signed-off-by tags
+just sob "HEAD~5..HEAD"     # check SOB for a custom range
+```
+
 This project was built using Gemini CLI. If you're using other development agents, make sure they follow the guidance in GEMINI.md.
 Please, make sure your code is working before sending PR. Make sure it can be built without warnings, all tests pass, run cargo fmt and clippy.
 If you're changing AI-related parts, please, run at least several code reviews.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Running an automated review system like Sashiko can be computationally expensive
 - **Rust**: Version 1.86 or later.
 - **Git**: For managing the repository and kernel tree.
 - **LLM Provider API Key**: Access to an LLM provider (e.g., Google's Gemini or Anthropic's Claude).
+- **System packages** (Debian/Ubuntu):
+    ```bash
+    sudo apt install pkg-config libssl-dev build-essential yamllint
+    ```
+    - `pkg-config`, `libssl-dev` — required by OpenSSL (used by reqwest and lettre for TLS)
+    - `build-essential` — C compiler needed by tree-sitter
+    - `yamllint` — required by `just lint`
+
+    On Fedora/RHEL:
+    ```bash
+    sudo dnf install pkg-config openssl-devel gcc yamllint
+    ```
 
 ## Setup
 


### PR DESCRIPTION
The Justfile has been the project's task runner but was not documented in the README. New contributors
had no way to discover available dev commands without reading the Justfile directly.

Also add system package prerequisites.