### PR TITLE
k8s: add netfilter-devel mailing list

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -83,7 +83,7 @@ spec:
                 linux-rdma,linux-trace-kernel,linux-watchdog,mptcp,netdev,
                 rust-for-linux,kvmarm,linux-arm-kernel,linux-block,linux-scsi,
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
-                kexec,linux-iio
+                kexec,linux-iio,netfilter-devel
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "36"
             - name: SASHIKO__SMTP__SENDER_ADDRESS


### PR DESCRIPTION
Make sashiko digest netfilter-devel mailing list so it can point out issues before the PR is sent to netdev.

Closes #100 