### PR TITLE
k8: add linux-renesas-soc and forward reviews to me

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -83,7 +83,7 @@ spec:
                 linux-rdma,linux-trace-kernel,linux-watchdog,mptcp,netdev,
                 rust-for-linux,kvmarm,linux-arm-kernel,linux-block,linux-scsi,
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
-                kexec,linux-iio,netfilter-devel
+                kexec,linux-iio,netfilter-devel,linux-renesas-soc,
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "36"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -47,3 +47,7 @@ cc = ["tytso@mit.edu"]
 [subsystems.net]
 lists = ["netdev@vger.kernel.org"]
 embargo_hours = 24
+
+[subsystems.renesas-soc]
+lists = ["linux-renesas-soc@vger.kernel.org"]
+cc = ["wsa+renesas@sang-engineering.com"]


### PR DESCRIPTION
I will evaluate a workflow with me sending out curated Sashiko reviews, so send the Sashiko reports to me only first.