### PR TITLE
WIP: DONOTMERGE: example fixes for Claude API

### DIFF
--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -248,11 +248,38 @@ fn translate_ai_request(request: &AiRequest, enable_caching: bool) -> Result<Cla
     let mut system_blocks = Vec::new();
 
     // Extract system prompt from the explicit system field
+    let json_instruction_owned: Option<String> =
+        if let Some(crate::ai::AiResponseFormat::Json { schema }) = &request.response_format {
+            // Claude has no native JSON mode; enforce it via instruction.
+            if let Some(schema) = schema {
+                Some(format!(
+                    "\n\nYou MUST respond with valid JSON only matching this schema: {}. Do not include any explanation, markdown, or code fences — output raw JSON.",
+                    serde_json::to_string(schema).unwrap_or_default()
+                ))
+            } else {
+                Some("\n\nYou MUST respond with valid JSON only. Do not include any explanation, markdown, or code fences — output raw JSON.".to_string())
+            }
+        } else {
+            None
+        };
+    let json_instruction = json_instruction_owned.as_deref();
+
     if let Some(system_text) = &request.system {
+        let mut text = system_text.clone();
+        if let Some(instr) = json_instruction {
+            text.push_str(instr);
+        }
         system_blocks.push(SystemBlock {
             block_type: "text".to_string(),
-            text: system_text.clone(),
+            text,
             cache_control: None, // Will be set later if caching is enabled
+        });
+    } else if let Some(instr) = json_instruction {
+        // No system prompt but JSON format required — create a minimal system block.
+        system_blocks.push(SystemBlock {
+            block_type: "text".to_string(),
+            text: instr.trim_start_matches('\n').to_string(),
+            cache_control: None,
         });
     }
 

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -34,7 +34,8 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
+    AiProvider, AiRequest, AiResponse, AiResponseFormat, AiRole, AiUsage, ProviderCapabilities,
+    ToolCall,
 };
 
 pub struct ClaudeCliProvider {
@@ -87,7 +88,17 @@ impl AiProvider for ClaudeCliProvider {
             }
         }
 
+        let raw = String::from_utf8_lossy(&output.stdout);
+
         if !output.status.success() {
+            // Try to extract the actual error message from the JSON output before giving up.
+            // The CLI emits a JSON object with is_error=true and the reason in the "result"
+            // field even when it exits non-zero (e.g. unknown model, quota exceeded).
+            if let Ok(outer) = serde_json::from_str::<Value>(&raw) {
+                if let Some(msg) = outer["result"].as_str() {
+                    anyhow::bail!("claude CLI error: {}", msg);
+                }
+            }
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!(
                 "claude CLI exited with {}: {}",
@@ -95,8 +106,6 @@ impl AiProvider for ClaudeCliProvider {
                 stderr.trim()
             );
         }
-
-        let raw = String::from_utf8_lossy(&output.stdout);
         let outer: Value = serde_json::from_str(&raw).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to parse claude CLI JSON output: {}\nRaw: {}",
@@ -209,6 +218,18 @@ pub fn build_prompt(request: &AiRequest) -> String {
              For your final answer: {\"content\": \"YOUR RESPONSE\"}\n\
              Do not mix both. Output exactly one JSON object.\n",
         );
+    } else if let Some(AiResponseFormat::Json { schema }) = &request.response_format {
+        // No tools but JSON format required (e.g. Phase 0, Planning).
+        if let Some(schema) = schema {
+            out.push_str(&format!(
+                "RESPONSE FORMAT: You MUST respond with valid JSON only matching this schema: {}. Do not include any explanation, markdown, or code fences — output raw JSON.\n",
+                serde_json::to_string(schema).unwrap_or_default()
+            ));
+        } else {
+            out.push_str(
+                "RESPONSE FORMAT: You MUST respond with valid JSON only. Do not include any explanation, markdown, or code fences — output raw JSON.\n",
+            );
+        }
     }
 
     out

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -472,11 +472,11 @@ impl Worker {
                         subsystem_md, target_commit_diff
                     );
                     let schema = json!({
-                        "type": "OBJECT",
+                        "type": "object",
                         "properties": {
                             "selected_prompts": {
-                                "type": "ARRAY",
-                                "items": { "type": "STRING" }
+                                "type": "array",
+                                "items": { "type": "string" }
                             }
                         },
                         "required": ["selected_prompts"]
@@ -619,11 +619,11 @@ impl Worker {
         let mut planning_selected_stages: Option<Vec<u8>> = None;
         if self.stages.is_none() {
             let schema = serde_json::json!({
-                "type": "OBJECT",
+                "type": "object",
                 "properties": {
                     "relevant_stages": {
-                        "type": "ARRAY",
-                        "items": { "type": "INTEGER" },
+                        "type": "array",
+                        "items": { "type": "integer" },
                         "description": "Array of stage numbers from 4, 5, 6, 7 that are relevant to this patch. Err on the side of inclusion if unsure."
                     }
                 },
@@ -636,7 +636,7 @@ impl Worker {
 - Stage 6: Security audit
 - Stage 7: Hardware engineer's review
 
-Return ONLY a JSON object containing an array of integers representing the relevant stages (e.g., [4, 5, 6, 7]).
+Return ONLY a JSON object with a "relevant_stages" key containing an array of integers (e.g., {"relevant_stages": [4, 5, 6, 7]}).
 CRITICAL: Always err on the side of running more stages. If you are not absolutely sure, include the stage. If the patch is a trivial typo fix, you may omit some stages. Stages 1, 2, and 3 are always run and should not be included in your answer."#;
 
             let req = AiRequest {

--- a/src/worker/tools.rs
+++ b/src/worker/tools.rs
@@ -69,22 +69,22 @@ impl ToolBox {
                 description: "Read the content of one or more files. In 'smart' mode, it collapses irrelevant code around the focus lines."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
                         "files": {
-                            "type": "ARRAY",
+                            "type": "array",
                             "description": "List of files to read.",
                             "items": {
-                                "type": "OBJECT",
+                                "type": "object",
                                 "properties": {
-                                    "path": { "type": "STRING", "description": "Relative path to the file." },
-                                    "start_line": { "type": "INTEGER", "description": "1-based start line (optional). In smart mode, this is the start of the focus area." },
-                                    "end_line": { "type": "INTEGER", "description": "1-based end line (optional). In smart mode, this is the end of the focus area." }
+                                    "path": { "type": "string", "description": "Relative path to the file." },
+                                    "start_line": { "type": "integer", "description": "1-based start line (optional). In smart mode, this is the start of the focus area." },
+                                    "end_line": { "type": "integer", "description": "1-based end line (optional). In smart mode, this is the end of the focus area." }
                                 },
                                 "required": ["path"]
                             }
                         },
-                        "mode": { "type": "STRING", "enum": ["raw", "smart"], "description": "Read mode. Defaults to 'raw'." }
+                        "mode": { "type": "string", "enum": ["raw", "smart"], "description": "Read mode. Defaults to 'raw'." }
                     },
                     "required": ["files"]
                 }),
@@ -94,11 +94,11 @@ impl ToolBox {
                 description: "Show what revision and author last modified each line of a file."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "path": { "type": "STRING", "description": "Relative path to the file." },
-                        "start_line": { "type": "INTEGER", "description": "1-based start line (optional)." },
-                        "end_line": { "type": "INTEGER", "description": "1-based end line (optional)." }
+                        "path": { "type": "string", "description": "Relative path to the file." },
+                        "start_line": { "type": "integer", "description": "1-based start line (optional)." },
+                        "end_line": { "type": "integer", "description": "1-based end line (optional)." }
                     },
                     "required": ["path"]
                 }),
@@ -108,9 +108,9 @@ impl ToolBox {
                 description: "Show changes between commits, commit and working tree, etc."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "args": { "type": "ARRAY", "items": { "type": "STRING" }, "description": "Arguments for git diff (e.g., ['HEAD^', 'HEAD'])." }
+                        "args": { "type": "array", "items": { "type": "string" }, "description": "Arguments for git diff (e.g., ['HEAD^', 'HEAD'])." }
                     },
                     "required": ["args"]
                 }),
@@ -120,12 +120,12 @@ impl ToolBox {
                 description: "Show various types of objects (blobs, trees, tags and commits). Supports line filtering for blobs and diff suppression for commits."
                     .to_string(),
                 parameters: json!({
-                        "type": "OBJECT",
+                        "type": "object",
                         "properties": {
-                            "object": { "type": "STRING", "description": "The object to show (e.g. 'HEAD:README.md' or 'HEAD')." },
-                            "suppress_diff": { "type": "BOOLEAN", "description": "If true, suppresses the diff output for commits (shows only metadata). Useful for checking commit details cheaply." },
-                            "start_line": { "type": "INTEGER", "description": "1-based start line (optional). Useful for reading specific parts of a file (blob)." },
-                            "end_line": { "type": "INTEGER", "description": "1-based end line (optional)." }
+                            "object": { "type": "string", "description": "The object to show (e.g. 'HEAD:README.md' or 'HEAD')." },
+                            "suppress_diff": { "type": "boolean", "description": "If true, suppresses the diff output for commits (shows only metadata). Useful for checking commit details cheaply." },
+                            "start_line": { "type": "integer", "description": "1-based start line (optional). Useful for reading specific parts of a file (blob)." },
+                            "end_line": { "type": "integer", "description": "1-based end line (optional)." }
                         },
                         "required": ["object"]
                 }),
@@ -134,9 +134,9 @@ impl ToolBox {
                 name: "git_log".to_string(),
                 description: "Show commit logs. IMPORTANT: When using expensive search flags like -S or -G, you MUST limit the search range using --since (e.g., '--since=1.year.ago') or specific commit ranges to avoid timeouts on large repositories.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "args": { "type": "ARRAY", "items": { "type": "STRING" }, "description": "Arguments for git log (e.g., ['-n', '3', '--oneline']). Bounded to 100 commits by default unless overridden. For -S/-G searches, always include a time limit like '--since=1.year.ago'." }
+                        "args": { "type": "array", "items": { "type": "string" }, "description": "Arguments for git log (e.g., ['-n', '3', '--oneline']). Bounded to 100 commits by default unless overridden. For -S/-G searches, always include a time limit like '--since=1.year.ago'." }
                     },
                 }),
             },
@@ -144,7 +144,7 @@ impl ToolBox {
                 name: "git_status".to_string(),
                 description: "Show the working tree status.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -152,9 +152,9 @@ impl ToolBox {
                 name: "git_checkout".to_string(),
                 description: "Switch branches or restore working tree files.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "target": { "type": "STRING", "description": "The branch or commit to checkout." }
+                        "target": { "type": "string", "description": "The branch or commit to checkout." }
                     },
                     "required": ["target"]
                 }),
@@ -163,7 +163,7 @@ impl ToolBox {
                 name: "git_branch".to_string(),
                 description: "List both remote-tracking branches and local branches.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -171,7 +171,7 @@ impl ToolBox {
                 name: "git_tag".to_string(),
                 description: "List tags.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -179,9 +179,9 @@ impl ToolBox {
                 name: "list_dir".to_string(),
                 description: "List files in a directory.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "path": { "type": "STRING", "description": "Directory path." }
+                        "path": { "type": "string", "description": "Directory path." }
                     },
                     "required": ["path"]
                 }),
@@ -190,11 +190,11 @@ impl ToolBox {
                 name: "search_file_content".to_string(),
                 description: "Search for a pattern in files using grep. Returns matching lines with context.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "pattern": { "type": "STRING", "description": "Regex pattern to search for." },
-                        "path": { "type": "STRING", "description": "Directory to search in (defaults to root)." },
-                        "context_lines": { "type": "INTEGER", "description": "Number of context lines to show (default 0)." }
+                        "pattern": { "type": "string", "description": "Regex pattern to search for." },
+                        "path": { "type": "string", "description": "Directory to search in (defaults to root)." },
+                        "context_lines": { "type": "integer", "description": "Number of context lines to show (default 0)." }
                     },
                     "required": ["pattern"]
                 }),
@@ -203,10 +203,10 @@ impl ToolBox {
                 name: "find_files".to_string(),
                 description: "Find files matching a glob pattern (e.g., '*.rs', 'src/**/mod.rs').".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "pattern": { "type": "STRING", "description": "Glob pattern to match." },
-                        "path": { "type": "STRING", "description": "Directory to search in (defaults to root)." }
+                        "pattern": { "type": "string", "description": "Glob pattern to match." },
+                        "path": { "type": "string", "description": "Directory to search in (defaults to root)." }
                     },
                     "required": ["pattern"]
                 }),
@@ -215,9 +215,9 @@ impl ToolBox {
                 name: "TodoWrite".to_string(),
                 description: "Add a new TODO item to the TODO.md file.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "content": { "type": "STRING", "description": "The TODO item content." }
+                        "content": { "type": "string", "description": "The TODO item content." }
                     },
                     "required": ["content"]
                 }),
@@ -229,9 +229,9 @@ impl ToolBox {
                 name: "read_prompt".to_string(),
                 description: "Read a specific prompt file from the prompt registry (e.g., 'mm.md', 'locking.md').".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "name": { "type": "STRING", "description": "Name of the prompt file (e.g., 'patterns/BPF-001.md')." }
+                        "name": { "type": "string", "description": "Name of the prompt file (e.g., 'patterns/BPF-001.md')." }
                     },
                     "required": ["name"]
                 }),


### PR DESCRIPTION
Was getting errors when trying to use Claude with $ANTHROPIC_API_KEY. Debugging with Claude Code, it found several issues:

1. Tool schemas (src/worker/tools.rs) — All type names were uppercase ("OBJECT", "STRING", "ARRAY", etc.), which Gemini accepts but the Claude API rejects with: "tools.0.custom.input_schema.type: Input should be 'object'" Changed all to lowercase. This was blocking every Stage 1 attempt.

2. Phase 0 and Planning schemas (src/worker/prompts.rs) — Same uppercase type issue in the inline JSON schemas used for those phases.

3. Claude ignores response_format (src/ai/claude.rs) — When AiResponseFormat::Json is requested, the Claude client was sending nothing special, so Claude responded with prose instead of JSON. Fixed by appending an explicit instruction to the system prompt when JSON format is requested, including the full schema so Claude knows the exact key names required.

   Two sub-issues fixed here: a. When system prompt is None (as in the planning phase request), the original fix never fired. Now a minimal system block is created to carry the JSON instruction in that case. b. The planning prompt example showed a bare array "[4, 5, 6, 7]" but the parsing code expected {"relevant_stages": [...]}. Updated the example to match the key name the code looks for.

After these fixes, all three phases work correctly with Claude:
  - Phase 0 selects relevant subsystem guides
  - Planning phase selects relevant review stages
  - Stage 1+ tool calls succeed

The changes here are entirely generated by Claude Code, and may break Gemini since the type casing conventions differ.  This patch is only intended as an example of what the Claude API expects.