### PR TITLE
Bedrock + Opus 4.7 improvements

### DIFF
--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -87,10 +87,19 @@ pub struct BedrockClient {
     region: Option<String>,
     model_id: String,
     context_window_size: usize,
+    max_tokens: u32,
+    thinking: Option<String>,
+    effort: Option<String>,
 }
 
 impl BedrockClient {
-    pub fn new(model_id: String, region: Option<String>) -> Self {
+    pub fn new(
+        model_id: String,
+        region: Option<String>,
+        max_tokens: u32,
+        thinking: Option<String>,
+        effort: Option<String>,
+    ) -> Self {
         let context_window_size = if model_id.contains("claude") {
             200_000
         } else {
@@ -102,6 +111,9 @@ impl BedrockClient {
             region,
             model_id,
             context_window_size,
+            max_tokens,
+            thinking,
+            effort,
         }
     }
 
@@ -126,10 +138,38 @@ struct ConverseParams {
     system: Option<Vec<SystemContentBlock>>,
     tool_config: Option<ToolConfiguration>,
     inference_config: Option<InferenceConfiguration>,
+    additional_model_request_fields: Option<Document>,
+}
+
+fn build_additional_fields(thinking: Option<&str>, effort: Option<&str>) -> Option<Document> {
+    let mut map: HashMap<String, Document> = HashMap::new();
+
+    if let Some(t) = thinking {
+        let mut thinking_obj: HashMap<String, Document> = HashMap::new();
+        thinking_obj.insert("type".to_string(), Document::String(t.to_string()));
+        map.insert("thinking".to_string(), Document::Object(thinking_obj));
+    }
+
+    if let Some(e) = effort {
+        let mut output_cfg: HashMap<String, Document> = HashMap::new();
+        output_cfg.insert("effort".to_string(), Document::String(e.to_string()));
+        map.insert("output_config".to_string(), Document::Object(output_cfg));
+    }
+
+    if map.is_empty() {
+        None
+    } else {
+        Some(Document::Object(map))
+    }
 }
 
 /// Translate Sashiko's generic AiRequest into Bedrock Converse API parameters.
-fn translate_request(request: &AiRequest) -> Result<ConverseParams> {
+fn translate_request(
+    request: &AiRequest,
+    max_tokens: u32,
+    thinking: Option<&str>,
+    effort: Option<&str>,
+) -> Result<ConverseParams> {
     let system = request
         .system
         .as_ref()
@@ -240,18 +280,23 @@ fn translate_request(request: &AiRequest) -> Result<ConverseParams> {
     });
 
     let inference_config = {
-        let mut builder = InferenceConfiguration::builder().max_tokens(4096);
-        if let Some(temp) = request.temperature {
-            builder = builder.temperature(temp);
+        let mut builder = InferenceConfiguration::builder().max_tokens(max_tokens as i32);
+        if thinking.is_none() {
+            if let Some(temp) = request.temperature {
+                builder = builder.temperature(temp);
+            }
         }
         Some(builder.build())
     };
+
+    let additional_model_request_fields = build_additional_fields(thinking, effort);
 
     Ok(ConverseParams {
         messages,
         system,
         tool_config,
         inference_config,
+        additional_model_request_fields,
     })
 }
 
@@ -332,7 +377,12 @@ fn estimate_tokens_generic(request: &AiRequest) -> usize {
 #[async_trait]
 impl AiProvider for BedrockClient {
     async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
-        let params = translate_request(&request)?;
+        let params = translate_request(
+            &request,
+            self.max_tokens,
+            self.thinking.as_deref(),
+            self.effort.as_deref(),
+        )?;
 
         let resp = self
             .get_client()
@@ -343,6 +393,7 @@ impl AiProvider for BedrockClient {
             .set_system(params.system)
             .set_tool_config(params.tool_config)
             .set_inference_config(params.inference_config)
+            .set_additional_model_request_fields(params.additional_model_request_fields)
             .send()
             .await;
 
@@ -427,7 +478,7 @@ mod tests {
         req.system = Some("You are helpful.".to_string());
         req.temperature = Some(0.5);
 
-        let params = translate_request(&req)?;
+        let params = translate_request(&req, 4096, None, None)?;
 
         let sys = params.system.unwrap();
         assert_eq!(sys.len(), 1);
@@ -466,7 +517,7 @@ mod tests {
             tool_call_id: None,
         }]);
 
-        let params = translate_request(&req)?;
+        let params = translate_request(&req, 4096, None, None)?;
         let content = params.messages[0].content();
         assert_eq!(content.len(), 2);
 
@@ -497,7 +548,7 @@ mod tests {
             tool_call_id: Some("call_1".to_string()),
         }]);
 
-        let params = translate_request(&req)?;
+        let params = translate_request(&req, 4096, None, None)?;
         assert_eq!(params.messages.len(), 1);
         assert_eq!(params.messages[0].role(), &ConversationRole::User);
 
@@ -528,7 +579,7 @@ mod tests {
             }),
         }]);
 
-        let params = translate_request(&req)?;
+        let params = translate_request(&req, 4096, None, None)?;
         let tools = params.tool_config.unwrap().tools().to_vec();
         assert_eq!(tools.len(), 1);
 
@@ -553,9 +604,60 @@ mod tests {
         }]);
         req.tools = Some(vec![]);
 
-        let params = translate_request(&req)?;
+        let params = translate_request(&req, 4096, None, None)?;
         assert!(params.tool_config.is_none());
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_additional_fields_none_when_unset() {
+        assert!(build_additional_fields(None, None).is_none());
+    }
+
+    #[test]
+    fn test_additional_fields_thinking_and_effort() {
+        let doc = build_additional_fields(Some("adaptive"), Some("xhigh")).unwrap();
+        let json = document_to_json(&doc);
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "xhigh"}
+            })
+        );
+    }
+
+    #[test]
+    fn test_max_tokens_propagates_to_inference_config() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let params = translate_request(&req, 8192, None, None)?;
+        assert_eq!(params.inference_config.unwrap().max_tokens(), Some(8192));
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_request_wires_additional_fields() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let params = translate_request(&req, 8192, Some("adaptive"), Some("high"))?;
+        let extra = params.additional_model_request_fields.unwrap();
+        let json = document_to_json(&extra);
+        assert_eq!(json["thinking"]["type"], "adaptive");
+        assert_eq!(json["output_config"]["effort"], "high");
         Ok(())
     }
 }

--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -20,9 +20,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
 use aws_sdk_bedrockruntime::types::{
-    ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock, Tool,
-    ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock, ToolSpecification,
-    ToolUseBlock,
+    CachePointBlock, CachePointType, ContentBlock, ConversationRole, InferenceConfiguration,
+    Message, SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock,
+    ToolResultContentBlock, ToolSpecification, ToolUseBlock,
 };
 use aws_smithy_types::{Document, Number};
 use std::collections::HashMap;
@@ -87,6 +87,7 @@ pub struct BedrockClient {
     region: Option<String>,
     model_id: String,
     context_window_size: usize,
+    enable_caching: bool,
     max_tokens: u32,
     thinking: Option<String>,
     effort: Option<String>,
@@ -96,6 +97,7 @@ impl BedrockClient {
     pub fn new(
         model_id: String,
         region: Option<String>,
+        enable_caching: bool,
         max_tokens: u32,
         thinking: Option<String>,
         effort: Option<String>,
@@ -111,6 +113,7 @@ impl BedrockClient {
             region,
             model_id,
             context_window_size,
+            enable_caching,
             max_tokens,
             thinking,
             effort,
@@ -166,14 +169,23 @@ fn build_additional_fields(thinking: Option<&str>, effort: Option<&str>) -> Opti
 /// Translate Sashiko's generic AiRequest into Bedrock Converse API parameters.
 fn translate_request(
     request: &AiRequest,
+    enable_caching: bool,
     max_tokens: u32,
     thinking: Option<&str>,
     effort: Option<&str>,
 ) -> Result<ConverseParams> {
-    let system = request
-        .system
-        .as_ref()
-        .map(|s| vec![SystemContentBlock::Text(s.clone())]);
+    let system = request.system.as_ref().map(|s| {
+        let mut blocks = vec![SystemContentBlock::Text(s.clone())];
+        if enable_caching {
+            blocks.push(SystemContentBlock::CachePoint(
+                CachePointBlock::builder()
+                    .r#type(CachePointType::Default)
+                    .build()
+                    .expect("CachePointBlock build"),
+            ));
+        }
+        blocks
+    });
 
     let mut messages: Vec<Message> = Vec::new();
 
@@ -255,11 +267,30 @@ fn translate_request(
     }
     flush_tool_results(&mut pending_tool_results, &mut messages)?;
 
+    if enable_caching
+        && let Some(last) = messages.last_mut()
+    {
+        let role = last.role().clone();
+        let mut builder = Message::builder().role(role);
+        for block in last.content().iter().cloned() {
+            builder = builder.content(block);
+        }
+        builder = builder.content(ContentBlock::CachePoint(
+            CachePointBlock::builder()
+                .r#type(CachePointType::Default)
+                .build()
+                .expect("CachePointBlock build"),
+        ));
+        *last = builder
+            .build()
+            .context("Failed to rebuild last message with cachePoint")?;
+    }
+
     let tool_config = request.tools.as_ref().and_then(|tools| {
         if tools.is_empty() {
             return None;
         }
-        let bedrock_tools: Vec<Tool> = tools
+        let mut bedrock_tools: Vec<Tool> = tools
             .iter()
             .filter_map(|t| {
                 let schema_doc = json_to_document(&t.parameters);
@@ -273,6 +304,14 @@ fn translate_request(
                 ))
             })
             .collect();
+        if enable_caching && !bedrock_tools.is_empty() {
+            bedrock_tools.push(Tool::CachePoint(
+                CachePointBlock::builder()
+                    .r#type(CachePointType::Default)
+                    .build()
+                    .expect("CachePointBlock build"),
+            ));
+        }
         ToolConfiguration::builder()
             .set_tools(Some(bedrock_tools))
             .build()
@@ -325,11 +364,18 @@ fn translate_response(
         }
     }
 
-    let usage = output.usage.as_ref().map(|u| AiUsage {
-        prompt_tokens: u.input_tokens() as usize,
-        completion_tokens: u.output_tokens() as usize,
-        total_tokens: (u.input_tokens() + u.output_tokens()) as usize,
-        cached_tokens: None,
+    let usage = output.usage.as_ref().map(|u| {
+        let cached = u.cache_read_input_tokens().unwrap_or(0);
+        AiUsage {
+            prompt_tokens: u.input_tokens() as usize,
+            completion_tokens: u.output_tokens() as usize,
+            total_tokens: (u.input_tokens() + u.output_tokens()) as usize,
+            cached_tokens: if cached > 0 {
+                Some(cached as usize)
+            } else {
+                None
+            },
+        }
     });
 
     Ok(AiResponse {
@@ -379,6 +425,7 @@ impl AiProvider for BedrockClient {
     async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
         let params = translate_request(
             &request,
+            self.enable_caching,
             self.max_tokens,
             self.thinking.as_deref(),
             self.effort.as_deref(),
@@ -412,7 +459,14 @@ impl AiProvider for BedrockClient {
         let usage_str = resp
             .usage
             .as_ref()
-            .map(|u| format!("in={}, out={}", u.input_tokens(), u.output_tokens()))
+            .map(|u| {
+                format!(
+                    "in={}, out={}, cached={}",
+                    u.input_tokens(),
+                    u.output_tokens(),
+                    u.cache_read_input_tokens().unwrap_or(0)
+                )
+            })
             .unwrap_or_else(|| "unknown".to_string());
         info!("Bedrock response received. Tokens: {}", usage_str);
 
@@ -478,7 +532,7 @@ mod tests {
         req.system = Some("You are helpful.".to_string());
         req.temperature = Some(0.5);
 
-        let params = translate_request(&req, 4096, None, None)?;
+        let params = translate_request(&req, false, 4096, None, None)?;
 
         let sys = params.system.unwrap();
         assert_eq!(sys.len(), 1);
@@ -517,7 +571,7 @@ mod tests {
             tool_call_id: None,
         }]);
 
-        let params = translate_request(&req, 4096, None, None)?;
+        let params = translate_request(&req, false, 4096, None, None)?;
         let content = params.messages[0].content();
         assert_eq!(content.len(), 2);
 
@@ -548,7 +602,7 @@ mod tests {
             tool_call_id: Some("call_1".to_string()),
         }]);
 
-        let params = translate_request(&req, 4096, None, None)?;
+        let params = translate_request(&req, false, 4096, None, None)?;
         assert_eq!(params.messages.len(), 1);
         assert_eq!(params.messages[0].role(), &ConversationRole::User);
 
@@ -579,7 +633,7 @@ mod tests {
             }),
         }]);
 
-        let params = translate_request(&req, 4096, None, None)?;
+        let params = translate_request(&req, false, 4096, None, None)?;
         let tools = params.tool_config.unwrap().tools().to_vec();
         assert_eq!(tools.len(), 1);
 
@@ -604,7 +658,7 @@ mod tests {
         }]);
         req.tools = Some(vec![]);
 
-        let params = translate_request(&req, 4096, None, None)?;
+        let params = translate_request(&req, false, 4096, None, None)?;
         assert!(params.tool_config.is_none());
 
         Ok(())
@@ -638,7 +692,7 @@ mod tests {
             tool_call_id: None,
         }]);
 
-        let params = translate_request(&req, 8192, None, None)?;
+        let params = translate_request(&req, false, 8192, None, None)?;
         assert_eq!(params.inference_config.unwrap().max_tokens(), Some(8192));
         Ok(())
     }
@@ -653,11 +707,159 @@ mod tests {
             tool_call_id: None,
         }]);
 
-        let params = translate_request(&req, 8192, Some("adaptive"), Some("high"))?;
+        let params = translate_request(&req, false, 8192, Some("adaptive"), Some("high"))?;
         let extra = params.additional_model_request_fields.unwrap();
         let json = document_to_json(&extra);
         assert_eq!(json["thinking"]["type"], "adaptive");
         assert_eq!(json["output_config"]["effort"], "high");
+        Ok(())
+    }
+
+    #[test]
+    fn test_cache_point_inserted_when_enabled() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("Hello!".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.system = Some("System prompt.".to_string());
+
+        let params = translate_request(&req, true, 4096, None, None)?;
+        let sys = params.system.unwrap();
+        assert_eq!(sys.len(), 2);
+        assert!(matches!(&sys[0], SystemContentBlock::Text(_)));
+        assert!(sys[1].is_cache_point());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rolling_cache_point_on_last_message_when_enabled() -> Result<()> {
+        let req = make_request(vec![
+            AiMessage {
+                role: AiRole::User,
+                content: Some("first".to_string()),
+                thought: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            AiMessage {
+                role: AiRole::Assistant,
+                content: Some("second".to_string()),
+                thought: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ]);
+
+        let params = translate_request(&req, true, 4096, None, None)?;
+        assert_eq!(params.messages.len(), 2);
+
+        let first_content = params.messages[0].content();
+        assert_eq!(first_content.len(), 1);
+        assert!(!first_content[0].is_cache_point());
+
+        let last_content = params.messages[1].content();
+        assert_eq!(last_content.len(), 2);
+        assert!(!last_content[0].is_cache_point());
+        assert!(last_content[1].is_cache_point());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rolling_cache_point_preserves_tool_result_blocks() -> Result<()> {
+        let req = make_request(vec![
+            AiMessage {
+                role: AiRole::Tool,
+                content: Some("result A".to_string()),
+                thought: None,
+                tool_calls: None,
+                tool_call_id: Some("call_a".to_string()),
+            },
+            AiMessage {
+                role: AiRole::Tool,
+                content: Some("result B".to_string()),
+                thought: None,
+                tool_calls: None,
+                tool_call_id: Some("call_b".to_string()),
+            },
+        ]);
+
+        let params = translate_request(&req, true, 4096, None, None)?;
+        assert_eq!(params.messages.len(), 1);
+        let content = params.messages[0].content();
+        assert_eq!(content.len(), 3);
+        assert!(matches!(&content[0], ContentBlock::ToolResult(_)));
+        assert!(matches!(&content[1], ContentBlock::ToolResult(_)));
+        assert!(content[2].is_cache_point());
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_rolling_cache_point_when_disabled() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let params = translate_request(&req, false, 4096, None, None)?;
+        let content = params.messages[0].content();
+        assert_eq!(content.len(), 1);
+        assert!(!content[0].is_cache_point());
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_cache_point_appended_when_enabled() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.tools = Some(vec![AiTool {
+            name: "read_file".to_string(),
+            description: "Read a file".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"path": {"type": "string"}}
+            }),
+        }]);
+
+        let params = translate_request(&req, true, 4096, None, None)?;
+        let tools = params.tool_config.unwrap().tools().to_vec();
+        assert_eq!(tools.len(), 2);
+        assert!(matches!(&tools[0], Tool::ToolSpec(_)));
+        assert!(tools[1].is_cache_point());
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_cache_point_absent_when_disabled() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.tools = Some(vec![AiTool {
+            name: "read_file".to_string(),
+            description: "Read a file".to_string(),
+            parameters: json!({"type": "object"}),
+        }]);
+
+        let params = translate_request(&req, false, 4096, None, None)?;
+        let tools = params.tool_config.unwrap().tools().to_vec();
+        assert_eq!(tools.len(), 1);
+        assert!(matches!(&tools[0], Tool::ToolSpec(_)));
         Ok(())
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -193,8 +193,18 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
         "stdio-claude" => Ok(Arc::new(claude::StdioClaudeClient)),
         "bedrock" => {
             let model = settings.ai.model.clone();
-            let region = settings.ai.bedrock.as_ref().and_then(|b| b.region.clone());
-            Ok(Arc::new(bedrock::BedrockClient::new(model, region)))
+            let bedrock = settings.ai.bedrock.as_ref();
+            let region = bedrock.and_then(|b| b.region.clone());
+            let max_tokens = bedrock.map(|b| b.max_tokens).unwrap_or(8192);
+            let thinking = bedrock.and_then(|b| b.thinking.clone());
+            let effort = bedrock.and_then(|b| b.effort.clone());
+            Ok(Arc::new(bedrock::BedrockClient::new(
+                model,
+                region,
+                max_tokens,
+                thinking,
+                effort,
+            )))
         }
         "openai" | "openai-compatible" => {
             let provider_type = match settings.ai.provider.to_lowercase().as_str() {

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -195,12 +195,14 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
             let model = settings.ai.model.clone();
             let bedrock = settings.ai.bedrock.as_ref();
             let region = bedrock.and_then(|b| b.region.clone());
+            let enable_caching = bedrock.map(|b| b.prompt_caching).unwrap_or(true);
             let max_tokens = bedrock.map(|b| b.max_tokens).unwrap_or(8192);
             let thinking = bedrock.and_then(|b| b.thinking.clone());
             let effort = bedrock.and_then(|b| b.effort.clone());
             Ok(Arc::new(bedrock::BedrockClient::new(
                 model,
                 region,
+                enable_caching,
                 max_tokens,
                 thinking,
                 effort,

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -275,28 +275,6 @@ impl OpenAiCompatClient {
     }
 }
 
-fn normalize_schema(mut schema: Value) -> Value {
-    if let Some(obj) = schema.as_object_mut() {
-        if let Some(ty) = obj.get_mut("type")
-            && let Some(s) = ty.as_str()
-        {
-            *ty = Value::String(s.to_lowercase());
-        }
-        for (_, val) in obj.iter_mut() {
-            if val.is_object() || val.is_array() {
-                *val = normalize_schema(val.clone());
-            }
-        }
-    } else if let Some(arr) = schema.as_array_mut() {
-        for val in arr.iter_mut() {
-            if val.is_object() || val.is_array() {
-                *val = normalize_schema(val.clone());
-            }
-        }
-    }
-    schema
-}
-
 fn translate_ai_request(
     request: AiRequest,
     max_tokens: u32,
@@ -372,7 +350,7 @@ fn translate_ai_request(
                         function: OpenAiFunction {
                             name: tool.name,
                             description: tool.description,
-                            parameters: normalize_schema(tool.parameters),
+                            parameters: tool.parameters,
                         },
                     })
                     .collect(),
@@ -1057,51 +1035,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_schema_lowercases_types() {
-        let schema = json!({
-            "type": "OBJECT",
-            "properties": {
-                "files": {
-                    "type": "ARRAY",
-                    "items": {
-                        "type": "OBJECT",
-                        "properties": {
-                            "path": { "type": "STRING" },
-                            "start_line": { "type": "INTEGER" }
-                        }
-                    }
-                },
-                "mode": { "type": "STRING", "enum": ["raw", "smart"] },
-                "flag": { "type": "BOOLEAN" }
-            }
-        });
-
-        let normalized = normalize_schema(schema);
-
-        assert_eq!(normalized["type"], "object");
-        assert_eq!(normalized["properties"]["files"]["type"], "array");
-        assert_eq!(normalized["properties"]["files"]["items"]["type"], "object");
-        assert_eq!(
-            normalized["properties"]["files"]["items"]["properties"]["path"]["type"],
-            "string"
-        );
-        assert_eq!(
-            normalized["properties"]["files"]["items"]["properties"]["start_line"]["type"],
-            "integer"
-        );
-        assert_eq!(normalized["properties"]["mode"]["type"], "string");
-        assert_eq!(normalized["properties"]["flag"]["type"], "boolean");
-    }
-
-    #[test]
-    fn test_normalize_schema_already_lowercase() {
-        let schema = json!({"type": "object", "properties": {"x": {"type": "string"}}});
-        let normalized = normalize_schema(schema.clone());
-        assert_eq!(normalized, schema);
-    }
-
-    #[test]
-    fn test_translate_request_normalizes_tool_schemas() -> Result<()> {
+    fn test_translate_request_preserves_tool_schemas() -> Result<()> {
         let request = AiRequest {
             system: None,
             messages: vec![],
@@ -1109,9 +1043,9 @@ mod tests {
                 name: "my_tool".to_string(),
                 description: "Does something.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "mode": { "type": "STRING" }
+                        "mode": { "type": "string" }
                     }
                 }),
             }]),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -116,6 +116,8 @@ pub struct BedrockSettings {
     /// AWS region for Bedrock API calls (e.g. "us-east-1").
     /// If omitted, uses the standard AWS SDK default chain.
     pub region: Option<String>,
+    #[serde(default = "default_prompt_caching")]
+    pub prompt_caching: bool,
     /// Max output tokens per Converse call.
     #[serde(default = "default_bedrock_max_tokens")]
     pub max_tokens: u32,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -116,6 +116,21 @@ pub struct BedrockSettings {
     /// AWS region for Bedrock API calls (e.g. "us-east-1").
     /// If omitted, uses the standard AWS SDK default chain.
     pub region: Option<String>,
+    /// Max output tokens per Converse call.
+    #[serde(default = "default_bedrock_max_tokens")]
+    pub max_tokens: u32,
+    /// Thinking mode sent as additional_model_request_fields. Opus 4.7 only accepts "adaptive".
+    /// Leave unset to omit (thinking disabled). Valid values: "adaptive".
+    #[serde(default)]
+    pub thinking: Option<String>,
+    /// output_config.effort level. Valid values: "low", "medium", "high", "xhigh", "max".
+    /// Leave unset to use the model default. "xhigh" is Opus 4.7-only.
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+fn default_bedrock_max_tokens() -> u32 {
+    8192
 }
 
 fn default_prompt_caching() -> bool {

--- a/src/worker/tools.rs
+++ b/src/worker/tools.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 use crate::ai::truncator::Truncator;
-use crate::ai::{
-    AiTool,
-    gemini::{FunctionDeclaration, Tool},
-};
+use crate::ai::AiTool;
 use anyhow::{Result, anyhow, ensure};
 use grep::printer::StandardBuilder;
 use grep::regex::RegexMatcher;
@@ -45,22 +42,6 @@ impl ToolBox {
         &self.worktree_path
     }
 
-    /// Returns Gemini-specific tool declarations.
-    /// TODO: Deprecate after migration.
-    pub fn get_declarations(&self) -> Tool {
-        let decls = self.get_declarations_generic();
-        Tool {
-            function_declarations: decls
-                .into_iter()
-                .map(|t| FunctionDeclaration {
-                    name: t.name,
-                    description: t.description,
-                    parameters: t.parameters,
-                })
-                .collect(),
-        }
-    }
-
     /// Returns generic tool declarations.
     pub fn get_declarations_generic(&self) -> Vec<AiTool> {
         let mut decls = vec![
@@ -69,22 +50,22 @@ impl ToolBox {
                 description: "Read the content of one or more files. In 'smart' mode, it collapses irrelevant code around the focus lines."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
                         "files": {
-                            "type": "ARRAY",
+                            "type": "array",
                             "description": "List of files to read.",
                             "items": {
-                                "type": "OBJECT",
+                                "type": "object",
                                 "properties": {
-                                    "path": { "type": "STRING", "description": "Relative path to the file." },
-                                    "start_line": { "type": "INTEGER", "description": "1-based start line (optional). In smart mode, this is the start of the focus area." },
-                                    "end_line": { "type": "INTEGER", "description": "1-based end line (optional). In smart mode, this is the end of the focus area." }
+                                    "path": { "type": "string", "description": "Relative path to the file." },
+                                    "start_line": { "type": "integer", "description": "1-based start line (optional). In smart mode, this is the start of the focus area." },
+                                    "end_line": { "type": "integer", "description": "1-based end line (optional). In smart mode, this is the end of the focus area." }
                                 },
                                 "required": ["path"]
                             }
                         },
-                        "mode": { "type": "STRING", "enum": ["raw", "smart"], "description": "Read mode. Defaults to 'raw'." }
+                        "mode": { "type": "string", "enum": ["raw", "smart"], "description": "Read mode. Defaults to 'raw'." }
                     },
                     "required": ["files"]
                 }),
@@ -94,11 +75,11 @@ impl ToolBox {
                 description: "Show what revision and author last modified each line of a file."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "path": { "type": "STRING", "description": "Relative path to the file." },
-                        "start_line": { "type": "INTEGER", "description": "1-based start line (optional)." },
-                        "end_line": { "type": "INTEGER", "description": "1-based end line (optional)." }
+                        "path": { "type": "string", "description": "Relative path to the file." },
+                        "start_line": { "type": "integer", "description": "1-based start line (optional)." },
+                        "end_line": { "type": "integer", "description": "1-based end line (optional)." }
                     },
                     "required": ["path"]
                 }),
@@ -108,9 +89,9 @@ impl ToolBox {
                 description: "Show changes between commits, commit and working tree, etc."
                     .to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "args": { "type": "ARRAY", "items": { "type": "STRING" }, "description": "Arguments for git diff (e.g., ['HEAD^', 'HEAD'])." }
+                        "args": { "type": "array", "items": { "type": "string" }, "description": "Arguments for git diff (e.g., ['HEAD^', 'HEAD'])." }
                     },
                     "required": ["args"]
                 }),
@@ -120,12 +101,12 @@ impl ToolBox {
                 description: "Show various types of objects (blobs, trees, tags and commits). Supports line filtering for blobs and diff suppression for commits."
                     .to_string(),
                 parameters: json!({
-                        "type": "OBJECT",
+                        "type": "object",
                         "properties": {
-                            "object": { "type": "STRING", "description": "The object to show (e.g. 'HEAD:README.md' or 'HEAD')." },
-                            "suppress_diff": { "type": "BOOLEAN", "description": "If true, suppresses the diff output for commits (shows only metadata). Useful for checking commit details cheaply." },
-                            "start_line": { "type": "INTEGER", "description": "1-based start line (optional). Useful for reading specific parts of a file (blob)." },
-                            "end_line": { "type": "INTEGER", "description": "1-based end line (optional)." }
+                            "object": { "type": "string", "description": "The object to show (e.g. 'HEAD:README.md' or 'HEAD')." },
+                            "suppress_diff": { "type": "boolean", "description": "If true, suppresses the diff output for commits (shows only metadata). Useful for checking commit details cheaply." },
+                            "start_line": { "type": "integer", "description": "1-based start line (optional). Useful for reading specific parts of a file (blob)." },
+                            "end_line": { "type": "integer", "description": "1-based end line (optional)." }
                         },
                         "required": ["object"]
                 }),
@@ -134,9 +115,9 @@ impl ToolBox {
                 name: "git_log".to_string(),
                 description: "Show commit logs. IMPORTANT: When using expensive search flags like -S or -G, you MUST limit the search range using --since (e.g., '--since=1.year.ago') or specific commit ranges to avoid timeouts on large repositories.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "args": { "type": "ARRAY", "items": { "type": "STRING" }, "description": "Arguments for git log (e.g., ['-n', '3', '--oneline']). Bounded to 100 commits by default unless overridden. For -S/-G searches, always include a time limit like '--since=1.year.ago'." }
+                        "args": { "type": "array", "items": { "type": "string" }, "description": "Arguments for git log (e.g., ['-n', '3', '--oneline']). Bounded to 100 commits by default unless overridden. For -S/-G searches, always include a time limit like '--since=1.year.ago'." }
                     },
                 }),
             },
@@ -144,7 +125,7 @@ impl ToolBox {
                 name: "git_status".to_string(),
                 description: "Show the working tree status.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -152,9 +133,9 @@ impl ToolBox {
                 name: "git_checkout".to_string(),
                 description: "Switch branches or restore working tree files.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "target": { "type": "STRING", "description": "The branch or commit to checkout." }
+                        "target": { "type": "string", "description": "The branch or commit to checkout." }
                     },
                     "required": ["target"]
                 }),
@@ -163,7 +144,7 @@ impl ToolBox {
                 name: "git_branch".to_string(),
                 description: "List both remote-tracking branches and local branches.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -171,7 +152,7 @@ impl ToolBox {
                 name: "git_tag".to_string(),
                 description: "List tags.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {},
                 }),
             },
@@ -179,9 +160,9 @@ impl ToolBox {
                 name: "list_dir".to_string(),
                 description: "List files in a directory.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "path": { "type": "STRING", "description": "Directory path." }
+                        "path": { "type": "string", "description": "Directory path." }
                     },
                     "required": ["path"]
                 }),
@@ -190,11 +171,11 @@ impl ToolBox {
                 name: "search_file_content".to_string(),
                 description: "Search for a pattern in files using grep. Returns matching lines with context.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "pattern": { "type": "STRING", "description": "Regex pattern to search for." },
-                        "path": { "type": "STRING", "description": "Directory to search in (defaults to root)." },
-                        "context_lines": { "type": "INTEGER", "description": "Number of context lines to show (default 0)." }
+                        "pattern": { "type": "string", "description": "Regex pattern to search for." },
+                        "path": { "type": "string", "description": "Directory to search in (defaults to root)." },
+                        "context_lines": { "type": "integer", "description": "Number of context lines to show (default 0)." }
                     },
                     "required": ["pattern"]
                 }),
@@ -203,10 +184,10 @@ impl ToolBox {
                 name: "find_files".to_string(),
                 description: "Find files matching a glob pattern (e.g., '*.rs', 'src/**/mod.rs').".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "pattern": { "type": "STRING", "description": "Glob pattern to match." },
-                        "path": { "type": "STRING", "description": "Directory to search in (defaults to root)." }
+                        "pattern": { "type": "string", "description": "Glob pattern to match." },
+                        "path": { "type": "string", "description": "Directory to search in (defaults to root)." }
                     },
                     "required": ["pattern"]
                 }),
@@ -215,9 +196,9 @@ impl ToolBox {
                 name: "TodoWrite".to_string(),
                 description: "Add a new TODO item to the TODO.md file.".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "content": { "type": "STRING", "description": "The TODO item content." }
+                        "content": { "type": "string", "description": "The TODO item content." }
                     },
                     "required": ["content"]
                 }),
@@ -229,9 +210,9 @@ impl ToolBox {
                 name: "read_prompt".to_string(),
                 description: "Read a specific prompt file from the prompt registry (e.g., 'mm.md', 'locking.md').".to_string(),
                 parameters: json!({
-                    "type": "OBJECT",
+                    "type": "object",
                     "properties": {
-                        "name": { "type": "STRING", "description": "Name of the prompt file (e.g., 'patterns/BPF-001.md')." }
+                        "name": { "type": "string", "description": "Name of the prompt file (e.g., 'patterns/BPF-001.md')." }
                     },
                     "required": ["name"]
                 }),


### PR DESCRIPTION
First, fix the JSON schema. (I think there's another PR opened recently with a similar change.)

Second, Bedrock had no caching implemented, which made it pretty useless. According to the API we have 4 explicit caching points we can insert. Start popping them in, one after the initial prompt, one after the patch, one after the per-stage instructions, and the last one "rolling". Reportedly Bedrock auto-ignores attempts to insert the rolling one if the delta from previous insert is too small, so no extra logic to save writes is added. 

Last, add Opus 4.7 params. Importantly we piggy back on presence of the "thinking" setting to stop sending temperature, because Opus 4.7 deprecated temperature and API errors out if we send anything but 1 (and some stages hard code temp of 0). Not super clear how best to handle this sort of "one model deprecates a random param" situation :s

All of this is vibe coded, of course, I cannot read Rust.