### PR TITLE
settings: support Settings.local.toml for local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ third_party/linux/
 benchmarks/smoke-repo/
 review_trees/
 sashiko.log
-Settings.toml
+Settings.local.toml
 email_policy.toml

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -268,6 +268,7 @@ impl Settings {
         let s = Config::builder()
             // Start with default settings
             .add_source(File::with_name("Settings"))
+            .add_source(File::with_name("Settings.local").required(false))
             // Add settings from environment variables (with a prefix of SASHIKO)
             // e.g. SASHIKO_SERVER__PORT=8081 would set the server port
             .add_source(Environment::with_prefix("SASHIKO").separator("__"))


### PR DESCRIPTION
Either I'm confused of something strange happened to the config. It's committed and in the .gitignore.
I think it makes sense to have the config / sample config committed so let's add a secondary "local" config for overrides?
Sorry if I'm completely off base..
