### PR TITLE
email: add rust-for-linux subsystem to policy

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -56,3 +56,8 @@ cc = ["tj@kernel.org", "hannes@cmpxchg.org", "mkoutny@suse.com"]
 [subsystems.renesas-soc]
 lists = ["linux-renesas-soc@vger.kernel.org"]
 cc = ["wsa+renesas@sang-engineering.com"]
+
+[subsystems.rust-for-linux]
+lists = ["rust-for-linux@vger.kernel.org"]
+reply_to_author = true
+cc = ["ojeda@kernel.org"]


### PR DESCRIPTION
In Rust for Linux, we would like to at least get the reports sent to the original author, thus configure sashiko.dev to do so. In addition, Cc me as well.

Depending on how it goes, I may request later to just send the reviews to the mailing list.

Thanks!