### PR TITLE
build: make bedrock provider an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.1.4"
 edition = "2024"
 default-run = "sashiko"
 
+[features]
+default = ["bedrock"]
+bedrock = ["aws-config", "aws-sdk-bedrockruntime", "aws-smithy-types"]
+
 [dependencies]
 anyhow = "1.0.100"
 async-trait = "0.1.89"
-aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-sdk-bedrockruntime = "1"
-aws-smithy-types = "1"
+aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
+aws-sdk-bedrockruntime = { version = "1", optional = true }
+aws-smithy-types = { version = "1", optional = true }
 axum = "0.8.8"
 chrono = "0.4.43"
 clap = { version = "4.5.54", features = ["derive", "env"] }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -191,6 +191,7 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
             Ok(Arc::new(claude::ClaudeClient::new(model, enable_caching)))
         }
         "stdio-claude" => Ok(Arc::new(claude::StdioClaudeClient)),
+        #[cfg(feature = "bedrock")]
         "bedrock" => {
             let model = settings.ai.model.clone();
             let bedrock = settings.ai.bedrock.as_ref();
@@ -208,6 +209,8 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
                 effort,
             )))
         }
+        #[cfg(not(feature = "bedrock"))]
+        "bedrock" => bail!("bedrock provider requires the 'bedrock' feature"),
         "openai" | "openai-compatible" => {
             let provider_type = match settings.ai.provider.to_lowercase().as_str() {
                 "openai" => openai::OpenAiProviderType::OpenAi,
@@ -257,6 +260,7 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
         p => bail!("Unsupported AI provider: {}", p),
     }
 }
+#[cfg(feature = "bedrock")]
 pub mod bedrock;
 pub mod claude;
 pub mod claude_cli;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -110,6 +110,7 @@ pub struct GeminiSettings {
     pub explicit_prompt_caching: bool,
 }
 
+#[cfg(feature = "bedrock")]
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
 pub struct BedrockSettings {
@@ -131,6 +132,7 @@ pub struct BedrockSettings {
     pub effort: Option<String>,
 }
 
+#[cfg(feature = "bedrock")]
 fn default_bedrock_max_tokens() -> u32 {
     8192
 }
@@ -172,6 +174,7 @@ pub struct AiSettings {
     // Provider-specific settings
     pub claude: Option<ClaudeSettings>,
     pub gemini: Option<GeminiSettings>,
+    #[cfg(feature = "bedrock")]
     pub bedrock: Option<BedrockSettings>,
     pub openai_compat: Option<OpenAiCompatSettings>,
 }


### PR DESCRIPTION
Building sashiko OOMs my laptop :( Roman suggests that the bedrock dependency is a major source of slowness.

Gate bedrock and it's dependencies, but keep it enabled by default to minimize changes.
I'm slightly tempted to disable it by default, but IDK. Could be just me that is annoyed by it.