### PR TITLE
prompts: exclude stage-specific guides from shared context

### DIFF
--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -43,6 +43,10 @@ use tracing::{info, warn};
 /// System identity prompt - used across all AI interactions
 pub const SYSTEM_IDENTITY: &str = "";
 
+/// Subsystem guides that are loaded per-stage in get_stage_prompt() and should
+/// be excluded from Phase 0's shared context to avoid double-counting.
+const STAGE_EXCLUSIVE_GUIDES: &[&str] = &["locking.md"];
+
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct PatchInput {
     pub index: i64,
@@ -519,6 +523,7 @@ impl Worker {
                         let prompts: Vec<String> = arr
                             .iter()
                             .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .filter(|name| !STAGE_EXCLUSIVE_GUIDES.contains(&name.as_str()))
                             .collect();
                         info!("Phase 0 selected prompts: {:?}", prompts);
                         Some(prompts)


### PR DESCRIPTION
locking.md is huge and already loaded by stage 5 via get_stage_prompt(), but Phase 0 was also including it in the shared context - causing every stage to pay its ~11.5k input tokens. Filter stage-exclusive guides out of Phase 0's selection.

This change saves 5%-10% of review cost. Of course we will now have different system prompts, but that's assumed to be okay given we construct those based on response from phase 0, anyway.

In my testing other stages still find locking issues (basic stuff like deadlocks) since that doesn't require much intricate knowledge from the model.

Note for validating - locking.md is loaded as a user message at stage 5 not inside the prompt (easy to miss when validating this works correctly).