### PR TITLE
index.html: add colorblind mode and settings menu

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -58,7 +58,13 @@
             --role-tool: #3f51b5;
             --fn-name: #6f42c1;
 
+            /* Severity Colors */
+            --sev-critical: #B71C1C;
+            --sev-high: #FF5722;
+            --sev-medium: #FF9800;
+            --sev-low: #FBC02D;
         }
+
         @media (prefers-color-scheme: dark) {
             :root {
                 --bg: #0d1117;
@@ -101,7 +107,124 @@
                 --role-user: #79c0ff;
                 --role-tool: #82aaff;
                 --fn-name: #d2a8ff;
+
+                /* Severity Colors - Dark Mode */
+                --sev-critical: #ff8b8b;
+                --sev-high: #ff9d7e;
+                --sev-medium: #ffc260;
+                --sev-low: #ffea7f;
             }
+        }
+
+        /* Colorblind Mode Overrides (Okabe-Ito inspired palette) */
+        body.colorblind-mode {
+            --status-pending: #56B4E9;   /* Sky Blue */
+            --status-inreview: #E69F00;  /* Orange */
+            --status-reviewed: #0072B2;  /* Blue */
+            --status-failed: #D55E00;    /* Vermilion */
+            --status-embargoed: #CC79A7; /* Reddish Purple */
+
+            --sev-critical: #D55E00;     /* Vermilion */
+            --sev-high: #E69F00;         /* Orange */
+            --sev-medium: #F0E442;       /* Yellow */
+            --sev-low: #56B4E9;          /* Sky Blue */
+        }
+
+        /* Explicit Theme Overrides */
+        body.theme-light {
+            color-scheme: light;
+            --bg: #f5f5f5;
+            --border: #ccc;
+            --border-light: #eee;
+            --text: #24292f;
+            --text-muted: #666;
+            --text-dim: #999;
+            --link: #007bff;
+            --hover: #e0e0e0;
+            --selected: #d0d0d0;
+            --code-bg: #f6f8fa;
+            --code-border: #d0d7de;
+            --btn-bg: #fff;
+            --input-bg: #fff;
+            --card-bg: #fff;
+            --ai-bg: #ffffff;
+            --ai-border: #283593;
+            --warn-bg: #fff3cd;
+            --warn-border: #ffeeba;
+            --warn-text: #856404;
+            --error-bg: #fff0f0;
+            --error-border: #ffcdd2;
+            --error-text: #d73a49;
+            --error-title: #b71c1c;
+            --thought-color: #6a737d;
+            --thought-border: #d0d7de;
+            --log-color: #000;
+            --th-bg: #fafafa;
+            --status-pending: #0366d6;
+            --status-inreview: #d67f05;
+            --status-reviewed: #22863a;
+            --status-failed: #d73a49;
+            --status-embargoed: #6f42c1;
+            --tag-bg: #e0f7fa;
+            --tag-text: #006064;
+            --diff-add-bg: #e6ffec;
+            --diff-rm-bg: #ffebe9;
+            --diff-header: #005cc5;
+            --role-user: #005cc5;
+            --role-tool: #3f51b5;
+            --fn-name: #6f42c1;
+            --sev-critical: #B71C1C;
+            --sev-high: #FF5722;
+            --sev-medium: #FF9800;
+            --sev-low: #FBC02D;
+        }
+
+        body.theme-dark {
+            color-scheme: dark;
+            --bg: #0d1117;
+            --border: #30363d;
+            --border-light: #21262d;
+            --text: #c9d1d9;
+            --text-muted: #8b949e;
+            --text-dim: #6e7681;
+            --link: #58a6ff;
+            --hover: #21262d;
+            --selected: #21262d;
+            --code-bg: #161b22;
+            --code-border: #30363d;
+            --btn-bg: #21262d;
+            --input-bg: #0d1117;
+            --card-bg: #161b22;
+            --ai-bg: #161b22;
+            --ai-border: #58a6ff;
+            --warn-bg: #3a2a00;
+            --warn-border: #755200;
+            --warn-text: #e5b300;
+            --error-bg: #3a0000;
+            --error-border: #750000;
+            --error-text: #ff6b6b;
+            --error-title: #ff8b8b;
+            --thought-color: #8b949e;
+            --thought-border: #30363d;
+            --log-color: #c9d1d9;
+            --th-bg: #161b22;
+            --status-pending: #58a6ff;
+            --status-inreview: #d29922;
+            --status-reviewed: #3fb950;
+            --status-failed: #f85149;
+            --status-embargoed: #d2a8ff;
+            --tag-bg: #032f62;
+            --tag-text: #79c0ff;
+            --diff-add-bg: rgba(46, 160, 67, 0.15);
+            --diff-rm-bg: rgba(248, 81, 73, 0.15);
+            --diff-header: #79c0ff;
+            --role-user: #79c0ff;
+            --role-tool: #82aaff;
+            --fn-name: #d2a8ff;
+            --sev-critical: #ff8b8b;
+            --sev-high: #ff9d7e;
+            --sev-medium: #ffc260;
+            --sev-low: #ffea7f;
         }
 
 
@@ -183,23 +306,27 @@
         }
 
         .controls button,
-        button {
+        button,
+        select {
             padding: 4px 10px;
             font-family: inherit;
             font-size: inherit;
             border: 1px solid var(--border);
             background: var(--btn-bg);
+            color: var(--text);
             border-radius: 3px;
             cursor: pointer;
         }
 
         .controls button:hover,
-        button:hover {
+        button:hover,
+        select:hover {
             background: var(--hover);
         }
 
         .controls button:disabled,
-        button:disabled {
+        button:disabled,
+        select:disabled {
             opacity: 0.5;
             cursor: default;
         }
@@ -850,6 +977,70 @@
         <kbd>q</kbd> back
     </div>
 
+    <div id="settingsModal" class="modal-overlay" onclick="if(event.target===this) closeSettings()">
+        <div class="modal-content">
+            <span class="modal-close" onclick="closeSettings()">&times;</span>
+            <div class="about-logo">
+                <svg style="height: 1em; margin-right: 12px;" viewBox="0 0 16 16" width="24" height="24" fill="currentColor"><path d="M8 0a8.2 8.2 0 0 1 .701.031C9.444.095 10.196.256 10.92.507c.052.018.103.037.154.057l.01.004c.431.166.844.387 1.236.657.352.243.68.522.98.833.3.311.57.652.804 1.018.234.367.43.76.585 1.177.025.066.048.133.07.2.145.43.25.874.316 1.332.03.207.045.418.045.629 0 .211-.015.422-.045.629a8.225 8.225 0 0 1-.316 1.332c-.022.067-.045.134-.07.2-.154.416-.351.81-.585 1.177-.234.366-.504.707-.804 1.018-.3.311-.628.59-0.98.833a8.163 8.163 0 0 1-1.236.657l-.01.004c-.051.02-.102.039-.154.057a8.217 8.217 0 0 1-2.219.538c-.23.015-.461.023-.692.023-.23 0-.461-.008-.692-.023a8.217 8.217 0 0 1-2.219-.538c-.052-.018-.103-.037-.154-.057l-.01-.004a8.163 8.163 0 0 1-1.236-.657c-.352-.243-.68-.522-.98-.833a8.14 8.14 0 0 1-.804-1.018 8.12 8.12 0 0 1-.585-1.177c-.025-.066-.048-.133-.07-.2a8.225 8.225 0 0 1-.316-1.332A8.156 8.156 0 0 1 0 8c0-.211.015-.422.045-.629a8.225 8.225 0 0 1 .316-1.332c.022-.067.045-.134.07-.2a8.12 8.12 0 0 1 .585-1.177c.234-.366.504-.707.804-1.018.3-.311.628-.59.98-.833a8.163 8.163 0 0 1 1.236-.657l.01-.004c.051-.02.102-.039.154-.057a8.217 8.217 0 0 1 2.219-.538C7.539.008 7.769 0 8 0Zm0 2.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Zm0 2a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z"></path></svg>
+                Settings
+            </div>
+            <div class="about-text">
+                <div style="margin-bottom: 24px;">
+                    <h3 style="margin-top: 0;">Appearance</h3>
+                    <div style="display: flex; flex-direction: column; gap: 12px;">
+                        <div style="display: flex; align-items: center; justify-content: space-between;">
+                            <span>Theme</span>
+                            <select id="themeSelect" onchange="setTheme(this.value)">
+                                <option value="auto">System Default</option>
+                                <option value="light">Light</option>
+                                <option value="dark">Dark</option>
+                            </select>
+                        </div>
+                        <div style="display: flex; align-items: center; justify-content: space-between;">
+                            <span>Colorblind Mode</span>
+                            <label class="switch">
+                                <input type="checkbox" id="colorblindToggle" onchange="setColorblind(this.checked)" style="opacity: 0; width: 0; height: 0;">
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="disclaimer" style="margin-top: 24px; font-size: 0.9em;">
+                    Settings are saved in your browser's cookies and will persist across sessions.
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        /* Toggle Switch Styling */
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 40px;
+            height: 20px;
+        }
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--border);
+            transition: .4s;
+            border-radius: 20px;
+        }
+        .switch input:checked + .slider { background-color: var(--status-reviewed); }
+        .switch input:focus + .slider { box-shadow: 0 0 1px var(--status-reviewed); }
+        .switch input:checked + .slider:before { transform: translateX(20px); }
+        .slider:before {
+            position: absolute; content: ""; height: 16px; width: 16px; left: 2px; bottom: 2px;
+            background-color: white; transition: .4s; border-radius: 50%;
+        }
+    </style>
+
     <div id="aboutModal" class="modal-overlay" onclick="if(event.target===this) closeAbout()">
         <div class="modal-content">
             <span class="modal-close" onclick="closeAbout()">&times;</span>
@@ -916,8 +1107,74 @@
             patchsetId: null,
             patchsetPage: 1,
             patchsetTotalPages: 1,
-            patchsetLimit: 50
+            patchsetLimit: 50,
+            settings: {
+                theme: 'auto',
+                colorblind: false
+            }
         };
+
+        // =====================================================================
+        // SETTINGS & COOKIES
+        // =====================================================================
+        function setCookie(name, value, days = 365) {
+            const d = new Date();
+            d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
+            document.cookie = `${name}=${value};expires=${d.toUTCString()};path=/`;
+        }
+
+        function getCookie(name) {
+            const value = `; ${document.cookie}`;
+            const parts = value.split(`; ${name}=`);
+            if (parts.length === 2) return parts.pop().split(';').shift();
+        }
+
+        function applySettings() {
+            const body = document.body;
+            
+            // Apply Theme
+            body.classList.remove('theme-light', 'theme-dark');
+            if (state.settings.theme === 'light') body.classList.add('theme-light');
+            else if (state.settings.theme === 'dark') body.classList.add('theme-dark');
+            
+            // Apply Colorblind Mode
+            if (state.settings.colorblind) body.classList.add('colorblind-mode');
+            else body.classList.remove('colorblind-mode');
+
+            // Sync UI
+            const themeSelect = document.getElementById('themeSelect');
+            if (themeSelect) themeSelect.value = state.settings.theme;
+            const cbToggle = document.getElementById('colorblindToggle');
+            if (cbToggle) cbToggle.checked = state.settings.colorblind;
+        }
+
+        function setTheme(val) {
+            state.settings.theme = val;
+            setCookie('sashiko_theme', val);
+            applySettings();
+        }
+
+        function setColorblind(val) {
+            state.settings.colorblind = !!val;
+            setCookie('sashiko_colorblind', state.settings.colorblind ? '1' : '0');
+            applySettings();
+        }
+
+        function loadSettings() {
+            const theme = getCookie('sashiko_theme');
+            if (theme) state.settings.theme = theme;
+            const cb = getCookie('sashiko_colorblind');
+            if (cb) state.settings.colorblind = cb === '1';
+            applySettings();
+        }
+
+        function openSettings() {
+            document.getElementById('settingsModal').classList.add('open');
+        }
+
+        function closeSettings() {
+            document.getElementById('settingsModal').classList.remove('open');
+        }
 
         // =====================================================================
         // ROUTER
@@ -1290,10 +1547,10 @@
             }
             return `
                 <div style="display:inline-flex; gap:6px; font-weight:bold; font-size:0.9em; vertical-align:middle;">
-                    <span style="color:${critical > 0 ? '#B71C1C' : 'var(--text-dim)'}" title="Critical">${critical}</span>
-                    <span style="color:${high > 0 ? '#FF5722' : 'var(--text-dim)'}" title="High">${high}</span>
-                    <span style="color:${medium > 0 ? '#FF9800' : 'var(--text-dim)'}" title="Medium">${medium}</span>
-                    <span style="color:${low > 0 ? '#FBC02D' : 'var(--text-dim)'}" title="Low">${low}</span>
+                    <span style="color:var(--sev-critical)" title="Critical">${critical}</span>
+                    <span style="color:var(--sev-high)" title="High">${high}</span>
+                    <span style="color:var(--sev-medium)" title="Medium">${medium}</span>
+                    <span style="color:var(--sev-low)" title="Low">${low}</span>
                 </div>
             `;
         }
@@ -1382,7 +1639,7 @@
                     </span>
                 </h1>
                 <div class="controls">
-                    <select id="listSelector" onchange="setMailingList(this.value)" style="padding: 4px 8px; border: 1px solid var(--border); border-radius: 3px;">
+                    <select id="listSelector" onchange="setMailingList(this.value)">
                         <option value="">All Lists</option>
                         ${listOptions}
                     </select>
@@ -1556,6 +1813,8 @@
                             <span class="stats-label">Sashiko</span> v${data.version}
                             <span class="stats-sep"></span>
                             <a href="#" onclick="event.preventDefault(); openAbout();" style="font-weight:500;">About</a>
+                            <span class="stats-sep"></span>
+                            <a href="#" onclick="event.preventDefault(); openSettings();" style="font-weight:500;">Settings</a>
                             <span class="stats-sep"></span>
                             <a href="#/stats" style="font-weight:500;">Stats</a>
                         </div>
@@ -2075,10 +2334,10 @@
                             displayResult = '<span style="color:#2e7d32;font-weight:bold;">No regressions</span>';
                         } else {
                             const parts = [];
-                            parts.push(`Critical: <span style="${counts.critical > 0 ? 'color:#B71C1C;font-weight:bold' : 'color:var(--text-dim)'}">${counts.critical}</span>`);
-                            parts.push(`High: <span style="${counts.high > 0 ? 'color:#FF5722;font-weight:bold' : 'color:var(--text-dim)'}">${counts.high}</span>`);
-                            parts.push(`Medium: <span style="${counts.medium > 0 ? 'color:#FF9800;font-weight:bold' : 'color:var(--text-dim)'}">${counts.medium}</span>`);
-                            parts.push(`Low: <span style="${counts.low > 0 ? 'color:#FBC02D;font-weight:bold' : 'color:var(--text-dim)'}">${counts.low}</span>`);
+                            parts.push(`Critical: <span style="${counts.critical > 0 ? 'color:var(--sev-critical);font-weight:bold' : 'color:var(--text-dim)'}">${counts.critical}</span>`);
+                            parts.push(`High: <span style="${counts.high > 0 ? 'color:var(--sev-high);font-weight:bold' : 'color:var(--text-dim)'}">${counts.high}</span>`);
+                            parts.push(`Medium: <span style="${counts.medium > 0 ? 'color:var(--sev-medium);font-weight:bold' : 'color:var(--text-dim)'}">${counts.medium}</span>`);
+                            parts.push(`Low: <span style="${counts.low > 0 ? 'color:var(--sev-low);font-weight:bold' : 'color:var(--text-dim)'}">${counts.low}</span>`);
                             displayResult = parts.join(' · ');
                         }
                         parsedFindings = true;
@@ -2812,11 +3071,13 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     const chart = echarts.init(document.getElementById('chart-findings'), isDark ? 'dark' : null);
                     const dates = [...new Set(timeline.findings.map(f => f.day))].sort();
                     const severities = ['low', 'medium', 'high', 'critical'];
+                    
+                    const computedStyle = getComputedStyle(document.body);
                     const severityColors = {
-                        'low': '#FBC02D',
-                        'medium': '#FF9800',
-                        'high': '#FF5722',
-                        'critical': '#B71C1C'
+                        'low': computedStyle.getPropertyValue('--sev-low').trim() || '#FBC02D',
+                        'medium': computedStyle.getPropertyValue('--sev-medium').trim() || '#FF9800',
+                        'high': computedStyle.getPropertyValue('--sev-high').trim() || '#FF5722',
+                        'critical': computedStyle.getPropertyValue('--sev-critical').trim() || '#B71C1C'
                     };
 
                     const series = severities.map(sev => {
@@ -2855,6 +3116,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
             }
         }
 
+        loadSettings();
         router();
     </script>
 </body>

--- a/static/index.html
+++ b/static/index.html
@@ -58,7 +58,13 @@
             --role-tool: #3f51b5;
             --fn-name: #6f42c1;
 
+            /* Severity Colors */
+            --sev-critical: #B71C1C;
+            --sev-high: #FF5722;
+            --sev-medium: #FF9800;
+            --sev-low: #FBC02D;
         }
+
         @media (prefers-color-scheme: dark) {
             :root {
                 --bg: #0d1117;
@@ -101,7 +107,124 @@
                 --role-user: #79c0ff;
                 --role-tool: #82aaff;
                 --fn-name: #d2a8ff;
+
+                /* Severity Colors - Dark Mode */
+                --sev-critical: #ff8b8b;
+                --sev-high: #ff9d7e;
+                --sev-medium: #ffc260;
+                --sev-low: #ffea7f;
             }
+        }
+
+        /* Colorblind Mode Overrides (Okabe-Ito inspired palette) */
+        body.colorblind-mode, body.colorblind-mode.theme-light, body.colorblind-mode.theme-dark {
+            --status-pending: #56B4E9;   /* Sky Blue */
+            --status-inreview: #E69F00;  /* Orange */
+            --status-reviewed: #0072B2;  /* Blue */
+            --status-failed: #D55E00;    /* Vermilion */
+            --status-embargoed: #CC79A7; /* Reddish Purple */
+
+            --sev-critical: #D55E00;     /* Vermilion */
+            --sev-high: #E69F00;         /* Orange */
+            --sev-medium: #F0E442;       /* Yellow */
+            --sev-low: #56B4E9;          /* Sky Blue */
+        }
+
+        /* Explicit Theme Overrides */
+        body.theme-light {
+            color-scheme: light;
+            --bg: #f5f5f5;
+            --border: #ccc;
+            --border-light: #eee;
+            --text: #24292f;
+            --text-muted: #666;
+            --text-dim: #999;
+            --link: #007bff;
+            --hover: #e0e0e0;
+            --selected: #d0d0d0;
+            --code-bg: #f6f8fa;
+            --code-border: #d0d7de;
+            --btn-bg: #fff;
+            --input-bg: #fff;
+            --card-bg: #fff;
+            --ai-bg: #ffffff;
+            --ai-border: #283593;
+            --warn-bg: #fff3cd;
+            --warn-border: #ffeeba;
+            --warn-text: #856404;
+            --error-bg: #fff0f0;
+            --error-border: #ffcdd2;
+            --error-text: #d73a49;
+            --error-title: #b71c1c;
+            --thought-color: #6a737d;
+            --thought-border: #d0d7de;
+            --log-color: #000;
+            --th-bg: #fafafa;
+            --status-pending: #0366d6;
+            --status-inreview: #d67f05;
+            --status-reviewed: #22863a;
+            --status-failed: #d73a49;
+            --status-embargoed: #6f42c1;
+            --tag-bg: #e0f7fa;
+            --tag-text: #006064;
+            --diff-add-bg: #e6ffec;
+            --diff-rm-bg: #ffebe9;
+            --diff-header: #005cc5;
+            --role-user: #005cc5;
+            --role-tool: #3f51b5;
+            --fn-name: #6f42c1;
+            --sev-critical: #B71C1C;
+            --sev-high: #FF5722;
+            --sev-medium: #FF9800;
+            --sev-low: #FBC02D;
+        }
+
+        body.theme-dark {
+            color-scheme: dark;
+            --bg: #0d1117;
+            --border: #30363d;
+            --border-light: #21262d;
+            --text: #c9d1d9;
+            --text-muted: #8b949e;
+            --text-dim: #6e7681;
+            --link: #58a6ff;
+            --hover: #21262d;
+            --selected: #21262d;
+            --code-bg: #161b22;
+            --code-border: #30363d;
+            --btn-bg: #21262d;
+            --input-bg: #0d1117;
+            --card-bg: #161b22;
+            --ai-bg: #161b22;
+            --ai-border: #58a6ff;
+            --warn-bg: #3a2a00;
+            --warn-border: #755200;
+            --warn-text: #e5b300;
+            --error-bg: #3a0000;
+            --error-border: #750000;
+            --error-text: #ff6b6b;
+            --error-title: #ff8b8b;
+            --thought-color: #8b949e;
+            --thought-border: #30363d;
+            --log-color: #c9d1d9;
+            --th-bg: #161b22;
+            --status-pending: #58a6ff;
+            --status-inreview: #d29922;
+            --status-reviewed: #3fb950;
+            --status-failed: #f85149;
+            --status-embargoed: #d2a8ff;
+            --tag-bg: #032f62;
+            --tag-text: #79c0ff;
+            --diff-add-bg: rgba(46, 160, 67, 0.15);
+            --diff-rm-bg: rgba(248, 81, 73, 0.15);
+            --diff-header: #79c0ff;
+            --role-user: #79c0ff;
+            --role-tool: #82aaff;
+            --fn-name: #d2a8ff;
+            --sev-critical: #ff8b8b;
+            --sev-high: #ff9d7e;
+            --sev-medium: #ffc260;
+            --sev-low: #ffea7f;
         }
 
 
@@ -183,23 +306,27 @@
         }
 
         .controls button,
-        button {
+        button,
+        select {
             padding: 4px 10px;
             font-family: inherit;
             font-size: inherit;
             border: 1px solid var(--border);
             background: var(--btn-bg);
+            color: var(--text);
             border-radius: 3px;
             cursor: pointer;
         }
 
         .controls button:hover,
-        button:hover {
+        button:hover,
+        select:hover {
             background: var(--hover);
         }
 
         .controls button:disabled,
-        button:disabled {
+        button:disabled,
+        select:disabled {
             opacity: 0.5;
             cursor: default;
         }
@@ -234,7 +361,7 @@
 
         tr.selected {
             background-color: var(--selected);
-            outline: 1px solid #aaa;
+            outline: 1px solid var(--border);
         }
 
         tr {
@@ -301,7 +428,7 @@
             border-radius: 3px;
             font-size: 0.75em;
             margin-right: 4px;
-            border: 1px solid #b2ebf2;
+            border: 1px solid var(--tag-bg);
             vertical-align: middle;
         }
 
@@ -547,19 +674,19 @@
         }
 
         .ai-comment-critical {
-            border-left-color: #B71C1C !important;
+            border-left-color: var(--sev-critical) !important;
         }
 
         .ai-comment-high {
-            border-left-color: #FF5722 !important;
+            border-left-color: var(--sev-high) !important;
         }
 
         .ai-comment-medium {
-            border-left-color: #FF9800 !important;
+            border-left-color: var(--sev-medium) !important;
         }
 
         .ai-comment-low {
-            border-left-color: #FBC02D !important;
+            border-left-color: var(--sev-low) !important;
         }
 
         /* Thread tree */
@@ -585,7 +712,7 @@
 
         .thread-tree .current {
             font-weight: bold;
-            background: #eef;
+            background: var(--selected);
         }
 
         /* Log viewer roles */
@@ -852,6 +979,77 @@
             border-radius: 4px;
             margin-top: 24px;
         }
+        /* Utility classes extracted from inline styles */
+        .status-placeholder {
+            font-style: italic;
+            color: var(--text-dim);
+        }
+
+        .text-success-bold {
+            color: var(--status-reviewed);
+            font-weight: bold;
+        }
+
+        .text-error-bold {
+            color: var(--error-text);
+            font-weight: bold;
+        }
+
+        .text-muted-sm {
+            color: var(--text-muted);
+            font-size: 0.85em;
+        }
+
+        .header-subtitle {
+            font-size: 0.7em;
+            font-weight: normal;
+            color: var(--text-dim);
+        }
+
+        .thought-block {
+            color: var(--thought-color);
+            font-style: italic;
+            border-left: 2px solid var(--thought-border);
+            padding-left: 8px;
+            margin: 4px 0;
+            white-space: pre-wrap;
+        }
+
+        .bl-table-header {
+            text-align: left;
+            padding: 6px;
+            border-bottom: 1px solid var(--code-border);
+        }
+
+        .bl-table-cell {
+            padding: 6px;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .chart-container {
+            width: 100%;
+            height: 300px;
+        }
+
+        .chart-container-lg {
+            width: 100%;
+            height: 500px;
+        }
+
+        .error-banner {
+            background: var(--error-bg);
+            border: 1px solid var(--error-border);
+            color: var(--error-text);
+            padding: 12px;
+            border-radius: 4px;
+            margin-bottom: 8px;
+        }
+
+        .error-banner-pre {
+            font-family: monospace;
+            white-space: pre-wrap;
+            font-size: 0.9em;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
 </head>
@@ -865,6 +1063,70 @@
         <kbd>Enter</kbd> open
         <kbd>q</kbd> back
     </div>
+
+    <div id="settingsModal" class="modal-overlay" onclick="if(event.target===this) closeSettings()">
+        <div class="modal-content">
+            <span class="modal-close" onclick="closeSettings()">&times;</span>
+            <div class="about-logo">
+                <svg style="height: 1em; margin-right: 12px;" viewBox="0 0 16 16" width="24" height="24" fill="currentColor"><path d="M8 0a8.2 8.2 0 0 1 .701.031C9.444.095 10.196.256 10.92.507c.052.018.103.037.154.057l.01.004c.431.166.844.387 1.236.657.352.243.68.522.98.833.3.311.57.652.804 1.018.234.367.43.76.585 1.177.025.066.048.133.07.2.145.43.25.874.316 1.332.03.207.045.418.045.629 0 .211-.015.422-.045.629a8.225 8.225 0 0 1-.316 1.332c-.022.067-.045.134-.07.2-.154.416-.351.81-.585 1.177-.234.366-.504.707-.804 1.018-.3.311-.628.59-0.98.833a8.163 8.163 0 0 1-1.236.657l-.01.004c-.051.02-.102.039-.154.057a8.217 8.217 0 0 1-2.219.538c-.23.015-.461.023-.692.023-.23 0-.461-.008-.692-.023a8.217 8.217 0 0 1-2.219-.538c-.052-.018-.103-.037-.154-.057l-.01-.004a8.163 8.163 0 0 1-1.236-.657c-.352-.243-.68-.522-.98-.833a8.14 8.14 0 0 1-.804-1.018 8.12 8.12 0 0 1-.585-1.177c-.025-.066-.048-.133-.07-.2a8.225 8.225 0 0 1-.316-1.332A8.156 8.156 0 0 1 0 8c0-.211.015-.422.045-.629a8.225 8.225 0 0 1 .316-1.332c.022-.067.045-.134.07-.2a8.12 8.12 0 0 1 .585-1.177c.234-.366.504-.707.804-1.018.3-.311.628-.59.98-.833a8.163 8.163 0 0 1 1.236-.657l.01-.004c.051-.02.102-.039.154-.057a8.217 8.217 0 0 1 2.219-.538C7.539.008 7.769 0 8 0Zm0 2.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Zm0 2a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z"></path></svg>
+                Settings
+            </div>
+            <div class="about-text">
+                <div style="margin-bottom: 24px;">
+                    <h3 style="margin-top: 0;">Appearance</h3>
+                    <div style="display: flex; flex-direction: column; gap: 12px;">
+                        <div style="display: flex; align-items: center; justify-content: space-between;">
+                            <span>Theme</span>
+                            <select id="themeSelect" onchange="setTheme(this.value)">
+                                <option value="auto">System Default</option>
+                                <option value="light">Light</option>
+                                <option value="dark">Dark</option>
+                            </select>
+                        </div>
+                        <div style="display: flex; align-items: center; justify-content: space-between;">
+                            <span>Colorblind Mode</span>
+                            <label class="switch">
+                                <input type="checkbox" id="colorblindToggle" onchange="setColorblind(this.checked)" style="opacity: 0; width: 0; height: 0;">
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="disclaimer" style="margin-top: 24px; font-size: 0.9em;">
+                    Settings are saved in your browser's cookies and will persist across sessions.
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        /* Toggle Switch Styling */
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 40px;
+            height: 20px;
+        }
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--border);
+            transition: .4s;
+            border-radius: 20px;
+        }
+        .switch input:checked + .slider { background-color: var(--status-reviewed); }
+        .switch input:focus + .slider { box-shadow: 0 0 1px var(--status-reviewed); }
+        .switch input:checked + .slider:before { transform: translateX(20px); }
+        .slider:before {
+            position: absolute; content: ""; height: 16px; width: 16px; left: 2px; bottom: 2px;
+            background-color: white; transition: .4s; border-radius: 50%;
+        }
+    </style>
 
     <div id="aboutModal" class="modal-overlay" onclick="if(event.target===this) closeAbout()">
         <div class="modal-content">
@@ -932,8 +1194,74 @@
             patchsetId: null,
             patchsetPage: 1,
             patchsetTotalPages: 1,
-            patchsetLimit: 50
+            patchsetLimit: 50,
+            settings: {
+                theme: 'auto',
+                colorblind: false
+            }
         };
+
+        // =====================================================================
+        // SETTINGS & COOKIES
+        // =====================================================================
+        function setCookie(name, value, days = 365) {
+            const d = new Date();
+            d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
+            document.cookie = `${name}=${value};expires=${d.toUTCString()};path=/`;
+        }
+
+        function getCookie(name) {
+            const value = `; ${document.cookie}`;
+            const parts = value.split(`; ${name}=`);
+            if (parts.length === 2) return parts.pop().split(';').shift();
+        }
+
+        function applySettings() {
+            const body = document.body;
+            
+            // Apply Theme
+            body.classList.remove('theme-light', 'theme-dark');
+            if (state.settings.theme === 'light') body.classList.add('theme-light');
+            else if (state.settings.theme === 'dark') body.classList.add('theme-dark');
+            
+            // Apply Colorblind Mode
+            if (state.settings.colorblind) body.classList.add('colorblind-mode');
+            else body.classList.remove('colorblind-mode');
+
+            // Sync UI
+            const themeSelect = document.getElementById('themeSelect');
+            if (themeSelect) themeSelect.value = state.settings.theme;
+            const cbToggle = document.getElementById('colorblindToggle');
+            if (cbToggle) cbToggle.checked = state.settings.colorblind;
+        }
+
+        function setTheme(val) {
+            state.settings.theme = val;
+            setCookie('sashiko_theme', val);
+            applySettings();
+        }
+
+        function setColorblind(val) {
+            state.settings.colorblind = !!val;
+            setCookie('sashiko_colorblind', state.settings.colorblind ? '1' : '0');
+            applySettings();
+        }
+
+        function loadSettings() {
+            const theme = getCookie('sashiko_theme');
+            if (theme) state.settings.theme = theme;
+            const cb = getCookie('sashiko_colorblind');
+            if (cb) state.settings.colorblind = cb === '1';
+            applySettings();
+        }
+
+        function openSettings() {
+            document.getElementById('settingsModal').classList.add('open');
+        }
+
+        function closeSettings() {
+            document.getElementById('settingsModal').classList.remove('open');
+        }
 
         // =====================================================================
         // ROUTER
@@ -1330,16 +1658,16 @@
             const { low = 0, medium = 0, high = 0, critical = 0 } = counts;
             if (low + medium + high + critical === 0) {
                 if (status === 'Reviewed' || status === 'Finished') {
-                    return '<span style="color:#2e7d32;">✓</span>';
+                    return '<span style="color:var(--status-reviewed);">✓</span>';
                 }
                 return '<span style="color:var(--text-dim)">-</span>';
             }
             return `
                 <div style="display:inline-flex; gap:6px; font-weight:bold; font-size:0.9em; vertical-align:middle;">
-                    <span style="color:${critical > 0 ? '#B71C1C' : 'var(--text-dim)'}" title="Critical">${critical}</span>
-                    <span style="color:${high > 0 ? '#FF5722' : 'var(--text-dim)'}" title="High">${high}</span>
-                    <span style="color:${medium > 0 ? '#FF9800' : 'var(--text-dim)'}" title="Medium">${medium}</span>
-                    <span style="color:${low > 0 ? '#FBC02D' : 'var(--text-dim)'}" title="Low">${low}</span>
+                    <span style="color:var(--sev-critical)" title="Critical">${critical}</span>
+                    <span style="color:var(--sev-high)" title="High">${high}</span>
+                    <span style="color:var(--sev-medium)" title="Medium">${medium}</span>
+                    <span style="color:var(--sev-low)" title="Low">${low}</span>
                 </div>
             `;
         }
@@ -1428,7 +1756,7 @@
                     </span>
                 </h1>
                 <div class="controls">
-                    <select id="listSelector" onchange="setMailingList(this.value)" style="padding: 4px 8px; border: 1px solid var(--border); border-radius: 3px;">
+                    <select id="listSelector" onchange="setMailingList(this.value)">
                         <option value="">All Lists</option>
                         ${listOptions}
                     </select>
@@ -1498,7 +1826,7 @@
 
                 const dateHtml = `
                     <div>${dateStr}</div>
-                    <div style="color:#666; font-size:0.85em;">${timeStr}</div>
+                    <div class="text-muted-sm">${timeStr}</div>
                 `;
 
                 // Parse author
@@ -1508,7 +1836,7 @@
 
                 const authorHtml = `
                     <div>${escapeHtml(nameToDisplay)}</div>
-                    ${emailToDisplay ? `<div style="color:#666; font-size:0.85em;">${escapeHtml(emailToDisplay)}</div>` : ''}
+                    ${emailToDisplay ? `<div class="text-muted-sm">${escapeHtml(emailToDisplay)}</div>` : ''}
                 `;
 
                 if (state.listMode === 'patchsets') {
@@ -1602,6 +1930,8 @@
                             <span class="stats-label">Sashiko</span> v${data.version}
                             <span class="stats-sep"></span>
                             <a href="#" onclick="event.preventDefault(); openAbout();" style="font-weight:500;">About</a>
+                            <span class="stats-sep"></span>
+                            <a href="#" onclick="event.preventDefault(); openSettings();" style="font-weight:500;">Settings</a>
                             <span class="stats-sep"></span>
                             <a href="#/stats" style="font-weight:500;">Stats</a>
                         </div>
@@ -1701,7 +2031,7 @@
                         const hoursText = hours !== null ? `${hours} hours` : 'some time';
                         return `<p style="font-style:italic; font-size:1.2em; color:var(--status-embargoed);">Embargoed by mailing list policy to ${hoursText} after posting. Public at ${formatDate(data.embargo_until, true)}</p>`;
                     }
-                    return `<p style="font-style:italic; color:#888;">No reviews yet.</p>`;
+                    return `<p class="status-placeholder">No reviews yet.</p>`;
                 }
                 return reviews.map((r, i) => renderReviewCard(r, i === reviews.length - 1 ? emailHtml : '')).join('');
             };
@@ -1742,7 +2072,7 @@
 
                 let statusHtml = '';
                 if (patch && (patch.status === 'error' || patch.status === 'failed')) {
-                     statusHtml = `<div style="background:var(--error-bg); border:1px solid var(--error-border); color:var(--error-text); padding:8px; border-radius:4px; margin-bottom:8px; font-family:monospace; white-space:pre-wrap; font-size:0.9em;"><strong>Patch Application Failed:</strong>\n${escapeHtml(patch.apply_error || 'Unknown error')}</div>`;
+                     statusHtml = `<div class="error-banner error-banner-pre"><strong>Patch Application Failed:</strong>\n${escapeHtml(patch.apply_error || 'Unknown error')}</div>`;
                 }
 
                 let emailHtml = '';
@@ -1773,10 +2103,10 @@
 
                 let listHtml = '';
                 if (patch && patch.status === 'Skipped') {
-                    listHtml = `<p style="font-style:italic; color:#888;">Skipped.</p>`;
+                    listHtml = `<p class="status-placeholder">Skipped.</p>`;
                 } else if (reviews && reviews.length > 0 && reviews.every(r => r.status === 'Skipped')) {
                     const reason = reviews[0].result || 'Skipped.';
-                    listHtml = `<p style="font-style:italic; color:#888;">${escapeHtml(reason)}</p>`;
+                    listHtml = `<p class="status-placeholder">${escapeHtml(reason)}</p>`;
                 } else {
                     listHtml = renderReviewList(reviews, emailHtml, patch ? patch.status : null);
                 }
@@ -1795,11 +2125,11 @@
                     let summaryStatus = '';
 
                     if (patch && (patch.status === 'error' || patch.status === 'failed')) {
-                        summaryStatus = `<span style="color:var(--error-text); font-weight:bold">Apply Failed</span>`;
+                        summaryStatus = `<span class="text-error-bold">Apply Failed</span>`;
                     } else if (patch && patch.status === 'Skipped') {
-                        summaryStatus = '<span style="color:#888">Skipped</span>';
+                        summaryStatus = '<span style="color:var(--text-dim)">Skipped</span>';
                     } else if (!reviews || reviews.length === 0) {
-                        summaryStatus = '<span style="color:#888">No reviews</span>';
+                        summaryStatus = '<span style="color:var(--text-dim)">No reviews</span>';
                     } else {                         // Aggregate "MAX" across all reviews for this patch
                         let maxCounts = { low: 0, medium: 0, high: 0, critical: 0 };
                         let hasSuccessful = false;
@@ -1851,15 +2181,15 @@
                         if (hasSuccessful) {
                            summaryStatus = renderFindingsBadges(maxCounts, 'Reviewed');
                            if (validRunCount > 1) {
-                               summaryStatus += ` <span style="color:#888; font-size:0.85em; font-style:italic;">(max of ${validRunCount} runs)</span>`;
+                               summaryStatus += ` <span style="color:var(--text-dim); font-size:0.85em; font-style:italic;">(max of ${validRunCount} runs)</span>`;
                            }
                         } else if (errors.length > 0) {
-                           summaryStatus = `<span style="color:var(--error-text); font-weight:bold">${escapeHtml(errors[0])}</span>`;
+                           summaryStatus = `<span class="text-error-bold">${escapeHtml(errors[0])}</span>`;
                         } else if (hasSkipped && !hasInProgress) {
                            // Only skipped
-                           summaryStatus = `<span style="color:#888" title="${escapeHtml(skippedReason)}">Skipped</span>`;
+                            summaryStatus = `<span style="color:var(--text-dim)" title="${escapeHtml(skippedReason)}">Skipped</span>`;
                         } else {
-                           summaryStatus = '<span style="color:#888">In progress...</span>';
+                            summaryStatus = '<span style="color:var(--text-dim)">In progress...</span>';
                         }
                     }
                     const patchLabel = patch ? `Patch ${patch.part_index}` : `Patch ${pid}`;
@@ -1901,9 +2231,9 @@
             let failureHtml = '';
             if (data.failed_reason) {
                 failureHtml = `
-                    <div class="section" style="background:var(--error-bg); border:1px solid var(--error-border); padding:12px; border-radius:4px; margin-bottom:16px;">
+                    <div class="section error-banner" style="margin-bottom:16px;">
                         <h3 style="margin-top:0; color:var(--error-title);">Ingestion Failed</h3>
-                        <div style="color:#d32f2f;">${escapeHtml(data.failed_reason)}</div>
+                        <div>${escapeHtml(data.failed_reason)}</div>
                     </div>
                 `;
             }
@@ -1936,9 +2266,9 @@
                             <table style="width:100%; border-collapse:collapse; margin-top:8px;">
                                 <thead>
                                     <tr style="background:var(--code-bg);">
-                                        <th style="text-align:left; padding:6px; border-bottom:1px solid #d0d7de;">Baseline</th>
-                                        <th style="text-align:left; padding:6px; border-bottom:1px solid #d0d7de; width:100px;">Status</th>
-                                        <th style="text-align:right; padding:6px; border-bottom:1px solid #d0d7de; width:120px;">Log</th>
+                                        <th class="bl-table-header">Baseline</th>
+                                        <th class="bl-table-header" style="width:100px;">Status</th>
+                                        <th class="bl-table-header" style="text-align:right; width:120px;">Log</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -1955,10 +2285,10 @@
                              
                              contentHtml += `
                                 <tr>
-                                    <td style="padding:6px; border-bottom:1px solid #eee;">${escapeHtml(item.baseline)}</td>
-                                    <td style="padding:6px; border-bottom:1px solid #eee;">${statusBadge}</td>
-                                    <td style="padding:6px; border-bottom:1px solid #eee; text-align:right;">
-                                        <a href="#/log/baseline/${encodeURIComponent(data.id || data.message_id)}/${idx}" style="font-weight:600; color:#666; text-decoration:none; font-size:0.85em;" onmouseover="this.style.color='#007bff'" onmouseout="this.style.color='#666'">View Log</a>
+                                    <td class="bl-table-cell">${escapeHtml(item.baseline)}</td>
+                                    <td class="bl-table-cell">${statusBadge}</td>
+                                    <td class="bl-table-cell" style="text-align:right;">
+                                        <a href="#/log/baseline/${encodeURIComponent(data.id || data.message_id)}/${idx}" style="font-weight:600; color:var(--text-muted); text-decoration:none; font-size:0.85em;" onmouseover="this.style.color='var(--link)'" onmouseout="this.style.color='var(--text-muted)'">View Log</a>
                                     </td>
                                 </tr>
                              `;
@@ -1972,10 +2302,10 @@
 
                  if (!isJson) {
                      const formattedLogs = escapeHtml(data.baseline_logs)
-                        .replace(/ - passed/g, ' - <span style="color:#2e7d32; font-weight:bold">passed</span>')
-                        .replace(/ - failed/g, ' - <span style="color:var(--error-text); font-weight:bold">failed</span>')
-                        .replace(/Application successful./g, '<span style="color:#2e7d32; font-weight:bold">Application successful.</span>')
-                        .replace(/Application failed./g, '<span style="color:var(--error-text); font-weight:bold">Application failed.</span>');
+                        .replace(/ - passed/g, ' - <span class="text-success-bold">passed</span>')
+                        .replace(/ - failed/g, ' - <span class="text-error-bold">failed</span>')
+                        .replace(/Application successful./g, '<span class="text-success-bold">Application successful.</span>')
+                        .replace(/Application failed./g, '<span class="text-error-bold">Application failed.</span>');
                      
                      contentHtml = `<div class="log-block" style="max-height:300px;">${formattedLogs}</div>`;
                  }
@@ -2081,7 +2411,7 @@
                 <div class="nav"><a href="#/" onclick="event.preventDefault(); goBack();">← Back</a></div>
                 <h1>
                     <span>Baseline Application Log</span>
-                    <span style="font-size:0.7em; font-weight:normal; color:#888;">
+                     <span class="header-subtitle">
                         ${escapeHtml(baselineName)} · 
                         <span class="status-badge status-${(status || '').replace(/ /g, '')}">${status}</span>
                     </span>
@@ -2126,13 +2456,13 @@
                             
                             const total = counts.low + counts.medium + counts.high + counts.critical;
                             if (total === 0) {
-                                displayResult = '<span style="color:#2e7d32;font-weight:bold;">No regressions</span>';
+                                displayResult = '<span class="text-success-bold">No regressions</span>';
                             } else {
                                 const parts = [];
-                                parts.push(`Critical: <span style="${counts.critical > 0 ? 'color:#B71C1C;font-weight:bold' : 'color:var(--text-dim)'}">${counts.critical}</span>`);
-                                parts.push(`High: <span style="${counts.high > 0 ? 'color:#FF5722;font-weight:bold' : 'color:var(--text-dim)'}">${counts.high}</span>`);
-                                parts.push(`Medium: <span style="${counts.medium > 0 ? 'color:#FF9800;font-weight:bold' : 'color:var(--text-dim)'}">${counts.medium}</span>`);
-                                parts.push(`Low: <span style="${counts.low > 0 ? 'color:#FBC02D;font-weight:bold' : 'color:var(--text-dim)'}">${counts.low}</span>`);
+                                parts.push(`Critical: <span style="${counts.critical > 0 ? 'color:var(--sev-critical);font-weight:bold' : 'color:var(--text-dim)'}">${counts.critical}</span>`);
+                                parts.push(`High: <span style="${counts.high > 0 ? 'color:var(--sev-high);font-weight:bold' : 'color:var(--text-dim)'}">${counts.high}</span>`);
+                                parts.push(`Medium: <span style="${counts.medium > 0 ? 'color:var(--sev-medium);font-weight:bold' : 'color:var(--text-dim)'}">${counts.medium}</span>`);
+                                parts.push(`Low: <span style="${counts.low > 0 ? 'color:var(--sev-low);font-weight:bold' : 'color:var(--text-dim)'}">${counts.low}</span>`);
                                 displayResult = parts.join(' · ');
                             }
                         } else {
@@ -2157,7 +2487,7 @@
                             const totalPre = counts.low.preexisting + counts.medium.preexisting + counts.high.preexisting + counts.critical.preexisting;
                             
                             if (totalNew + totalPre === 0) {
-                                displayResult = '<span style="color:#2e7d32;font-weight:bold;">No regressions</span>';
+                                displayResult = '<span class="text-success-bold">No regressions</span>';
                             } else {
                                 const renderSeverity = (label, severityCounts, color) => {
                                     const newCount = severityCounts.new;
@@ -2171,10 +2501,10 @@
                                 };
                                 
                                 const parts = [];
-                                parts.push(renderSeverity('Critical', counts.critical, '#B71C1C'));
-                                parts.push(renderSeverity('High', counts.high, '#FF5722'));
-                                parts.push(renderSeverity('Medium', counts.medium, '#FF9800'));
-                                parts.push(renderSeverity('Low', counts.low, '#FBC02D'));
+                                parts.push(renderSeverity('Critical', counts.critical, 'var(--sev-critical)'));
+                                parts.push(renderSeverity('High', counts.high, 'var(--sev-high)'));
+                                parts.push(renderSeverity('Medium', counts.medium, 'var(--sev-medium)'));
+                                parts.push(renderSeverity('Low', counts.low, 'var(--sev-low)'));
                                 displayResult = parts.join(' · ');
                             }
                         }
@@ -2187,11 +2517,11 @@
             if (!parsedFindings) {
                 const rawResult = r.result || 'Finished';
                 if (rawResult === "Review completed successfully.") {
-                     displayResult = '<span style="color:#2e7d32;font-weight:bold;">No regressions</span>';
+                     displayResult = '<span class="text-success-bold">No regressions</span>';
                 } else {
                     // Check for "garbage" (long JSON or similar)
                     if (rawResult.trim().startsWith('{') || rawResult.length > 60) {
-                         displayResult = `<span style="color:#666; font-style:italic;" title="${escapeHtml(rawResult)}">See log for details</span>`;
+                         displayResult = `<span style="color:var(--text-muted); font-style:italic;" title="${escapeHtml(rawResult)}">See log for details</span>`;
                     } else {
                          displayResult = `<span style="font-weight:bold;">${escapeHtml(rawResult)}</span>`;
                     }
@@ -2256,7 +2586,7 @@
         }
 
         function renderThreadTree(thread) {
-            if (!thread || thread.length === 0) return '<p style="font-style:italic; color:#888;">No thread history.</p>';
+            if (!thread || thread.length === 0) return '<p class="status-placeholder">No thread history.</p>';
 
             const msgMap = new Map();
             const childrenMap = new Map();
@@ -2388,7 +2718,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
 
             let logsHtml = '';
             if (!logs.length) {
-                logsHtml = '<div style="padding:20px; text-align:center; color:#888;">No logs recorded.</div>';
+                logsHtml = '<div style="padding:20px; text-align:center; color:var(--text-dim);">No logs recorded.</div>';
             } else {
                 let jsonCounter = 0;
                 logsHtml = logs.map((entry, idx) => {
@@ -2406,7 +2736,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
 
                     // Unified format: direct content and tool_calls
                     if (entry.thought && typeof entry.thought === 'string') {
-                        content += `<div style="color: var(--thought-color); font-style: italic; border-left: 2px solid var(--thought-border); padding-left: 8px; margin: 4px 0; white-space: pre-wrap;">${escapeHtml(entry.thought)}</div>`;
+                        content += `<div class="thought-block">${escapeHtml(entry.thought)}</div>`;
                     }
                     
                     if (entry.content && typeof entry.content === 'string') {
@@ -2427,7 +2757,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     parts.forEach(part => {
                         if (part.text) {
                             if (part.thought) {
-                                content += `<div style="color: var(--thought-color); font-style: italic; border-left: 2px solid var(--thought-border); padding-left: 8px; margin: 4px 0; white-space: pre-wrap;">${escapeHtml(part.text)}</div>`;
+                                content += `<div class="thought-block">${escapeHtml(part.text)}</div>`;
                             } else {
                                 content += `<div>${escapeHtml(part.text)}</div>`;
                             }
@@ -2451,7 +2781,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                 <div class="nav"><a href="#/" onclick="event.preventDefault(); goBack();">← Back</a></div>
                 <h1>
                     <span>Interaction Log</span>
-                    <span style="font-size:0.7em; font-weight:normal; color:#888;">
+                     <span class="header-subtitle">
                         ${data.model || '?'} · ${data.prompts_hash ? 'Sashiko ver.: ' + data.prompts_hash.substring(0, 8) + ' · ' : ''}
                         <span class="status-badge status-${(data.status || '').replace(/ /g, '')}">${data.status}</span>
                     </span>
@@ -2732,11 +3062,11 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     patchset: '#fac858',
                     individual_patches: '#5ab1ef', // Light Blue/Teal
                     failure: '#ee6666',
-                    text: '#666'
+                    text: themeText
                 };
 
                 // HTML Structure
-                let html = '<h2>Activity Timeline</h2><div class="chart-section"><div id="chart-timeline" style="width:100%; height:300px;"></div></div>';
+                let html = '<h2>Activity Timeline</h2><div class="chart-section"><div id="chart-timeline" class="chart-container"></div></div>';
 
                 // Summary Cards
                 html += '<h2>AI Reviews</h2>';
@@ -2754,9 +3084,9 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                 html += renderStatCard('Success Rate (last 1k reviews)', successRateLast1k);
                 html += '</div>';
                 
-                html += '<h3>Review Outcomes</h3><div class="chart-section"><div id="chart-review-outcomes" style="width:100%; height:300px;"></div></div>';
+                html += '<h3>Review Outcomes</h3><div class="chart-section"><div id="chart-review-outcomes" class="chart-container"></div></div>';
 
-                html += '<h3>Findings Severity</h3><div class="chart-section"><div id="chart-findings" style="width:100%; height:300px;"></div></div>';
+                html += '<h3>Findings Severity</h3><div class="chart-section"><div id="chart-findings" class="chart-container"></div></div>';
 
                 // Calculate total tokens
                 // Exclude In Review (Pending/In Review) AND Failed To Apply
@@ -2782,7 +3112,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                 html += renderStatCard('Out tokens/patch', avgTokensOut);
                 html += '</div>';
                 
-                html += '<h2>Tool Usage (last 1k reviews)</h2><div class="chart-section"><div id="chart-tools" style="width:100%; height:500px;"></div></div>';
+                html += '<h2>Tool Usage (last 1k reviews)</h2><div class="chart-section"><div id="chart-tools" class="chart-container-lg"></div></div>';
 
                 const container = document.getElementById('stats-content');
                 container.innerHTML = html;
@@ -2832,7 +3162,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     const getColor = (s) => {
                          if (s === 'Reviewed') return colors.secondary;
                          if (s === 'Pending') return colors.primary;
-                         if (s === 'In Review') return '#d67f05';
+                         if (s === 'In Review') return getComputedStyle(document.body).getPropertyValue('--status-inreview').trim() || '#d67f05';
                          if (s.toLowerCase().includes('failed')) return colors.failure;
                          return null;
                     };
@@ -2913,11 +3243,13 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     const chart = echarts.init(document.getElementById('chart-findings'), isDark ? 'dark' : null);
                     const dates = [...new Set(timeline.findings.map(f => f.day))].sort();
                     const severities = ['low', 'medium', 'high', 'critical'];
+                    
+                    const computedStyle = getComputedStyle(document.body);
                     const severityColors = {
-                        'low': '#FBC02D',
-                        'medium': '#FF9800',
-                        'high': '#FF5722',
-                        'critical': '#B71C1C'
+                        'low': computedStyle.getPropertyValue('--sev-low').trim() || '#FBC02D',
+                        'medium': computedStyle.getPropertyValue('--sev-medium').trim() || '#FF9800',
+                        'high': computedStyle.getPropertyValue('--sev-high').trim() || '#FF5722',
+                        'critical': computedStyle.getPropertyValue('--sev-critical').trim() || '#B71C1C'
                     };
 
                     const series = severities.map(sev => {
@@ -2956,6 +3288,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
             }
         }
 
+        loadSettings();
         router();
     </script>
 </body>


### PR DESCRIPTION
index.html: add colorblind mode and settings menu
- Implement colorblind-safe palette for statuses and findings
- Add theme selector (auto, light, dark)
- Persist settings in cookies
- Add settings menu in the footer

<img width="1691" height="1392" alt="Screenshot From 2026-04-23 15-55-03" src="https://github.com/user-attachments/assets/b4e9e10d-aa46-460f-827d-57254b1726a9" />
<img width="1691" height="1392" alt="Screenshot From 2026-04-23 15-55-07" src="https://github.com/user-attachments/assets/63dcee7d-f173-4927-837b-ce58d3c9929a" />
<img width="1691" height="1392" alt="Screenshot From 2026-04-23 15-55-13" src="https://github.com/user-attachments/assets/3e9fb6c8-4339-4b98-9217-41ecac722fa1" />

