### PR TITLE
k8s: add rcu to tracked mailing lists

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -84,7 +84,7 @@ spec:
                 rust-for-linux,kvmarm,linux-arm-kernel,linux-block,linux-scsi,
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
-                linux-cxl,nvdimm,linux-ide,linux-btrfs
+                linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "48"
             - name: SASHIKO__SMTP__SENDER_ADDRESS


### PR DESCRIPTION
Add the rcu mailing list. I spoke Paul at the Portland Linux kernel meetup tonight and he said he would like to see the rcu list included in the shashiko website.