### PR TITLE
Claude support for thinking

### DIFF
--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -39,6 +39,11 @@ pub enum ClaudeContent {
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
+    Thinking {
+        thinking: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -323,6 +328,14 @@ fn translate_ai_request(
                     });
                 }
 
+                // Add thinking content if present
+                if let Some(thinking) = &msg.thought {
+                    content.push(ClaudeContent::Thinking {
+                        thinking: thinking.clone(),
+                        signature: None,
+                    });
+                }
+
                 // Add tool calls as tool_use blocks
                 if let Some(tool_calls) = &msg.tool_calls {
                     for call in tool_calls {
@@ -383,10 +396,7 @@ fn translate_ai_request(
             Some(system_blocks)
         },
         tools,
-        thinking: Some(ThinkingConfig {
-            thinking,
-            effort,
-        }),
+        thinking: Some(ThinkingConfig { thinking, effort }),
     };
 
     // Apply cache control if enabled
@@ -419,6 +429,7 @@ fn apply_cache_control(request: &mut ClaudeRequest) {
 
 fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
     let mut content = String::new();
+    let mut thought = String::new();
     let mut tool_calls = Vec::new();
 
     for block in &resp.content {
@@ -426,12 +437,15 @@ fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
             ClaudeContent::Text { text, .. } => {
                 content.push_str(text);
             }
+            ClaudeContent::Thinking { thinking, .. } => {
+                thought.push_str(thinking);
+            }
             ClaudeContent::ToolUse { id, name, input } => {
                 tool_calls.push(ToolCall {
                     id: id.clone(),
                     function_name: name.clone(),
                     arguments: input.clone(),
-                    thought_signature: None, // Claude doesn't expose thought signatures
+                    thought_signature: None,
                 });
             }
             ClaudeContent::ToolResult { .. } => {
@@ -453,7 +467,11 @@ fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
         } else {
             Some(content)
         },
-        thought: None,
+        thought: if thought.is_empty() {
+            None
+        } else {
+            Some(thought)
+        },
         tool_calls: if tool_calls.is_empty() {
             None
         } else {

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -86,8 +86,6 @@ pub struct ClaudeRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<ClaudeTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ThinkingConfig>,
 }
 
@@ -374,12 +372,6 @@ fn translate_ai_request(
             .collect()
     });
 
-    // With thinking enabled or adaptive temperature have to be set to 1.0
-    let normalize_temperature: Option<f32> = match thinking.as_deref() {
-        Some("disabled") => request.temperature,
-        Some(_) | None => Some(1.0),
-    };
-
     // Build the request
     let mut claude_request = ClaudeRequest {
         model: String::new(), // Will be set by the client
@@ -391,7 +383,6 @@ fn translate_ai_request(
             Some(system_blocks)
         },
         tools,
-        temperature: normalize_temperature,
         thinking: Some(ThinkingConfig {
             thinking,
             effort,

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -88,6 +88,13 @@ pub struct ClaudeRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ThinkingConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub thinking: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
@@ -378,8 +385,6 @@ fn translate_ai_request(
         model: String::new(), // Will be set by the client
         messages,
         max_tokens,
-        thinking,
-        effort,
         system: if system_blocks.is_empty() {
             None
         } else {
@@ -387,6 +392,10 @@ fn translate_ai_request(
         },
         tools,
         temperature: normalize_temperature,
+        thinking: Some(ThinkingConfig {
+            thinking,
+            effort,
+        }),
     };
 
     // Apply cache control if enabled


### PR DESCRIPTION
Hi,

Just enable parsing "thinking" from response json to unlock review when thinking is "enabled" or "adaptive".

First patch is fixing the thinking config which I incorrect set in previous PR (sorry, I used proxy which isn't strictly following antrophic API).

Second patch is dropping temperature according to what @kuba-moo did in bedrock. This is also suggested in antrophic documentation (temperature is deprecated field).

Last patch is adding parsing for thinking and return it following gemini scheme.