### PR TITLE
reviewer: adopt an attitude of gratitude in the review header

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1984,7 +1984,7 @@ impl Reviewer {
                     && !findings_arr.is_empty()
                 {
                     header.push_str(&format!(
-                        "Sashiko AI review found {} potential issue(s):\n",
+                        "Thank you for your contribution! Sashiko AI review found {} potential issue(s) to consider:\n",
                         findings_arr.len()
                     ));
 


### PR DESCRIPTION
Improves the review header phrasing to thank the authors for their contributions before providing the constructive feedback. 
  
This creates a more collaborative and encouraging opening without weakening the severity or quality of the findings.
