### PR TITLE
Add sched_ext subsystem to email_policy.toml

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -61,3 +61,8 @@ cc = ["wsa+renesas@sang-engineering.com"]
 lists = ["rust-for-linux@vger.kernel.org"]
 reply_to_author = true
 cc = ["ojeda@kernel.org"]
+
+[subsystems.sched-ext]
+lists = ["sched-ext@lists.linux.dev"]
+reply_to_author = true
+cc = ["sched-ext@lists.linux.dev"]


### PR DESCRIPTION
As requested by Tejun in https://lore.kernel.org/all/afEUFzbBUXjCMTGQ@slm.duckdns.org/

CC @htejun