### PR TITLE
Feature remote baseline

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -46,6 +46,13 @@ port = 8080
 [git]
 repository_path = "third_party/linux"
 
+# Track custom remotes and attempt to apply patches on their branches
+# [[git.custom_remotes]]
+# name = "remote-name"
+# url = "git://my-custom.com/remote"
+# check_all_branches = true
+# only_branches = []
+
 [review]
 concurrency = 20
 worktree_dir = "review_trees"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -268,6 +268,53 @@ impl BaselineRegistry {
         // For simplicity: HEAD.
         candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
 
+        // 5. Custom Remotes
+        if let Some(custom_remotes) = &self.custom_remotes {
+            for remote in custom_remotes {
+                // Fetch to ensure we have the latest branches (Issue 1)
+                if let Err(e) =
+                    crate::git_ops::ensure_remote(&self.repo_path, &remote.name, &remote.url, false)
+                        .await
+                {
+                    warn!(
+                        "Failed to ensure custom remote {}: {}. Using local branches.",
+                        remote.name, e
+                    );
+                }
+
+                if remote.check_all_branches {
+                    match crate::git_ops::get_remote_branches(&self.repo_path, &remote.name).await {
+                        Ok(branches) => {
+                            for branch in branches {
+                                candidates.push(BaselineResolution::RemoteTarget {
+                                    url: remote.url.clone(),
+                                    name: remote.name.clone(),
+                                    branch: Some(branch),
+                                });
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to get remote branches for {}: {}. Continuing.",
+                                remote.name, e
+                            );
+                        }
+                    }
+                }
+
+                // Change else if to if (Issue 3)
+                if let Some(branches) = &remote.only_branches {
+                    for branch in branches {
+                        candidates.push(BaselineResolution::RemoteTarget {
+                            url: remote.url.clone(),
+                            name: remote.name.clone(),
+                            branch: Some(branch.clone()),
+                        });
+                    }
+                }
+            }
+        }
+
         // Deduplicate
         // Simple deduplication based on string representation or enum equality
         // Since we implement PartialEq, dedup works if consecutive. We need unique.
@@ -740,5 +787,47 @@ F: patterns/
         let pos_net_nonext = names_nonext.iter().position(|x| x == "net").unwrap();
         let pos_net_next_nonext = names_nonext.iter().position(|x| x == "net-next").unwrap();
         assert!(pos_net_nonext < pos_net_next_nonext);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_custom_remotes() {
+        use crate::settings::CustomRemoteSettings;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path();
+
+        // Init git repo to avoid ensure_remote failing too hard
+        std::process::Command::new("git")
+            .current_dir(repo_path)
+            .arg("init")
+            .output()
+            .unwrap();
+
+        let mut remote_map = HashMap::new();
+        let dummy_url = repo_path.join("dummy_remote").to_str().unwrap().to_string();
+        remote_map.insert(dummy_url.clone(), "dummy-repo".to_string());
+
+        let registry = BaselineRegistry {
+            entries: Vec::new(),
+            remote_map,
+            custom_remotes: Some(vec![CustomRemoteSettings {
+                name: "dummy-repo".to_string(),
+                url: dummy_url,
+                check_all_branches: false,
+                only_branches: Some(vec!["master".to_string()]),
+            }]),
+            repo_path: repo_path.to_path_buf(),
+        };
+
+        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+
+        let candidate_names: Vec<String> = candidates
+            .iter()
+            .filter_map(|c| match c {
+                BaselineResolution::RemoteTarget { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(candidate_names.contains(&"dummy-repo".to_string()));
     }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::settings::CustomRemoteSettings;
 use anyhow::Result;
 use regex::Regex;
 use std::collections::HashMap;
@@ -55,10 +56,15 @@ impl BaselineResolution {
 pub struct BaselineRegistry {
     entries: Vec<MaintainersEntry>,
     remote_map: HashMap<String, String>, // URL -> Local Remote Name
+    pub custom_remotes: Option<Vec<CustomRemoteSettings>>,
+    pub repo_path: std::path::PathBuf,
 }
 
 impl BaselineRegistry {
-    pub fn new(repo_path: &Path) -> Result<Self> {
+    pub fn new(
+        repo_path: &Path,
+        custom_remotes: Option<Vec<CustomRemoteSettings>>,
+    ) -> Result<Self> {
         let remote_map = Self::load_git_remotes(repo_path).unwrap_or_default();
 
         // Identify Linus's tree
@@ -104,6 +110,8 @@ impl BaselineRegistry {
         Ok(Self {
             entries,
             remote_map,
+            custom_remotes,
+            repo_path: repo_path.to_path_buf(),
         })
     }
 
@@ -214,7 +222,7 @@ impl BaselineRegistry {
         Ok(map)
     }
 
-    pub fn resolve_candidates(
+    pub async fn resolve_candidates(
         &self,
         files: &[String],
         subject: &str,
@@ -517,16 +525,20 @@ mod tests {
         BaselineRegistry {
             entries,
             remote_map,
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
         }
     }
 
-    #[test]
-    fn test_resolve_candidates() {
+    #[tokio::test]
+    async fn test_resolve_candidates() {
         let registry = create_registry();
         let files = vec!["net/core.c".to_string()];
         let body = "Some text\nbase-commit: 1234567890123456789012345678901234567890\n";
 
-        let candidates = registry.resolve_candidates(&files, "Subject", Some(body));
+        let candidates = registry
+            .resolve_candidates(&files, "Subject", Some(body))
+            .await;
 
         assert_eq!(candidates.len(), 4); // Base, Subsystem, Next, Head
 
@@ -558,8 +570,8 @@ F: patterns/
         assert_eq!(entries[0].trees[0].1, Some("branch".to_string()));
     }
 
-    #[test]
-    fn test_resolve_linux_mm() {
+    #[tokio::test]
+    async fn test_resolve_linux_mm() {
         let entries = vec![MaintainersEntry {
             subsystem: "MEMORY MANAGEMENT".to_string(),
             trees: vec![(
@@ -577,10 +589,12 @@ F: patterns/
         let registry = BaselineRegistry {
             entries,
             remote_map,
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
         };
 
         let files = vec!["mm/memory.c".to_string()];
-        let candidates = registry.resolve_candidates(&files, "Subject", None);
+        let candidates = registry.resolve_candidates(&files, "Subject", None).await;
 
         // Expected order:
         // 1. mm-new (Subsystem Heuristic 1)
@@ -612,8 +626,8 @@ F: patterns/
         }
     }
 
-    #[test]
-    fn test_resolve_multiple_trees() {
+    #[tokio::test]
+    async fn test_resolve_multiple_trees() {
         let entries = vec![MaintainersEntry {
             subsystem: "PERFORMANCE EVENTS SUBSYSTEM".to_string(),
             trees: vec![
@@ -642,10 +656,12 @@ F: patterns/
         let registry = BaselineRegistry {
             entries,
             remote_map,
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
         };
 
         let files = vec!["tools/perf/builtin-report.c".to_string()];
-        let candidates = registry.resolve_candidates(&files, "Subject", None);
+        let candidates = registry.resolve_candidates(&files, "Subject", None).await;
 
         // Current implementation likely only returns ONE of the trees (arbitrarily or first)
         // plus linux-next and HEAD.
@@ -668,8 +684,8 @@ F: patterns/
         );
     }
 
-    #[test]
-    fn test_resolve_next_prioritization() {
+    #[tokio::test]
+    async fn test_resolve_next_prioritization() {
         let entries = vec![MaintainersEntry {
             subsystem: "NETWORKING".to_string(),
             trees: vec![
@@ -685,13 +701,16 @@ F: patterns/
         let registry = BaselineRegistry {
             entries,
             remote_map,
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
         };
 
         let files = vec!["net/core.c".to_string()];
 
         // With "next" in subject
-        let candidates_next =
-            registry.resolve_candidates(&files, "[PATCH net-next] something", None);
+        let candidates_next = registry
+            .resolve_candidates(&files, "[PATCH net-next] something", None)
+            .await;
         let names_next: Vec<String> = candidates_next
             .iter()
             .filter_map(|c| match c {
@@ -706,7 +725,9 @@ F: patterns/
         assert!(pos_net_next < pos_net);
 
         // Without "next" in subject
-        let candidates_nonext = registry.resolve_candidates(&files, "[PATCH net] something", None);
+        let candidates_nonext = registry
+            .resolve_candidates(&files, "[PATCH net] something", None)
+            .await;
         let names_nonext: Vec<String> = candidates_nonext
             .iter()
             .filter_map(|c| match c {

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -537,6 +537,31 @@ pub async fn ensure_remote(
     Ok(())
 }
 
+pub async fn get_remote_branches(repo_path: &Path, remote_name: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["branch", "-r", "--list", &format!("{}/*", remote_name)])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Failed to list remote branches: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let branches = stdout
+        .lines()
+        .map(|line| line.trim())
+        .filter_map(|line| line.strip_prefix(&format!("{}/", remote_name)))
+        .filter(|s| !s.contains("->")) // Filter out symbolic references like HEAD -> origin/main
+        .map(|s| s.to_string())
+        .collect();
+    Ok(branches)
+}
+
 pub async fn get_commit_hash(path: &Path, ref_name: &str) -> Result<String> {
     let output = Command::new("git")
         .current_dir(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,6 +531,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
+    // Initialize custom remotes
+    let repo_path = std::path::PathBuf::from(&settings.git.repository_path);
+    if let Some(custom_remotes) = &settings.git.custom_remotes {
+        for remote in custom_remotes {
+            info!("Ensuring custom remote {} -> {}", remote.name, remote.url);
+            if let Err(e) =
+                sashiko::git_ops::ensure_remote(&repo_path, &remote.name, &remote.url, false).await
+            {
+                error!("Failed to ensure custom remote {}: {}", remote.name, e);
+            }
+        }
+    }
+
     // Start Reviewer Service
     let reviewer = Reviewer::new(db.clone(), settings.clone());
     tokio::spawn(async move {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -694,6 +694,7 @@ impl Reviewer {
     ) {
         let mut attempts: Vec<BaselineAttempt> = Vec::new();
         let repo_path = PathBuf::from(&ctx.settings.git.repository_path);
+        let mut tested_shas = std::collections::HashSet::new();
 
         for candidate in candidates {
             let baseline_ref = candidate.as_str();
@@ -729,6 +730,11 @@ impl Reviewer {
                     continue;
                 }
             };
+
+            if !tested_shas.insert(baseline_sha.clone()) {
+                info!("Skipping duplicate baseline SHA {}", baseline_sha);
+                continue;
+            }
 
             let baseline_display = format!("{} ({})", baseline_ref, baseline_sha);
             current_log = format!("Trying baseline: {}\n", baseline_display);

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -94,18 +94,22 @@ impl Reviewer {
         let concurrency = settings.review.concurrency;
         let repo_path = PathBuf::from(&settings.git.repository_path);
 
-        let baseline_registry = match BaselineRegistry::new(&repo_path) {
-            Ok(r) => Arc::new(r),
-            Err(e) => {
-                error!(
-                    "Failed to initialize BaselineRegistry: {}. Using empty registry.",
-                    e
-                );
-                Arc::new(BaselineRegistry::new(&repo_path).unwrap_or_else(|_| {
-                    panic!("Critical error initializing BaselineRegistry: {}", e)
-                }))
-            }
-        };
+        let baseline_registry =
+            match BaselineRegistry::new(&repo_path, settings.git.custom_remotes.clone()) {
+                Ok(r) => Arc::new(r),
+                Err(e) => {
+                    error!(
+                        "Failed to initialize BaselineRegistry: {}. Using empty registry.",
+                        e
+                    );
+                    Arc::new(
+                        BaselineRegistry::new(&repo_path, settings.git.custom_remotes.clone())
+                            .unwrap_or_else(|_| {
+                                panic!("Critical error initializing BaselineRegistry: {}", e)
+                            }),
+                    )
+                }
+            };
 
         // Initialize Provider
         let provider = create_provider(&settings).expect("Failed to create AI provider");
@@ -358,10 +362,12 @@ impl Reviewer {
             } else {
                 ctx.baseline_registry
                     .resolve_candidates(&all_files, &subject, body.as_deref())
+                    .await
             }
         } else {
             ctx.baseline_registry
                 .resolve_candidates(&all_files, &subject, body.as_deref())
+                .await
         };
 
         // 1. Find a working baseline (apply series)
@@ -2200,7 +2206,7 @@ echo '{"patchset_id": 1, "patches": [{"index": 1, "status": "applied"}]}'
             semaphore: Arc::new(Semaphore::new(1)),
             db: db.clone(),
             settings: settings.clone(),
-            baseline_registry: Arc::new(BaselineRegistry::new(Path::new(".")).unwrap()),
+            baseline_registry: Arc::new(BaselineRegistry::new(Path::new("."), None).unwrap()),
             quota_manager,
             target_review_count: 1,
             provider,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -214,8 +214,18 @@ pub struct ServerSettings {
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct CustomRemoteSettings {
+    pub name: String,
+    pub url: String,
+    pub check_all_branches: bool,
+    pub only_branches: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct GitSettings {
     pub repository_path: String,
+    pub custom_remotes: Option<Vec<CustomRemoteSettings>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
Currently, sashiko only relies on upstream trees listed in the MAINTAINERS file to find baseline candidates for applying patches. This causes patches targeting internal or downstream repositories to fail to apply. We need a way to specify custom repositories and check all or specific branches as potential baselines.

• Configurable custom remotes: Added support in Settings.toml to define a list of custom remotes with options to check all branches or a specific subset.
• Dynamic baseline injection: Updated the baseline resolution logic to fetch these custom remotes and inject their branches as candidates when trying to apply a patch.
• Optimizations and hardening: Added deduplication of candidates by commit SHA to prevent redundant application tests, and isolated unit tests using temporary git repositories to avoid polluting the developer environment.