### PR TITLE
prompts: Another I2C subsystem prompt update

### DIFF
--- a/third_party/prompts/kernel/subsystem/i2c.md
+++ b/third_party/prompts/kernel/subsystem/i2c.md
@@ -5,4 +5,6 @@
 - debugfs entries attached to the `debugfs` object in `struct i2c_client` are
   cleaned up by the I2C subsystem core in the client device removal function
   after calling the client driver remove function and before releasing client
-  device resources allocated with devres functions.
+  device resources allocated with devres functions, and in the I2C subsystem
+  probe function after a probe failure has been reported by the driver's probe
+  function.


### PR DESCRIPTION
Debugfs entries are also removed by the I2C subsystem core after a driver probe function failed.