### PR TITLE
email: add email policy for the PCI subsystem

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -66,3 +66,8 @@ cc = ["ojeda@kernel.org"]
 lists = ["sched-ext@lists.linux.dev"]
 reply_to_author = true
 cc = ["sched-ext@lists.linux.dev"]
+
+[subsystems.pci]
+lists = ["linux-pci@vger.kernel.org"]
+reply_to_author = true
+cc = ["linux-pci@vger.kernel.org"]


### PR DESCRIPTION
We want to make sure that the author and the mailing list will be notified of any reviews, so that we don't need to chase after patches and series submissions ourselves.

Depends on the volume, we might roll this back, or not.