### PR TITLE
k8s: add oe-linux-nfc to tracked mailing lists

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -84,7 +84,7 @@ spec:
                 rust-for-linux,kvmarm,linux-arm-kernel,linux-block,linux-scsi,
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
-                linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext
+                linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "48"
             - name: SASHIKO__SMTP__SENDER_ADDRESS


### PR DESCRIPTION
The NFC in orphaned state was covered by `netdev`, but as the development continues, the [oe-linux-nfc](https://lore.kernel.org/oe-linux-nfc/) mailing list going to be used. Track it.

Thank you
David