### PR TITLE
Add watchdog subsystem to email_policy.toml

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -67,7 +67,13 @@ lists = ["sched-ext@lists.linux.dev"]
 reply_to_author = true
 cc = ["sched-ext@lists.linux.dev"]
 
+
 [subsystems.pci]
 lists = ["linux-pci@vger.kernel.org"]
 reply_to_author = true
 cc = ["linux-pci@vger.kernel.org"]
+
+[subsystems.watchdog]
+lists = ["linux-watchdog@vger.kernel.org"]
+reply_to_author = true
+cc = ["linux-watchdog@vger.kernel.org"]


### PR DESCRIPTION
Add the watchdog subsystem to the email policy, sending replies to authors and to the mailing list.