### PR TITLE
add batman(-adv) mailing list to recognized mailing lists

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -84,7 +84,8 @@ spec:
                 rust-for-linux,kvmarm,linux-arm-kernel,linux-block,linux-scsi,
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
-                linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc
+                linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
+                batman
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "48"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -29,6 +29,10 @@ lists = ["linux-perf-users@vger.kernel.org"]
 reply_to_author = true
 cc = ["linux-perf-users@vger.kernel.org"]
 
+[subsystems.batman]
+lists = ["b.a.t.m.a.n@lists.open-mesh.org"]
+cc = ["marek.lindner@mailbox.org", "sw@simonwunderlich.de", "antonio@mandelbit.com", "sven@narfation.org"]
+
 [subsystems.bpf]
 lists = ["bpf@vger.kernel.org"]
 reply_to_author = true


### PR DESCRIPTION
I would like to request to get the batman-adv mailing list added to the email policy, CCing only maintainers. This is necessary to not get in conflict with the net 24h embargo from commit 2ece30494cda ("Implement AI review embargoes for patchsets"). This embargo was added to avoid patchset authors to send more than 1 version per 24 hours.

All maintainers were contacted and agreed to get their addresses in the Cc for reviews of patches to b.a.t.m.a.n@lists.open-mesh.org

* @lindnermarek
* @simonwunderlich
* @ordex

---

The batman(-adv) lore id was added because the batman-adv patches are only sometimes reviewed via the netdev mailing list.  It can easily happen that they are send for a first review only to the batman(-adv) mailing list. It would be nice to also get the reviews for these patches directly. Otherwise, we would maybe only see these reviews after the patches are applied to the batman-adv tree and they got submitted to netdev as PR.