### PR TITLE
cli: Skip reviews with empty inline_review

### DIFF
--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -609,8 +609,11 @@ async fn handle_show(
                             {
                                 for r in reviews {
                                     if r.get("patch_id").and_then(|id| id.as_i64()) == Some(p_id) {
-                                        patch_review = Some(r);
-                                        break;
+                                        if let Some(inline) = r.get("inline_review").and_then(|s| s.as_str())
+                                            && !inline.is_empty() {
+                                                patch_review = Some(r);
+                                                break;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
When using sashiko CLI to fetch the review using command line using patchset ID, it only shows the review of 1 patch. This happens when it matches the patch with an invalid review that has empty inline_review string.

Check for empty inline_review before breaking the looping when matching patch with patch_review.