### PR TITLE
Response cache + IPv6 support

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -40,7 +40,7 @@ temperature = 1.0
 prompt_caching = true
 
 [server]
-host = "127.0.0.1"
+host = "::"
 port = 8080
 
 [git]

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -8,6 +8,18 @@ use tracing::{debug, info};
 
 use super::{AiProvider, AiRequest, AiResponse, ProviderCapabilities};
 
+fn fmt_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            result.push('.');
+        }
+        result.push(c);
+    }
+    result
+}
+
 pub struct CachingAiProvider {
     inner: Arc<dyn AiProvider>,
     conn: libsql::Connection,
@@ -128,7 +140,11 @@ impl AiProvider for CachingAiProvider {
                 };
                 info!(
                     "Cache hit [{}] ({}) — {} tokens saved (total {}: {})",
-                    hash_prefix, origin, tokens_saved, origin, total
+                    hash_prefix,
+                    origin,
+                    fmt_thousands(tokens_saved as u64),
+                    origin,
+                    fmt_thousands(total)
                 );
                 if let Some(ref mut usage) = resp.usage {
                     usage.cached_tokens =

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -6,9 +6,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 
-use super::{AiProvider, AiRequest, AiResponse, ProviderCapabilities};
+use super::{AiProvider, AiRequest, AiResponse, CacheStats, ProviderCapabilities};
 
-fn fmt_thousands(n: u64) -> String {
+pub fn fmt_thousands(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
     for (i, c) in s.chars().enumerate() {
@@ -24,6 +24,8 @@ pub struct CachingAiProvider {
     inner: Arc<dyn AiProvider>,
     conn: libsql::Connection,
     session_start: i64,
+    hits_this: AtomicU64,
+    hits_prev: AtomicU64,
     tokens_saved_this: AtomicU64,
     tokens_saved_prev: AtomicU64,
 }
@@ -88,6 +90,8 @@ impl CachingAiProvider {
             inner,
             conn,
             session_start,
+            hits_this: AtomicU64::new(0),
+            hits_prev: AtomicU64::new(0),
             tokens_saved_this: AtomicU64::new(0),
             tokens_saved_prev: AtomicU64::new(0),
         })
@@ -126,12 +130,14 @@ impl AiProvider for CachingAiProvider {
             let created_at: i64 = row.get(2)?;
             if let Ok(mut resp) = serde_json::from_str::<AiResponse>(&response_json) {
                 let (origin, total) = if created_at >= self.session_start {
+                    self.hits_this.fetch_add(1, Ordering::Relaxed);
                     let t = self
                         .tokens_saved_this
                         .fetch_add(tokens_saved as u64, Ordering::Relaxed)
                         + tokens_saved as u64;
                     ("this session", t)
                 } else {
+                    self.hits_prev.fetch_add(1, Ordering::Relaxed);
                     let t = self
                         .tokens_saved_prev
                         .fetch_add(tokens_saved as u64, Ordering::Relaxed)
@@ -196,5 +202,14 @@ impl AiProvider for CachingAiProvider {
 
     fn get_capabilities(&self) -> ProviderCapabilities {
         self.inner.get_capabilities()
+    }
+
+    fn cache_stats(&self) -> Option<CacheStats> {
+        Some(CacheStats {
+            hits_this_session: self.hits_this.load(Ordering::Relaxed),
+            hits_prev_session: self.hits_prev.load(Ordering::Relaxed),
+            tokens_saved_this_session: self.tokens_saved_this.load(Ordering::Relaxed),
+            tokens_saved_prev_session: self.tokens_saved_prev.load(Ordering::Relaxed),
+        })
     }
 }

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 
@@ -11,6 +12,8 @@ pub struct CachingAiProvider {
     inner: Arc<dyn AiProvider>,
     conn: libsql::Connection,
     session_start: i64,
+    tokens_saved_this: AtomicU64,
+    tokens_saved_prev: AtomicU64,
 }
 
 impl CachingAiProvider {
@@ -73,6 +76,8 @@ impl CachingAiProvider {
             inner,
             conn,
             session_start,
+            tokens_saved_this: AtomicU64::new(0),
+            tokens_saved_prev: AtomicU64::new(0),
         })
     }
 
@@ -108,14 +113,22 @@ impl AiProvider for CachingAiProvider {
             let tokens_saved: i64 = row.get(1)?;
             let created_at: i64 = row.get(2)?;
             if let Ok(mut resp) = serde_json::from_str::<AiResponse>(&response_json) {
-                let origin = if created_at >= self.session_start {
-                    "this session"
+                let (origin, total) = if created_at >= self.session_start {
+                    let t = self
+                        .tokens_saved_this
+                        .fetch_add(tokens_saved as u64, Ordering::Relaxed)
+                        + tokens_saved as u64;
+                    ("this session", t)
                 } else {
-                    "previous session"
+                    let t = self
+                        .tokens_saved_prev
+                        .fetch_add(tokens_saved as u64, Ordering::Relaxed)
+                        + tokens_saved as u64;
+                    ("previous session", t)
                 };
                 info!(
-                    "Cache hit [{}] ({}) — {} tokens saved",
-                    hash_prefix, origin, tokens_saved
+                    "Cache hit [{}] ({}) — {} tokens saved (total {}: {})",
+                    hash_prefix, origin, tokens_saved, origin, total
                 );
                 if let Some(ref mut usage) = resp.usage {
                     usage.cached_tokens =

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -1,0 +1,171 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, info};
+
+use super::{AiProvider, AiRequest, AiResponse, ProviderCapabilities};
+
+pub struct CachingAiProvider {
+    inner: Arc<dyn AiProvider>,
+    conn: libsql::Connection,
+    session_start: i64,
+}
+
+impl CachingAiProvider {
+    pub async fn new(inner: Arc<dyn AiProvider>, cache_path: &str, ttl_days: u64) -> Result<Self> {
+        let db = libsql::Builder::new_local(cache_path).build().await?;
+        let conn = db.connect()?;
+
+        let _ = conn
+            .query("PRAGMA journal_mode=WAL;", ())
+            .await?
+            .next()
+            .await;
+        let _ = conn
+            .query("PRAGMA busy_timeout = 5000;", ())
+            .await?
+            .next()
+            .await;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS response_cache (
+                request_hash TEXT PRIMARY KEY,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                request_json TEXT NOT NULL,
+                response_json TEXT NOT NULL,
+                tokens_saved INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL
+            );",
+        )
+        .await?;
+
+        let cutoff = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+            - ttl_days as i64 * 86400;
+        let result = conn
+            .execute(
+                "DELETE FROM response_cache WHERE created_at < ?",
+                libsql::params![cutoff],
+            )
+            .await;
+        if let Ok(reaped) = result {
+            if reaped > 0 {
+                info!(
+                    "Response cache: reaped {} expired entries (>{} days old)",
+                    reaped, ttl_days
+                );
+            }
+        }
+
+        let session_start = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        info!("Response cache enabled ({})", cache_path);
+
+        Ok(Self {
+            inner,
+            conn,
+            session_start,
+        })
+    }
+
+    fn compute_cache_key(request: &AiRequest) -> String {
+        let mut val = serde_json::to_value(request).unwrap_or_default();
+        // Strip nondeterministic fields
+        if let serde_json::Value::Object(ref mut map) = val {
+            map.remove("context_tag");
+        }
+        super::scrub_thought_signatures(&mut val);
+        let canonical = serde_json::to_string(&val).unwrap_or_default();
+        let hash = Sha256::digest(canonical.as_bytes());
+        hash.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+}
+
+#[async_trait]
+impl AiProvider for CachingAiProvider {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let hash = Self::compute_cache_key(&request);
+        let hash_prefix = &hash[..12];
+
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT response_json, tokens_saved, created_at FROM response_cache WHERE request_hash = ?",
+                libsql::params![hash.clone()],
+            )
+            .await?;
+
+        if let Some(row) = rows.next().await? {
+            let response_json: String = row.get(0)?;
+            let tokens_saved: i64 = row.get(1)?;
+            let created_at: i64 = row.get(2)?;
+            if let Ok(mut resp) = serde_json::from_str::<AiResponse>(&response_json) {
+                let origin = if created_at >= self.session_start {
+                    "this session"
+                } else {
+                    "previous session"
+                };
+                info!(
+                    "Cache hit [{}] ({}) — {} tokens saved",
+                    hash_prefix, origin, tokens_saved
+                );
+                if let Some(ref mut usage) = resp.usage {
+                    usage.cached_tokens =
+                        Some(usage.cached_tokens.unwrap_or(0) + usage.prompt_tokens);
+                }
+                return Ok(resp);
+            }
+        }
+
+        debug!("Cache miss [{}]", hash_prefix);
+
+        let resp = self.inner.generate_content(request.clone()).await?;
+
+        let response_json = serde_json::to_string(&resp)?;
+        let request_json = serde_json::to_string(&request)?;
+        let caps = self.inner.get_capabilities();
+        let tokens_saved = resp
+            .usage
+            .as_ref()
+            .map(|u| u.prompt_tokens + u.completion_tokens)
+            .unwrap_or(0);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let _ = self
+            .conn
+            .execute(
+                "INSERT OR REPLACE INTO response_cache (request_hash, provider, model, request_json, response_json, tokens_saved, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                libsql::params![
+                    hash,
+                    caps.model_name.clone(),
+                    caps.model_name,
+                    request_json,
+                    response_json,
+                    tokens_saved as i64,
+                    now
+                ],
+            )
+            .await;
+
+        Ok(resp)
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        self.inner.estimate_tokens(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        self.inner.get_capabilities()
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -165,6 +165,15 @@ pub struct ProviderCapabilities {
     pub context_window_size: usize,
 }
 
+/// Cache statistics returned by providers that support local response caching.
+#[derive(Debug, Clone, Default)]
+pub struct CacheStats {
+    pub hits_this_session: u64,
+    pub hits_prev_session: u64,
+    pub tokens_saved_this_session: u64,
+    pub tokens_saved_prev_session: u64,
+}
+
 /// Trait defining the standard interface for all AI providers in Sashiko.
 #[async_trait]
 pub trait AiProvider: Send + Sync {
@@ -176,6 +185,11 @@ pub trait AiProvider: Send + Sync {
 
     /// Returns the capabilities and constraints of this provider.
     fn get_capabilities(&self) -> ProviderCapabilities;
+
+    /// Returns cache statistics, if the provider supports local response caching.
+    fn cache_stats(&self) -> Option<CacheStats> {
+        None
+    }
 }
 
 /// Creates an AI provider, optionally wrapping it with a local response cache.

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -178,6 +178,27 @@ pub trait AiProvider: Send + Sync {
     fn get_capabilities(&self) -> ProviderCapabilities;
 }
 
+/// Creates an AI provider, optionally wrapping it with a local response cache.
+pub async fn create_provider_cached(
+    settings: &Settings,
+    enable_cache: bool,
+    cache_ttl_days: u64,
+) -> Result<Arc<dyn AiProvider>> {
+    let provider = create_provider(settings)?;
+    if enable_cache {
+        let cache_path = std::path::Path::new(&settings.database.url)
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("response_cache.db");
+        let cached =
+            cache::CachingAiProvider::new(provider, &cache_path.to_string_lossy(), cache_ttl_days)
+                .await?;
+        Ok(Arc::new(cached))
+    } else {
+        Ok(provider)
+    }
+}
+
 /// Creates an AI provider based on the application settings.
 pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
     match settings.ai.provider.to_lowercase().as_str() {
@@ -282,6 +303,7 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
 }
 #[cfg(feature = "bedrock")]
 pub mod bedrock;
+pub mod cache;
 pub mod claude;
 pub mod claude_cli;
 pub mod codex_cli;

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,7 +23,7 @@ use axum::{
     routing::{get, get_service, post},
 };
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -272,10 +272,14 @@ pub async fn run_server(
         .nest_service("/static", ServeDir::new("static"))
         .with_state(state);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], settings.port));
-    info!("Web API listening on {}", addr);
+    let bind_addr = format!("{}:{}", settings.host, settings.port);
+    let addrs: Vec<SocketAddr> = bind_addr
+        .to_socket_addrs()
+        .map_err(|e| anyhow::anyhow!("invalid bind address '{}': {}", bind_addr, e))?
+        .collect();
+    info!("Web API listening on {:?}", addrs);
 
-    let listener = TcpListener::bind(addr).await?;
+    let listener = TcpListener::bind(addrs.as_slice()).await?;
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -309,7 +313,7 @@ async fn submit_patch(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    if !state.allow_all_submit && !addr.ip().is_loopback() {
+    if !state.allow_all_submit && !addr.ip().to_canonical().is_loopback() {
         info!("Refused patch submission from non-localhost: {}", addr);
         return Err(StatusCode::FORBIDDEN);
     }
@@ -914,7 +918,7 @@ async fn rerun_patchset(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    if !state.allow_all_submit && !addr.ip().is_loopback() {
+    if !state.allow_all_submit && !addr.ip().to_canonical().is_loopback() {
         return Err(StatusCode::FORBIDDEN);
     }
 
@@ -940,7 +944,7 @@ async fn rerun_patch(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    if !state.allow_all_submit && !addr.ip().is_loopback() {
+    if !state.allow_all_submit && !addr.ip().to_canonical().is_loopback() {
         return Err(StatusCode::FORBIDDEN);
     }
 

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -117,7 +117,11 @@ async fn main() -> Result<()> {
         "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git".to_string()
     });
 
-    let target_url = format!("http://127.0.0.1:{}/api/submit", port);
+    let target_url = if settings.server.host.contains(':') {
+        format!("http://[::1]:{}/api/submit", port)
+    } else {
+        format!("http://{}:{}/api/submit", settings.server.host, port)
+    };
     let client = Client::new();
 
     // --- Phase 1: Ingestion ---

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -118,7 +118,13 @@ async fn main() -> Result<()> {
     // Load settings, falling back to defaults if file missing/invalid
     let base_url = cli.server.unwrap_or_else(|| {
         Settings::new()
-            .map(|s| format!("http://{}:{}", s.server.host, s.server.port))
+            .map(|s| {
+                if s.server.host.contains(':') {
+                    format!("http://[::1]:{}", s.server.port)
+                } else {
+                    format!("http://{}:{}", s.server.host, s.server.port)
+                }
+            })
             .unwrap_or_else(|_| "http://127.0.0.1:8080".to_string())
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -545,7 +545,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Start Reviewer Service
-    let reviewer = Reviewer::new(db.clone(), settings.clone());
+    let reviewer = Reviewer::new(db.clone(), settings.clone()).await;
     tokio::spawn(async move {
         reviewer.start().await;
     });

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -683,6 +683,24 @@ impl Reviewer {
                 .update_patchset_status(patchset_id, ReviewStatus::FailedToApply.as_str())
                 .await;
         }
+
+        if let Some(stats) = ctx.provider.cache_stats() {
+            use crate::ai::cache::fmt_thousands;
+            let total_hits = stats.hits_this_session + stats.hits_prev_session;
+            let total_tokens = stats.tokens_saved_this_session + stats.tokens_saved_prev_session;
+            if total_hits > 0 {
+                info!(
+                    "Patchset {} cache summary — {} hits ({} this session, {} previous), {} tokens saved ({} this session, {} previous)",
+                    patchset_id,
+                    fmt_thousands(total_hits),
+                    fmt_thousands(stats.hits_this_session),
+                    fmt_thousands(stats.hits_prev_session),
+                    fmt_thousands(total_tokens),
+                    fmt_thousands(stats.tokens_saved_this_session),
+                    fmt_thousands(stats.tokens_saved_prev_session),
+                );
+            }
+        }
     }
 
     async fn prepare_baseline_worktree(

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -14,7 +14,7 @@
 
 use crate::ReviewStatus;
 use crate::ai::quota::QuotaManager;
-use crate::ai::{AiProvider, AiRequest, create_provider};
+use crate::ai::{AiProvider, AiRequest, create_provider_cached};
 use crate::baseline::{BaselineRegistry, BaselineResolution, extract_files_from_diff};
 use crate::db::{AiInteractionParams, Database, Finding, PatchsetRow, Severity, ToolUsage};
 use crate::email_policy::EmailPolicyConfig;
@@ -90,7 +90,7 @@ impl Reviewer {
     ///
     /// * `db` - The database connection.
     /// * `settings` - Application settings.
-    pub fn new(db: Arc<Database>, settings: Settings) -> Self {
+    pub async fn new(db: Arc<Database>, settings: Settings) -> Self {
         let concurrency = settings.review.concurrency;
         let repo_path = PathBuf::from(&settings.git.repository_path);
 
@@ -111,11 +111,14 @@ impl Reviewer {
                 }
             };
 
-        // Initialize Provider
-        let provider = create_provider(&settings).expect("Failed to create AI provider");
+        let provider = create_provider_cached(
+            &settings,
+            settings.ai.response_cache,
+            settings.ai.response_cache_ttl_days,
+        )
+        .await
+        .expect("Failed to create AI provider");
 
-        // Initialize CacheManager
-        // Assuming prompts are in "third_party/prompts/kernel" in CWD.
         Self {
             db,
             settings,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -183,12 +183,20 @@ pub struct AiSettings {
     /// Useful for debugging but verbose; disabled by default.
     #[serde(default)]
     pub log_turns: bool,
+    #[serde(default)]
+    pub response_cache: bool,
+    #[serde(default = "default_response_cache_ttl_days")]
+    pub response_cache_ttl_days: u64,
     // Provider-specific settings
     pub claude: Option<ClaudeSettings>,
     pub gemini: Option<GeminiSettings>,
     #[cfg(feature = "bedrock")]
     pub bedrock: Option<BedrockSettings>,
     pub openai_compat: Option<OpenAiCompatSettings>,
+}
+
+fn default_response_cache_ttl_days() -> u64 {
+    7
 }
 
 fn default_api_timeout_secs() -> u64 {


### PR DESCRIPTION
I'm using Sashiko locally, calling "sashiko submit" from Claude Code and then doing "sashiko show" + "sashiko show --format json" to go on considering sashiko's review comments in Claude while the rest continues to be reviewed by sashiko.

This response cache was an experimentation to see if using it locally with Claude there would be many hits, and indeed there is a lot, even on the same patch series review session, let alone from previous sessions.

According to Claude:

● That's actually expected — and good news! Within the same batch, cache hits can happen when:  1. Retries — if a review fails and gets retried (up to 3 attempts), the retry's AI turns are identical to the first attempt's, so they hit the cache
  2. Concurrent reviews of patches that share identical early turns (same system prompt + same tool declarations + same initial context)  So the cache is already saving you tokens on this first run. How many hits are you seeing?
  
And then, now, with the series applied and running for a while:

2026-05-05T21:36:58.132536Z  INFO sashiko::reviewer: [review-bin] Restarting AI review (attempt 2/3)...
2026-05-05T21:36:58.132633Z  INFO sashiko::reviewer: [review-bin] Executing Phase 0: Pre-screening relevant subsystem guides.
2026-05-05T21:36:58.133626Z  INFO sashiko::ai::cache: Cache hit [8d0a7fba39f2] (previous session) — 4.162 tokens saved (total previous session: 68.401.522)
2026-05-05T21:36:58.133826Z  INFO sashiko::reviewer: [review-bin] Phase 0 selected prompts: ["perf.md"]
2026-05-05T21:37:00.418453Z  INFO sashiko::reviewer: [review-bin] Running planning pre-phase
2026-05-05T21:37:00.420213Z  INFO sashiko::ai::cache: Cache hit [6c1281dab81a] (previous session) — 8.887 tokens saved (total previous session: 68.410.409)
2026-05-05T21:37:00.420492Z  INFO sashiko::reviewer: [review-bin] Planning phase selected stages: [1, 2, 3, 6]
2026-05-05T21:37:00.420513Z  INFO sashiko::reviewer: [review-bin] Running Stage 1
2026-05-05T21:37:00.422723Z  INFO sashiko::ai::cache: Cache hit [4f3ec7791495] (previous session) — 10.349 tokens saved (total previous session: 68.420.758)
2026-05-05T21:37:02.549310Z  INFO sashiko::ai::cache: Cache hit [68e0c030bced] (this session) — 66.329 tokens saved (total this session: 91.807.991)
2026-05-05T21:37:07.727945Z  INFO sashiko::ai::cache: Cache hit [8ccac8d934a6] (previous session) — 12.239 tokens saved (total previous session: 68.432.997)
2026-05-05T21:37:07.734284Z  INFO sashiko::ai::cache: Cache hit [d052622a6324] (previous session) — 12.727 tokens saved (total previous session: 68.445.724)
2026-05-05T21:37:10.085300Z  INFO sashiko::ai::cache: Cache hit [2aaaaf0b1d9e] (this session) — 69.891 tokens saved (total this session: 91.877.882)

So it is quite a lot :-)

Please take a look, its totally vibe coded, but it passes tests, took into account the design docs in the sashiko codebase and is greatly speeding up my local development workflow.

There is also a patch to make it listen on ipv6 addresses, if configured to do it.

By default neither IPv6 nor the response cache is enabled.