### PR TITLE
cli: introduce a variety of quality-of-life changes for local development

### DIFF
--- a/designs/DESIGN_CLI_TOOL_V2.md
+++ b/designs/DESIGN_CLI_TOOL_V2.md
@@ -68,6 +68,22 @@ sashiko submit [INPUT] [OPTIONS]
   - Auto-detect if ID is not provided? (Maybe last submitted?).
   - Allow `HEAD` if we can resolve it to a patchset ID? (Complex).
   - Show "most recent" if no ID? `sashiko show latest`.
+  - Add `--watch` `-w` flag to stream status updates linearly.
+  - Parity between JSON and text outputs (show detailed findings in text format).
+
+### 5. `rerun`
+**Goal:** Request a re-review of a completed patchset.
+- `sashiko rerun <ID>`.
+- **Improvement:**
+  - Placed back into `Pending` queue.
+
+### 6. `local`
+**Goal:** Run a local review with optional interactive loop.
+- `sashiko local [INPUT] [OPTIONS]`.
+- **Improvement:**
+  - Add `--interactive` flag.
+  - If issues are found, pauses and prompts the user/agent to modify the code or provide a rebuttal.
+  - Loops until review is clean (LGTM).
 
 ## Action Plan
 1.  **Refine `submit` argument parsing:** Implement robust detection logic.

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -12,7 +12,7 @@ pub fn fmt_thousands(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
     for (i, c) in s.chars().enumerate() {
-        if i > 0 && (s.len() - i) % 3 == 0 {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
             result.push('.');
         }
         result.push(c);
@@ -70,13 +70,13 @@ impl CachingAiProvider {
                 libsql::params![cutoff],
             )
             .await;
-        if let Ok(reaped) = result {
-            if reaped > 0 {
-                info!(
-                    "Response cache: reaped {} expired entries (>{} days old)",
-                    reaped, ttl_days
-                );
-            }
+        if let Ok(reaped) = result
+            && reaped > 0
+        {
+            info!(
+                "Response cache: reaped {} expired entries (>{} days old)",
+                reaped, ttl_days
+            );
         }
 
         let session_start = SystemTime::now()

--- a/src/api.rs
+++ b/src/api.rs
@@ -187,6 +187,13 @@ pub struct SubsystemQuery {
 }
 
 #[derive(Deserialize)]
+pub struct CancelQuery {
+    pub id: i64,
+    #[serde(default)]
+    pub force: bool,
+}
+
+#[derive(Deserialize)]
 pub struct InjectRequest {
     pub raw: String,
     pub group: Option<String>,
@@ -267,6 +274,7 @@ pub async fn run_server(
         .route("/api/stats/tools", get(stats_tools))
         .route("/api/submit", post(submit_patch))
         .route("/api/patchset/rerun", post(rerun_patchset))
+        .route("/api/patchset/cancel", post(cancel_patchset))
         .route("/api/patch/rerun", post(rerun_patch))
         .route("/", get_service(ServeFile::new("static/index.html")))
         .nest_service("/static", ServeDir::new("static"))
@@ -933,6 +941,44 @@ async fn rerun_patchset(
     })?;
 
     Ok(Json(serde_json::json!({ "status": "accepted" })))
+}
+
+async fn cancel_patchset(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<CancelQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if state.read_only {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    if !state.allow_all_submit && !addr.ip().is_loopback() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let cancelled = state
+        .db
+        .cancel_patchset(query.id, query.force)
+        .await
+        .map_err(|e| {
+            error!("Failed to cancel patchset {}: {}", query.id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if cancelled {
+        info!("Patchset {} cancelled (force={})", query.id, query.force);
+        Ok(Json(serde_json::json!({ "status": "cancelled" })))
+    } else {
+        let reason = if query.force {
+            "Patchset is not in a cancellable state (must be Pending, Incomplete, or In Review)"
+        } else {
+            "Patchset is not in a cancellable state (must be Pending or Incomplete; use force=true for In Review)"
+        };
+        Ok(Json(serde_json::json!({
+            "status": "not_modified",
+            "reason": reason
+        })))
+    }
 }
 
 async fn rerun_patch(

--- a/src/bin/review.rs
+++ b/src/bin/review.rs
@@ -18,11 +18,10 @@ use sashiko::{
     git_ops::GitWorktree,
     settings::Settings,
     worker::{
-        PatchInput, Worker, WorkerConfig, calculate_series_range, prompts::PromptRegistry,
-        tools::ToolBox,
+        PatchInput, ReviewInput, Worker, WorkerConfig, calculate_series_range,
+        prompts::PromptRegistry, tools::ToolBox,
     },
 };
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -77,13 +76,6 @@ struct Args {
     /// Select which stages from 1-7 to run.
     #[arg(long, hide = true, value_delimiter = ',')]
     stages: Option<Vec<u8>>,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-struct ReviewInput {
-    id: i64,
-    subject: String,
-    patches: Vec<PatchInput>,
 }
 
 #[tokio::main]

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -640,42 +640,18 @@ async fn handle_show(
                                 }
                             }
 
-                            if let Some(r) = patch_review {
-                                let mut counts = std::collections::HashMap::new();
-                                if let Some(output_str) = r.get("output").and_then(|o| o.as_str())
-                                    && let Ok(output_json) = from_str::<Value>(output_str)
-                                    && let Some(findings) =
-                                        output_json.get("findings").and_then(|f| f.as_array())
-                                {
-                                    for f in findings {
-                                        if let Some(sev) =
-                                            f.get("severity").and_then(|s| s.as_str())
-                                        {
-                                            *counts.entry(sev.to_lowercase()).or_insert(0) += 1;
-                                        }
-                                    }
-                                }
-
-                                let c = counts.get("critical").copied().unwrap_or(0);
-                                let h = counts.get("high").copied().unwrap_or(0);
-                                let m = counts.get("medium").copied().unwrap_or(0);
-                                let l = counts.get("low").copied().unwrap_or(0);
-                                let has_findings = c > 0 || h > 0 || m > 0 || l > 0;
-                                if has_findings {
-                                    println!("Patch {}: {}", idx, subject);
-                                    println!(
-                                        "Critical: {} · High: {} · Medium: {} · Low: {}\n",
-                                        c, h, m, l
-                                    );
-                                    if let Some(inline) =
-                                        r.get("inline_review").and_then(|s| s.as_str())
-                                        && !inline.is_empty()
-                                        && inline != "No issues found."
-                                    {
-                                        println!("{}", inline.trim());
-                                    }
-                                    println!();
-                                }
+                            if let Some(r) = patch_review
+                                && let Some(output_str) = r.get("output").and_then(|o| o.as_str())
+                                && let Ok(output_json) = from_str::<Value>(output_str)
+                                && let Some(findings) =
+                                    output_json.get("findings").and_then(|f| f.as_array())
+                            {
+                                let inline = r.get("inline_review").and_then(|s| s.as_str());
+                                print_findings_summary(
+                                    &format!("Patch {}: {}", idx, subject),
+                                    findings,
+                                    inline,
+                                );
                             }
                         }
                     }
@@ -734,6 +710,44 @@ async fn handle_cancel(
     }
 
     Ok(())
+}
+
+/// Count finding severities from a findings JSON array.
+fn count_severities(findings: &[Value]) -> (usize, usize, usize, usize) {
+    let mut counts = std::collections::HashMap::new();
+    for f in findings {
+        if let Some(sev) = f.get("severity").and_then(|s| s.as_str()) {
+            *counts.entry(sev.to_lowercase()).or_insert(0) += 1;
+        }
+    }
+    (
+        counts.get("critical").copied().unwrap_or(0),
+        counts.get("high").copied().unwrap_or(0),
+        counts.get("medium").copied().unwrap_or(0),
+        counts.get("low").copied().unwrap_or(0),
+    )
+}
+
+/// Print a findings summary line with severity counts if any findings exist.
+/// Returns true if findings were printed.
+fn print_findings_summary(label: &str, findings: &[Value], inline_review: Option<&str>) -> bool {
+    let (c, h, m, l) = count_severities(findings);
+    if c == 0 && h == 0 && m == 0 && l == 0 {
+        return false;
+    }
+    println!("{}", label);
+    println!(
+        "Critical: {} · High: {} · Medium: {} · Low: {}\n",
+        c, h, m, l
+    );
+    if let Some(inline) = inline_review
+        && !inline.is_empty()
+        && inline != "No issues found."
+    {
+        println!("{}", inline.trim());
+    }
+    println!();
+    true
 }
 
 fn print_colored(color: Color, text: &str) {

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -106,6 +106,32 @@ enum Commands {
         #[arg(long, short)]
         force: bool,
     },
+    /// Run a local review (or queue to running server)
+    Local {
+        /// Git revision, range (e.g. HEAD~3..HEAD), or commit SHA
+        #[arg(default_value = "HEAD")]
+        input: String,
+
+        /// Baseline reference (default: parent of first commit in range)
+        #[arg(long)]
+        baseline: Option<String>,
+
+        /// Path to git repository (default: current directory)
+        #[arg(long, short = 'r')]
+        repo: Option<PathBuf>,
+
+        /// Skip AI review, only test patch application
+        #[arg(long)]
+        no_ai: bool,
+
+        /// Custom prompt to append to the review task
+        #[arg(long)]
+        custom_prompt: Option<String>,
+
+        /// Force local execution even if server is running
+        #[arg(long)]
+        force_local: bool,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -198,6 +224,27 @@ async fn run_command(
         } => handle_list(client, base_url, page, per_page, filter, format).await,
         Commands::Show { id } => handle_show(client, base_url, id, format).await,
         Commands::Cancel { id, force } => handle_cancel(client, base_url, id, force, format).await,
+        Commands::Local {
+            input,
+            baseline,
+            repo,
+            no_ai,
+            custom_prompt,
+            force_local,
+        } => {
+            handle_local(
+                client,
+                base_url,
+                input,
+                baseline,
+                repo,
+                no_ai,
+                custom_prompt,
+                force_local,
+                format,
+            )
+            .await
+        }
     }
 }
 
@@ -710,6 +757,350 @@ async fn handle_cancel(
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_local(
+    client: &Client,
+    base_url: &str,
+    input: String,
+    baseline: Option<String>,
+    repo: Option<PathBuf>,
+    no_ai: bool,
+    custom_prompt: Option<String>,
+    force_local: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    // Determine repository path
+    let repo_path = if let Some(r) = repo {
+        r
+    } else {
+        let cwd = std::env::current_dir().context("Failed to get current directory")?;
+        // Verify CWD is a git repo
+        if !cwd.join(".git").exists() {
+            return Err(anyhow::anyhow!(
+                "Current directory is not a git repository. Use --repo to specify one."
+            ));
+        }
+        cwd
+    };
+
+    // Check if server is running (unless --force-local)
+    if !force_local && let Ok(settings) = Settings::new() {
+        let addr = format!("{}:{}", settings.server.host, settings.server.port);
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            // Server is running — submit via API
+            let submit_type = if input.contains("..") {
+                SubmitType::Range
+            } else {
+                SubmitType::Remote
+            };
+            let repo_str = Some(repo_path.to_string_lossy().to_string());
+
+            let url = format!("{}/api/submit", base_url);
+            let payload = match submit_type {
+                SubmitType::Range => SubmitRequest::RemoteRange {
+                    sha: input.clone(),
+                    repo: repo_str,
+                    skip_subjects: None,
+                    only_subjects: None,
+                },
+                _ => SubmitRequest::Remote {
+                    sha: input.clone(),
+                    repo: repo_str,
+                    skip_subjects: None,
+                    only_subjects: None,
+                },
+            };
+
+            let resp = client.post(&url).json(&payload).send().await?;
+            if resp.status().is_success() {
+                let result: SubmitResponse = resp.json().await?;
+                print_colored(Color::Green, "Queued: ");
+                println!(
+                    "Review submitted (ID: {}). View at {}/",
+                    result.id, base_url
+                );
+                println!("\nUse `sashiko-cli show {}` to check progress.", result.id);
+            } else {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!(
+                    "Failed to queue review ({}): {}",
+                    status,
+                    text
+                ));
+            }
+            return Ok(());
+        }
+    }
+    // Cold start path: run review locally via sashiko-review subprocess
+    eprint_phase(1, 4, &format!("Extracting patches from {}...", input));
+
+    // Resolve commits
+    let shas = if input.contains("..") {
+        sashiko::git_ops::resolve_git_range(&repo_path, &input).await?
+    } else {
+        // Single ref — resolve to SHA
+        let sha = sashiko::git_ops::get_commit_hash(&repo_path, &input).await?;
+        vec![sha]
+    };
+
+    eprintln!(
+        " ({} commit{})",
+        shas.len(),
+        if shas.len() == 1 { "" } else { "s" }
+    );
+
+    // Extract patch metadata and build ReviewInput
+    let mut patches = Vec::new();
+    for (i, sha) in shas.iter().enumerate() {
+        let meta = sashiko::git_ops::extract_patch_metadata(&repo_path, sha)
+            .await
+            .with_context(|| format!("Failed to extract metadata for commit {}", sha))?;
+        patches.push(sashiko::worker::PatchInput {
+            index: (i + 1) as i64,
+            diff: meta.diff,
+            subject: Some(meta.subject),
+            author: Some(meta.author),
+            date: Some(meta.timestamp),
+            message_id: None,
+            commit_id: Some(sha.clone()),
+        });
+    }
+
+    let review_input = sashiko::worker::ReviewInput {
+        id: 0, // Local review, no DB ID
+        subject: patches
+            .first()
+            .and_then(|p| p.subject.clone())
+            .unwrap_or_else(|| input.clone()),
+        patches,
+    };
+
+    let review_json =
+        serde_json::to_string(&review_input).context("Failed to serialize review input")?;
+
+    // Locate sashiko-review binary
+    let review_bin = find_review_binary()?;
+
+    // Build subprocess args
+    let baseline_ref = if let Some(b) = &baseline {
+        b.clone()
+    } else {
+        // Default: parent of first commit
+        let first_sha = &shas[0];
+        format!("{}^", first_sha)
+    };
+
+    let mut args = vec!["--baseline".to_string(), baseline_ref];
+
+    if no_ai {
+        args.push("--no-ai".to_string());
+    }
+    if let Some(prompt) = &custom_prompt {
+        args.push("--custom-prompt".to_string());
+        args.push(prompt.clone());
+    }
+
+    eprint_phase(2, 4, "Starting review subprocess...");
+    eprintln!();
+
+    // Spawn review subprocess
+    let mut child = tokio::process::Command::new(&review_bin)
+        .args(&args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .env("SASHIKO_LOG_PLAIN", "1")
+        .spawn()
+        .with_context(|| format!("Failed to start review binary: {:?}", review_bin))?;
+
+    // Write input to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(format!("{}\n", review_json).as_bytes())
+            .await
+            .context("Failed to write to review subprocess stdin")?;
+        drop(stdin);
+    }
+
+    // Stream stderr for progress in a background task
+    let stderr = child.stderr.take();
+    let stderr_handle = tokio::spawn(async move {
+        if let Some(stderr) = stderr {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            let mut saw_applying = false;
+            let mut saw_ai_review = false;
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !saw_applying && line.contains("Applying") {
+                    saw_applying = true;
+                    eprint_phase(2, 4, "Applying patches to worktree...");
+                    eprintln!();
+                }
+                if !saw_ai_review && line.contains("Starting AI review") {
+                    saw_ai_review = true;
+                    eprint_phase(3, 4, "AI review in progress...");
+                    eprintln!();
+                }
+                if line.contains("AI review completed") {
+                    eprint_phase(4, 4, "Review complete.");
+                    eprintln!();
+                }
+            }
+        }
+    });
+
+    // Capture stdout
+    let output = child
+        .wait_with_output()
+        .await
+        .context("Failed to wait for review subprocess")?;
+
+    let _ = stderr_handle.await;
+
+    let exit_code = output.status.code().unwrap_or(1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+    if stdout.trim().is_empty() {
+        return Err(anyhow::anyhow!(
+            "Review subprocess produced no output (exit code: {})",
+            exit_code
+        ));
+    }
+
+    // Parse the review output
+    let result: Value =
+        serde_json::from_str(stdout.trim()).context("Failed to parse review output JSON")?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        OutputFormat::Text => {
+            print_local_review_results(&result, &input);
+        }
+    }
+
+    // Determine exit code based on findings
+    if let Some(err) = result.get("error").and_then(|e| e.as_str())
+        && !err.is_empty()
+    {
+        std::process::exit(3);
+    }
+    if let Some(review) = result.get("review")
+        && let Some(findings) = review.get("findings").and_then(|f| f.as_array())
+    {
+        let (c, h, _, _) = count_severities(findings);
+        if c > 0 || h > 0 {
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn eprint_phase(current: usize, total: usize, msg: &str) {
+    eprint!("[{}/{}] {}", current, total, msg);
+}
+
+fn find_review_binary() -> Result<PathBuf> {
+    // Try same directory as current executable
+    if let Ok(exe) = std::env::current_exe() {
+        let dir = exe.parent().unwrap_or(std::path::Path::new("."));
+        let candidate = dir.join("sashiko-review");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        // Also check for "review" (cargo build output name)
+        let candidate = dir.join("review");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    // Try PATH
+    if let Ok(output) = std::process::Command::new("which")
+        .arg("sashiko-review")
+        .output()
+        && output.status.success()
+    {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Ok(PathBuf::from(path));
+    }
+
+    Err(anyhow::anyhow!(
+        "Cannot find sashiko-review binary.\n\
+         Build it with: cargo build --bin review\n\
+         Or specify its location in PATH."
+    ))
+}
+
+fn print_local_review_results(result: &Value, input: &str) {
+    let baseline = result["baseline"].as_str().unwrap_or("unknown");
+    print_colored(Color::Cyan, "Local Review Results\n");
+    println!("  Input:    {}", input);
+    println!("  Baseline: {}", baseline);
+
+    // Show patch application status
+    if let Some(patches) = result.get("patches").and_then(|p| p.as_array()) {
+        println!("\nPatch Application:");
+        for p in patches {
+            let idx = p["index"].as_i64().unwrap_or(0);
+            let status = p["status"].as_str().unwrap_or("unknown");
+            let method = p["method"].as_str().unwrap_or("");
+            let color = match status {
+                "applied" => Color::Green,
+                "failed" | "error" => Color::Red,
+                _ => Color::Yellow,
+            };
+            print!("  [{}] ", idx);
+            print_colored(color, status);
+            if !method.is_empty() {
+                print!(" ({})", method);
+            }
+            println!();
+            if let Some(err) = p.get("error").and_then(|e| e.as_str()) {
+                print_colored(Color::Red, "      Error: ");
+                println!("{}", err);
+            }
+        }
+    }
+
+    // Show error if present
+    if let Some(err) = result.get("error").and_then(|e| e.as_str())
+        && !err.is_empty()
+    {
+        println!();
+        print_colored(Color::Red, "Error: ");
+        println!("{}", err);
+        return;
+    }
+
+    // Show review results
+    if let Some(review) = result.get("review")
+        && let Some(findings) = review.get("findings").and_then(|f| f.as_array())
+    {
+        let inline = result.get("inline_review").and_then(|s| s.as_str());
+        println!();
+        if !print_findings_summary("Review Findings:", findings, inline) {
+            print_colored(Color::Green, "\nNo issues found.\n");
+        }
+    }
+
+    // Show token usage
+    let tokens_in = result["tokens_in"].as_u64().unwrap_or(0);
+    let tokens_out = result["tokens_out"].as_u64().unwrap_or(0);
+    let tokens_cached = result["tokens_cached"].as_u64().unwrap_or(0);
+    if tokens_in > 0 || tokens_out > 0 {
+        println!(
+            "\nTokens: {} in / {} out / {} cached",
+            tokens_in, tokens_out, tokens_cached
+        );
+    }
 }
 
 /// Count finding severities from a findings JSON array.

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -96,6 +96,15 @@ enum Commands {
         /// ID of the patchset or "latest"
         #[arg(default_value = "latest")]
         id: String,
+
+        /// Stream status updates linearly
+        #[arg(long, short = 'w')]
+        watch: bool,
+    },
+    /// Request a re-review of a completed patchset
+    Rerun {
+        /// ID of the patchset to re-review
+        id: i64,
     },
     /// Cancel a pending review
     Cancel {
@@ -131,6 +140,10 @@ enum Commands {
         /// Force local execution even if server is running
         #[arg(long)]
         force_local: bool,
+
+        /// Pause on failure, wait for agent/user to fix code, and re-run automatically
+        #[arg(long)]
+        interactive: bool,
     },
 }
 
@@ -222,7 +235,8 @@ async fn run_command(
             page,
             per_page,
         } => handle_list(client, base_url, page, per_page, filter, format).await,
-        Commands::Show { id } => handle_show(client, base_url, id, format).await,
+        Commands::Show { id, watch } => handle_show(client, base_url, id, watch, format).await,
+        Commands::Rerun { id } => handle_rerun(client, base_url, id, format).await,
         Commands::Cancel { id, force } => handle_cancel(client, base_url, id, force, format).await,
         Commands::Local {
             input,
@@ -231,6 +245,7 @@ async fn run_command(
             no_ai,
             custom_prompt,
             force_local,
+            interactive,
         } => {
             handle_local(
                 client,
@@ -241,6 +256,7 @@ async fn run_command(
                 no_ai,
                 custom_prompt,
                 force_local,
+                interactive,
                 format,
             )
             .await
@@ -497,6 +513,7 @@ async fn handle_show(
     client: &Client,
     base_url: &str,
     mut id: String,
+    watch: bool,
     format: OutputFormat,
 ) -> Result<()> {
     if id == "latest" {
@@ -518,203 +535,264 @@ async fn handle_show(
         }
     }
 
-    let url = format!("{}/api/patch?id={}", base_url, id);
-    let resp = client.get(&url).send().await?;
+    let mut last_status = String::new();
+    loop {
+        let url = format!("{}/api/patch?id={}", base_url, id);
+        let resp = client.get(&url).send().await?;
 
-    if resp.status().is_success() {
-        let mut details: Value = resp.json().await?;
-        let status = details["status"].as_str().unwrap_or("").to_string();
+        if resp.status().is_success() {
+            let mut details: Value = resp.json().await?;
+            let status = details["status"].as_str().unwrap_or("").to_string();
 
-        // Extract the actual numeric ID for subsequent calls
-        let numeric_id = details["id"].to_string();
+            let is_terminal = matches!(
+                status.as_str(),
+                "Reviewed" | "Failed" | "Error" | "Cancelled" | "Embargoed" | "Failed To Apply"
+            );
 
-        // Fetch review if available
-        let mut review_data = None;
-        if status == "Reviewed" || status == "Failed" || status == "Failed To Apply" {
-            let review_url = format!("{}/api/review_log?patchset_id={}", base_url, numeric_id);
-            let review_resp = client.get(&review_url).send().await?;
-
-            if review_resp.status().is_success() {
-                review_data = Some(review_resp.json::<Value>().await?);
-            }
-        }
-
-        match format {
-            OutputFormat::Json => {
-                if let Some(r) = review_data {
-                    details["review"] = r;
+            if watch && status != last_status {
+                if matches!(format, OutputFormat::Text) {
+                    println!(
+                        "[{}] Status: {}",
+                        chrono::Local::now().format("%H:%M:%S"),
+                        status
+                    );
                 }
-                println!("{}", serde_json::to_string_pretty(&details)?);
+                last_status = status.clone();
             }
-            OutputFormat::Text => {
-                print_colored(Color::Cyan, "Patchset Details:\n");
-                println!("  ID:        {}", details["id"]);
-                println!("  Subject:   {}", details["subject"].as_str().unwrap_or(""));
-                println!("  Author:    {}", details["author"].as_str().unwrap_or(""));
-                let status_str = details["status"].as_str().unwrap_or("");
-                if status_str == "Embargoed" {
-                    if let Some(until_ts) = details.get("embargo_until").and_then(|u| u.as_i64()) {
-                        println!(
-                            "  Status:    Embargoed until {}",
-                            format_timestamp(until_ts)
-                        );
+
+            if watch && !is_terminal {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                continue;
+            }
+
+            // Extract the actual numeric ID for subsequent calls
+            let numeric_id = details["id"].to_string();
+
+            // Fetch review if available
+            let mut review_data = None;
+            if status == "Reviewed" || status == "Failed" || status == "Failed To Apply" {
+                let review_url = format!("{}/api/review_log?patchset_id={}", base_url, numeric_id);
+                let review_resp = client.get(&review_url).send().await?;
+
+                if review_resp.status().is_success() {
+                    review_data = Some(review_resp.json::<Value>().await?);
+                }
+            }
+
+            match format {
+                OutputFormat::Json => {
+                    if let Some(r) = review_data {
+                        details["review"] = r;
+                    }
+                    println!("{}", serde_json::to_string_pretty(&details)?);
+                }
+                OutputFormat::Text => {
+                    print_colored(Color::Cyan, "Patchset Details:\n");
+                    println!("  ID:        {}", details["id"]);
+                    println!("  Subject:   {}", details["subject"].as_str().unwrap_or(""));
+                    println!("  Author:    {}", details["author"].as_str().unwrap_or(""));
+                    let status_str = details["status"].as_str().unwrap_or("");
+                    if status_str == "Embargoed" {
+                        if let Some(until_ts) =
+                            details.get("embargo_until").and_then(|u| u.as_i64())
+                        {
+                            println!(
+                                "  Status:    Embargoed until {}",
+                                format_timestamp(until_ts)
+                            );
+                        } else {
+                            println!("  Status:    Embargoed");
+                        }
                     } else {
-                        println!("  Status:    Embargoed");
-                    }
-                } else {
-                    println!("  Status:    {}", status_str);
-                }
-
-                if let Some(ts) = details["date"].as_i64() {
-                    println!("  Date:      {}", format_timestamp(ts));
-                }
-
-                if let Some(reason) = details.get("failed_reason").and_then(|r| r.as_str()) {
-                    print_colored(Color::Red, "\nFailure Reason: ");
-                    println!("{}", reason);
-                }
-
-                if let Some(patches) = details.get("patches").and_then(|p| p.as_array()) {
-                    println!("\nPatches ({}):", patches.len());
-                    for patch in patches {
-                        let idx = patch["part_index"].as_i64().unwrap_or(0);
-                        let status = patch["status"].as_str().unwrap_or("");
-                        let apply_err = patch["apply_error"].as_str();
-                        let p_id = patch["id"].as_i64().unwrap_or(0);
-
-                        let mut patch_review_status = None;
-                        let mut has_issues = false;
-                        if let Some(reviews) = details.get("reviews").and_then(|r| r.as_array()) {
-                            for r in reviews {
-                                if r.get("patch_id").and_then(|id| id.as_i64()) == Some(p_id) {
-                                    patch_review_status = r.get("status").and_then(|s| s.as_str());
-                                    if let Some(inline) =
-                                        r.get("inline_review").and_then(|s| s.as_str())
-                                        && inline != "No issues found."
-                                        && !inline.is_empty()
-                                    {
-                                        has_issues = true;
-                                    }
-                                }
-                            }
-                        }
-
-                        print!("  [{}] {}", idx, patch["subject"].as_str().unwrap_or(""));
-                        if !status.is_empty() && status != "Pending" {
-                            print!(" (");
-                            let color = match status {
-                                "Failed" | "Failed To Apply" | "Error" => Color::Red,
-                                "Embargoed" => Color::Magenta,
-                                _ => Color::Green,
-                            };
-                            print_colored(color, status);
-                            print!(")");
-                        }
-
-                        if let Some(rev_status) = patch_review_status {
-                            print!(" [");
-                            let color = if has_issues {
-                                Color::Yellow
-                            } else if rev_status == "Failed" {
-                                Color::Red
-                            } else {
-                                Color::Green
-                            };
-                            let label = if has_issues {
-                                "Issues Found"
-                            } else {
-                                rev_status
-                            };
-                            print_colored(color, label);
-                            print!("]");
-                        }
-                        println!();
-
-                        if let Some(err) = apply_err {
-                            print_colored(Color::Red, "      Error: ");
-                            println!("{}", err.trim());
-                        }
-                    }
-                }
-
-                if let Some(review) = review_data {
-                    println!("\nReview Summary:");
-                    if let Some(verdict) = review.get("verdict").and_then(|v| v.as_str()) {
-                        let color = match verdict {
-                            "LGTM" => Color::Green,
-                            "Request Changes" => Color::Red,
-                            _ => Color::Yellow,
-                        };
-                        print!("  Verdict: ");
-                        print_colored(color, verdict);
-                        println!();
+                        println!("  Status:    {}", status_str);
                     }
 
-                    if let Some(model) = review.get("model").and_then(|m| m.as_str()) {
-                        println!("  Model:   {}", model);
+                    if let Some(ts) = details["date"].as_i64() {
+                        println!("  Date:      {}", format_timestamp(ts));
                     }
 
-                    if let Some(summary) = review.get("summary").and_then(|s| s.as_str())
-                        && summary != "No summary available."
-                        && !summary.is_empty()
-                    {
-                        println!("\n{}", summary.trim());
+                    if let Some(reason) = details.get("failed_reason").and_then(|r| r.as_str()) {
+                        print_colored(Color::Red, "\nFailure Reason: ");
+                        println!("{}", reason);
                     }
 
                     if let Some(patches) = details.get("patches").and_then(|p| p.as_array()) {
-                        println!();
+                        println!("\nPatches ({}):", patches.len());
                         for patch in patches {
                             let idx = patch["part_index"].as_i64().unwrap_or(0);
-                            let subject = patch["subject"].as_str().unwrap_or("");
+                            let status = patch["status"].as_str().unwrap_or("");
+                            let apply_err = patch["apply_error"].as_str();
                             let p_id = patch["id"].as_i64().unwrap_or(0);
 
-                            let mut patch_review = None;
+                            let mut patch_review_status = None;
+                            let mut has_issues = false;
                             if let Some(reviews) = details.get("reviews").and_then(|r| r.as_array())
                             {
                                 for r in reviews {
                                     if r.get("patch_id").and_then(|id| id.as_i64()) == Some(p_id) {
-                                        let status = r.get("status").and_then(|s| s.as_str());
-                                        let current_status =
-                                            patch_review.and_then(|pr: &serde_json::Value| {
-                                                pr.get("status").and_then(|s| s.as_str())
-                                            });
-                                        if status == Some("Reviewed")
-                                            || current_status != Some("Reviewed")
+                                        patch_review_status =
+                                            r.get("status").and_then(|s| s.as_str());
+                                        if let Some(inline) =
+                                            r.get("inline_review").and_then(|s| s.as_str())
+                                            && inline != "No issues found."
+                                            && !inline.is_empty()
                                         {
-                                            patch_review = Some(r);
+                                            has_issues = true;
                                         }
                                     }
                                 }
                             }
 
-                            if let Some(r) = patch_review
-                                && let Some(output_str) = r.get("output").and_then(|o| o.as_str())
-                                && let Ok(output_json) = from_str::<Value>(output_str)
-                                && let Some(findings) =
-                                    output_json.get("findings").and_then(|f| f.as_array())
-                            {
-                                let inline = r.get("inline_review").and_then(|s| s.as_str());
-                                print_findings_summary(
-                                    &format!("Patch {}: {}", idx, subject),
-                                    findings,
-                                    inline,
-                                );
+                            print!("  [{}] {}", idx, patch["subject"].as_str().unwrap_or(""));
+                            if !status.is_empty() && status != "Pending" {
+                                print!(" (");
+                                let color = match status {
+                                    "Failed" | "Failed To Apply" | "Error" => Color::Red,
+                                    "Embargoed" => Color::Magenta,
+                                    _ => Color::Green,
+                                };
+                                print_colored(color, status);
+                                print!(")");
+                            }
+
+                            if let Some(rev_status) = patch_review_status {
+                                print!(" [");
+                                let color = if has_issues {
+                                    Color::Yellow
+                                } else if rev_status == "Failed" {
+                                    Color::Red
+                                } else {
+                                    Color::Green
+                                };
+                                let label = if has_issues {
+                                    "Issues Found"
+                                } else {
+                                    rev_status
+                                };
+                                print_colored(color, label);
+                                print!("]");
+                            }
+                            println!();
+
+                            if let Some(err) = apply_err {
+                                print_colored(Color::Red, "      Error: ");
+                                println!("{}", err.trim());
                             }
                         }
                     }
-                } else if let Some(logs) = details.get("baseline_logs").and_then(|l| l.as_str()) {
-                    // Fallback to baseline logs if review is missing (e.g. Failed To Apply during baseline prep)
-                    if status == "Failed To Apply" {
-                        println!("\nBaseline Logs:\n{}", logs);
+
+                    if let Some(review) = review_data {
+                        println!("\nReview Summary:");
+                        if let Some(verdict) = review.get("verdict").and_then(|v| v.as_str()) {
+                            let color = match verdict {
+                                "LGTM" => Color::Green,
+                                "Request Changes" => Color::Red,
+                                _ => Color::Yellow,
+                            };
+                            print!("  Verdict: ");
+                            print_colored(color, verdict);
+                            println!();
+                        }
+
+                        if let Some(model) = review.get("model").and_then(|m| m.as_str()) {
+                            println!("  Model:   {}", model);
+                        }
+
+                        if let Some(summary) = review.get("summary").and_then(|s| s.as_str())
+                            && summary != "No summary available."
+                            && !summary.is_empty()
+                        {
+                            println!("\n{}", summary.trim());
+                        }
+
+                        if let Some(patches) = details.get("patches").and_then(|p| p.as_array()) {
+                            println!();
+                            for patch in patches {
+                                let idx = patch["part_index"].as_i64().unwrap_or(0);
+                                let subject = patch["subject"].as_str().unwrap_or("");
+                                let p_id = patch["id"].as_i64().unwrap_or(0);
+
+                                let mut patch_review = None;
+                                if let Some(reviews) =
+                                    details.get("reviews").and_then(|r| r.as_array())
+                                {
+                                    for r in reviews {
+                                        if r.get("patch_id").and_then(|id| id.as_i64())
+                                            == Some(p_id)
+                                        {
+                                            let status = r.get("status").and_then(|s| s.as_str());
+                                            let current_status =
+                                                patch_review.and_then(|pr: &serde_json::Value| {
+                                                    pr.get("status").and_then(|s| s.as_str())
+                                                });
+                                            if status == Some("Reviewed")
+                                                || current_status != Some("Reviewed")
+                                            {
+                                                patch_review = Some(r);
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if let Some(r) = patch_review
+                                    && let Some(output_str) =
+                                        r.get("output").and_then(|o| o.as_str())
+                                    && let Ok(output_json) = from_str::<Value>(output_str)
+                                    && let Some(findings) =
+                                        output_json.get("findings").and_then(|f| f.as_array())
+                                {
+                                    let inline = r.get("inline_review").and_then(|s| s.as_str());
+                                    print_findings_summary(
+                                        &format!("Patch {}: {}", idx, subject),
+                                        findings,
+                                        inline,
+                                    );
+                                }
+                            }
+                        }
+                    } else if let Some(logs) = details.get("baseline_logs").and_then(|l| l.as_str())
+                    {
+                        // Fallback to baseline logs if review is missing (e.g. Failed To Apply during baseline prep)
+                        if status == "Failed To Apply" {
+                            println!("\nBaseline Logs:\n{}", logs);
+                        }
                     }
                 }
             }
+            break;
+        } else {
+            return Err(anyhow::anyhow!(
+                "Failed to show patchset: {}",
+                resp.status()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_rerun(
+    client: &Client,
+    base_url: &str,
+    id: i64,
+    format: OutputFormat,
+) -> Result<()> {
+    let url = format!("{}/api/patchset/rerun?id={}", base_url, id);
+    let resp = client.post(&url).send().await?;
+
+    if resp.status().is_success() {
+        let result: serde_json::Value = resp.json().await?;
+        match format {
+            OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&result)?),
+            OutputFormat::Text => {
+                print_colored(Color::Green, "Rerun queued: ");
+                println!("Patchset {} has been re-added to the review queue.", id);
+            }
         }
     } else {
-        return Err(anyhow::anyhow!(
-            "Failed to show patchset: {}",
-            resp.status()
-        ));
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!("Rerun failed ({}): {}", status, text));
     }
 
     Ok(())
@@ -769,6 +847,7 @@ async fn handle_local(
     no_ai: bool,
     custom_prompt: Option<String>,
     force_local: bool,
+    interactive: bool,
     format: OutputFormat,
 ) -> Result<()> {
     // Determine repository path
@@ -835,170 +914,203 @@ async fn handle_local(
         }
     }
     // Cold start path: run review locally via sashiko-review subprocess
-    eprint_phase(1, 4, &format!("Extracting patches from {}...", input));
+    let mut dynamic_prompt = custom_prompt;
+    loop {
+        eprint_phase(1, 4, &format!("Extracting patches from {}...", input));
 
-    // Resolve commits
-    let shas = if input.contains("..") {
-        sashiko::git_ops::resolve_git_range(&repo_path, &input).await?
-    } else {
-        // Single ref — resolve to SHA
-        let sha = sashiko::git_ops::get_commit_hash(&repo_path, &input).await?;
-        vec![sha]
-    };
+        // Resolve commits
+        let shas = if input.contains("..") {
+            sashiko::git_ops::resolve_git_range(&repo_path, &input).await?
+        } else {
+            // Single ref — resolve to SHA
+            let sha = sashiko::git_ops::get_commit_hash(&repo_path, &input).await?;
+            vec![sha]
+        };
 
-    eprintln!(
-        " ({} commit{})",
-        shas.len(),
-        if shas.len() == 1 { "" } else { "s" }
-    );
+        eprintln!(
+            " ({} commit{})",
+            shas.len(),
+            if shas.len() == 1 { "" } else { "s" }
+        );
 
-    // Extract patch metadata and build ReviewInput
-    let mut patches = Vec::new();
-    for (i, sha) in shas.iter().enumerate() {
-        let meta = sashiko::git_ops::extract_patch_metadata(&repo_path, sha)
-            .await
-            .with_context(|| format!("Failed to extract metadata for commit {}", sha))?;
-        patches.push(sashiko::worker::PatchInput {
-            index: (i + 1) as i64,
-            diff: meta.diff,
-            subject: Some(meta.subject),
-            author: Some(meta.author),
-            date: Some(meta.timestamp),
-            message_id: None,
-            commit_id: Some(sha.clone()),
-        });
-    }
+        // Extract patch metadata and build ReviewInput
+        let mut patches = Vec::new();
+        for (i, sha) in shas.iter().enumerate() {
+            let meta = sashiko::git_ops::extract_patch_metadata(&repo_path, sha)
+                .await
+                .with_context(|| format!("Failed to extract metadata for commit {}", sha))?;
+            patches.push(sashiko::worker::PatchInput {
+                index: (i + 1) as i64,
+                diff: meta.diff,
+                subject: Some(meta.subject),
+                author: Some(meta.author),
+                date: Some(meta.timestamp),
+                message_id: None,
+                commit_id: Some(sha.clone()),
+            });
+        }
 
-    let review_input = sashiko::worker::ReviewInput {
-        id: 0, // Local review, no DB ID
-        subject: patches
-            .first()
-            .and_then(|p| p.subject.clone())
-            .unwrap_or_else(|| input.clone()),
-        patches,
-    };
+        let review_input = sashiko::worker::ReviewInput {
+            id: 0, // Local review, no DB ID
+            subject: patches
+                .first()
+                .and_then(|p| p.subject.clone())
+                .unwrap_or_else(|| input.clone()),
+            patches,
+        };
 
-    let review_json =
-        serde_json::to_string(&review_input).context("Failed to serialize review input")?;
+        let review_json =
+            serde_json::to_string(&review_input).context("Failed to serialize review input")?;
 
-    // Locate sashiko-review binary
-    let review_bin = find_review_binary()?;
+        // Locate sashiko-review binary
+        let review_bin = find_review_binary()?;
 
-    // Build subprocess args
-    let baseline_ref = if let Some(b) = &baseline {
-        b.clone()
-    } else {
-        // Default: parent of first commit
-        let first_sha = &shas[0];
-        format!("{}^", first_sha)
-    };
+        // Build subprocess args
+        let baseline_ref = if let Some(b) = &baseline {
+            b.clone()
+        } else {
+            // Default: parent of first commit
+            let first_sha = &shas[0];
+            format!("{}^", first_sha)
+        };
 
-    let mut args = vec!["--baseline".to_string(), baseline_ref];
+        let mut args = vec!["--baseline".to_string(), baseline_ref];
 
-    if no_ai {
-        args.push("--no-ai".to_string());
-    }
-    if let Some(prompt) = &custom_prompt {
-        args.push("--custom-prompt".to_string());
-        args.push(prompt.clone());
-    }
+        if no_ai {
+            args.push("--no-ai".to_string());
+        }
+        if let Some(prompt) = &dynamic_prompt {
+            args.push("--custom-prompt".to_string());
+            args.push(prompt.clone());
+        }
 
-    eprint_phase(2, 4, "Starting review subprocess...");
-    eprintln!();
+        eprint_phase(2, 4, "Starting review subprocess...");
+        eprintln!();
 
-    // Spawn review subprocess
-    let mut child = tokio::process::Command::new(&review_bin)
-        .args(&args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .env("SASHIKO_LOG_PLAIN", "1")
-        .spawn()
-        .with_context(|| format!("Failed to start review binary: {:?}", review_bin))?;
+        // Spawn review subprocess
+        let mut child = tokio::process::Command::new(&review_bin)
+            .args(&args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .env("SASHIKO_LOG_PLAIN", "1")
+            .spawn()
+            .with_context(|| format!("Failed to start review binary: {:?}", review_bin))?;
 
-    // Write input to stdin
-    if let Some(mut stdin) = child.stdin.take() {
-        use tokio::io::AsyncWriteExt;
-        stdin
-            .write_all(format!("{}\n", review_json).as_bytes())
-            .await
-            .context("Failed to write to review subprocess stdin")?;
-        drop(stdin);
-    }
+        // Write input to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin
+                .write_all(format!("{}\n", review_json).as_bytes())
+                .await
+                .context("Failed to write to review subprocess stdin")?;
+            drop(stdin);
+        }
 
-    // Stream stderr for progress in a background task
-    let stderr = child.stderr.take();
-    let stderr_handle = tokio::spawn(async move {
-        if let Some(stderr) = stderr {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let reader = BufReader::new(stderr);
-            let mut lines = reader.lines();
-            let mut saw_applying = false;
-            let mut saw_ai_review = false;
-            while let Ok(Some(line)) = lines.next_line().await {
-                if !saw_applying && line.contains("Applying") {
-                    saw_applying = true;
-                    eprint_phase(2, 4, "Applying patches to worktree...");
-                    eprintln!();
-                }
-                if !saw_ai_review && line.contains("Starting AI review") {
-                    saw_ai_review = true;
-                    eprint_phase(3, 4, "AI review in progress...");
-                    eprintln!();
-                }
-                if line.contains("AI review completed") {
-                    eprint_phase(4, 4, "Review complete.");
-                    eprintln!();
+        // Stream stderr for progress in a background task
+        let stderr = child.stderr.take();
+        let stderr_handle = tokio::spawn(async move {
+            if let Some(stderr) = stderr {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                let mut saw_applying = false;
+                let mut saw_ai_review = false;
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if !saw_applying && line.contains("Applying") {
+                        saw_applying = true;
+                        eprint_phase(2, 4, "Applying patches to worktree...");
+                        eprintln!();
+                    }
+                    if !saw_ai_review && line.contains("Starting AI review") {
+                        saw_ai_review = true;
+                        eprint_phase(3, 4, "AI review in progress...");
+                        eprintln!();
+                    }
+                    if line.contains("AI review completed") {
+                        eprint_phase(4, 4, "Review complete.");
+                        eprintln!();
+                    }
                 }
             }
+        });
+
+        // Capture stdout
+        let output = child
+            .wait_with_output()
+            .await
+            .context("Failed to wait for review subprocess")?;
+
+        let _ = stderr_handle.await;
+
+        let exit_code = output.status.code().unwrap_or(1);
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+        if stdout.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "Review subprocess produced no output (exit code: {})",
+                exit_code
+            ));
         }
-    });
 
-    // Capture stdout
-    let output = child
-        .wait_with_output()
-        .await
-        .context("Failed to wait for review subprocess")?;
+        // Parse the review output
+        let result: Value =
+            serde_json::from_str(stdout.trim()).context("Failed to parse review output JSON")?;
 
-    let _ = stderr_handle.await;
-
-    let exit_code = output.status.code().unwrap_or(1);
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-
-    if stdout.trim().is_empty() {
-        return Err(anyhow::anyhow!(
-            "Review subprocess produced no output (exit code: {})",
-            exit_code
-        ));
-    }
-
-    // Parse the review output
-    let result: Value =
-        serde_json::from_str(stdout.trim()).context("Failed to parse review output JSON")?;
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&result)?);
+        match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+            OutputFormat::Text => {
+                print_local_review_results(&result, &input);
+            }
         }
-        OutputFormat::Text => {
-            print_local_review_results(&result, &input);
-        }
-    }
 
-    // Determine exit code based on findings
-    if let Some(err) = result.get("error").and_then(|e| e.as_str())
-        && !err.is_empty()
-    {
-        std::process::exit(3);
-    }
-    if let Some(review) = result.get("review")
-        && let Some(findings) = review.get("findings").and_then(|f| f.as_array())
-    {
-        let (c, h, _, _) = count_severities(findings);
-        if c > 0 || h > 0 {
-            std::process::exit(1);
+        // Determine exit code based on findings
+        let mut has_error = false;
+        if let Some(err) = result.get("error").and_then(|e| e.as_str())
+            && !err.is_empty()
+        {
+            has_error = true;
         }
-    }
+        let mut has_issues = false;
+        if let Some(review) = result.get("review")
+            && let Some(findings) = review.get("findings").and_then(|f| f.as_array())
+        {
+            let (c, h, m, l) = count_severities(findings);
+            if c > 0 || h > 0 || m > 0 || l > 0 {
+                has_issues = true;
+            }
+        }
+
+        if interactive && (has_error || has_issues) {
+            println!(
+                "\nIssues found. Please modify the code, or type a rebuttal here, then press Enter to re-run the review... (or Ctrl+C to exit)"
+            );
+            let mut rebuttal = String::new();
+            std::io::stdin().read_line(&mut rebuttal)?;
+            if !rebuttal.trim().is_empty() {
+                dynamic_prompt = Some(rebuttal.trim().to_string());
+            } else {
+                dynamic_prompt = None;
+            }
+            continue;
+        }
+
+        if has_error {
+            std::process::exit(3);
+        }
+        if let Some(review) = result.get("review")
+            && let Some(findings) = review.get("findings").and_then(|f| f.as_array())
+        {
+            let (c, h, _, _) = count_severities(findings);
+            if c > 0 || h > 0 {
+                std::process::exit(1);
+            }
+        }
+
+        break;
+    } // End of loop
 
     Ok(())
 }
@@ -1131,6 +1243,44 @@ fn print_findings_summary(label: &str, findings: &[Value], inline_review: Option
         "Critical: {} · High: {} · Medium: {} · Low: {}\n",
         c, h, m, l
     );
+
+    for f in findings {
+        let sev = f
+            .get("severity")
+            .and_then(|s| s.as_str())
+            .unwrap_or("Unknown");
+        let file = f.get("file").and_then(|s| s.as_str()).unwrap_or("");
+        let line = f.get("line").and_then(|l| l.as_i64()).unwrap_or(0);
+        let desc = f
+            .get("problem_description")
+            .and_then(|s| s.as_str())
+            .unwrap_or("");
+        let fix = f
+            .get("recommended_fix")
+            .and_then(|s| s.as_str())
+            .unwrap_or("");
+
+        let color = match sev.to_lowercase().as_str() {
+            "critical" | "high" => Color::Red,
+            "medium" => Color::Yellow,
+            "low" => Color::Cyan,
+            _ => Color::White,
+        };
+
+        let location = if !file.is_empty() {
+            format!("{}:{}: ", file, line)
+        } else {
+            "".to_string()
+        };
+
+        print_colored(color, &format!("  {}[{}] ", location, sev));
+        println!("{}", desc);
+        if !fix.is_empty() {
+            println!("    Fix: {}", fix);
+        }
+    }
+    println!();
+
     if let Some(inline) = inline_review
         && !inline.is_empty()
         && inline != "No issues found."

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -97,6 +97,15 @@ enum Commands {
         #[arg(default_value = "latest")]
         id: String,
     },
+    /// Cancel a pending review
+    Cancel {
+        /// ID of the patchset to cancel
+        id: i64,
+
+        /// Force cancel even if the review is already in progress
+        #[arg(long, short)]
+        force: bool,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -188,6 +197,7 @@ async fn run_command(
             per_page,
         } => handle_list(client, base_url, page, per_page, filter, format).await,
         Commands::Show { id } => handle_show(client, base_url, id, format).await,
+        Commands::Cancel { id, force } => handle_cancel(client, base_url, id, force, format).await,
     }
 }
 
@@ -395,6 +405,7 @@ async fn handle_list(
                         "Embargoed" => Color::Magenta,
                         "Failed" | "Error" | "Failed To Apply" => Color::Red,
                         "Pending" | "In Review" => Color::Yellow,
+                        "Cancelled" => Color::Red,
                         _ => Color::White,
                     };
 
@@ -681,6 +692,45 @@ async fn handle_show(
             "Failed to show patchset: {}",
             resp.status()
         ));
+    }
+
+    Ok(())
+}
+
+async fn handle_cancel(
+    client: &Client,
+    base_url: &str,
+    id: i64,
+    force: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let url = format!("{}/api/patchset/cancel?id={}&force={}", base_url, id, force);
+    let resp = client.post(&url).send().await?;
+
+    if resp.status().is_success() {
+        let result: serde_json::Value = resp.json().await?;
+        match format {
+            OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&result)?),
+            OutputFormat::Text => {
+                let status = result["status"].as_str().unwrap_or("");
+                if status == "cancelled" {
+                    print_colored(Color::Green, "Cancelled: ");
+                    println!("Patchset {} has been cancelled.", id);
+                } else {
+                    print_colored(Color::Yellow, "Not modified: ");
+                    println!(
+                        "{}",
+                        result["reason"]
+                            .as_str()
+                            .unwrap_or("Patchset could not be cancelled.")
+                    );
+                }
+            }
+        }
+    } else {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!("Cancel failed ({}): {}", status, text));
     }
 
     Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -3234,6 +3234,31 @@ impl Database {
         Ok(())
     }
 
+    pub async fn get_patchset_status(&self, id: i64) -> Result<Option<String>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT status FROM patchsets WHERE id = ?",
+                libsql::params![id],
+            )
+            .await?;
+        if let Some(row) = rows.next().await? {
+            Ok(Some(row.get(0)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn cancel_patchset(&self, id: i64, force: bool) -> Result<bool> {
+        let query = if force {
+            "UPDATE patchsets SET status = 'Cancelled' WHERE id = ? AND status IN ('Pending', 'Incomplete', 'In Review')"
+        } else {
+            "UPDATE patchsets SET status = 'Cancelled' WHERE id = ? AND status IN ('Pending', 'Incomplete')"
+        };
+        let count = self.conn.execute(query, libsql::params![id]).await?;
+        Ok(count > 0)
+    }
+
     pub async fn restart_failed_reviews(&self) -> Result<u64> {
         let count = self.conn.execute(
             "UPDATE patchsets SET status = 'Pending', failed_reason = NULL WHERE status IN ('Failed', 'Failed To Apply')",

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -176,72 +176,23 @@ impl FetchAgent {
                     // It's a range
                     let range = &commit_or_range;
 
-                    // 1. Count commits
-                    let count_output = Command::new("git")
-                        .current_dir(&self.repo_path)
-                        .args(["-c", "safe.bareRepository=all"])
-                        .args(["rev-list", "--count", range])
-                        .output()
-                        .await;
-
-                    let count = match count_output {
-                        Ok(output) if output.status.success() => {
-                            String::from_utf8_lossy(&output.stdout)
-                                .trim()
-                                .parse::<u32>()
-                                .unwrap_or(0)
-                        }
-                        _ => {
+                    let shas = match crate::git_ops::resolve_git_range(&self.repo_path, range).await
+                    {
+                        Ok(shas) => shas,
+                        Err(e) => {
                             let _ = self
                                 .main_tx
                                 .send(Event::IngestionFailed {
                                     article_id: range.clone(),
-                                    error: "Failed to resolve git range count".to_string(),
+                                    error: format!("Failed to resolve git range: {}", e),
                                 })
                                 .await;
                             continue;
                         }
                     };
+                    let count = shas.len() as u32;
 
-                    if count == 0 {
-                        let _ = self
-                            .main_tx
-                            .send(Event::IngestionFailed {
-                                article_id: range.clone(),
-                                error: "Git range is empty".to_string(),
-                            })
-                            .await;
-                        continue;
-                    }
-
-                    // 2. Get list of SHAs
-                    let list_output = Command::new("git")
-                        .current_dir(&self.repo_path)
-                        .args(["-c", "safe.bareRepository=all"])
-                        .args(["rev-list", "--reverse", range])
-                        .output()
-                        .await;
-
-                    let shas = match list_output {
-                        Ok(output) if output.status.success() => {
-                            String::from_utf8_lossy(&output.stdout)
-                                .lines()
-                                .map(|s| s.to_string())
-                                .collect::<Vec<_>>()
-                        }
-                        _ => {
-                            let _ = self
-                                .main_tx
-                                .send(Event::IngestionFailed {
-                                    article_id: range.clone(),
-                                    error: "Failed to resolve git range SHAs".to_string(),
-                                })
-                                .await;
-                            continue;
-                        }
-                    };
-
-                    // 3. Process each SHA
+                    // Process each SHA
                     for (i, sha) in shas.iter().enumerate() {
                         match self.extract_patch(sha, range, (i + 1) as u32, count).await {
                             Ok(mut event) => {
@@ -467,80 +418,18 @@ impl FetchAgent {
         index: u32,
         total: u32,
     ) -> Result<Event> {
-        // Resolve parent to use as base_commit
-        let parent_output = Command::new("git")
-            .current_dir(&self.repo_path)
-            .args(["rev-parse", &format!("{}^", commit)])
-            .output()
-            .await?;
-
-        let base_commit = if parent_output.status.success() {
-            Some(
-                String::from_utf8_lossy(&parent_output.stdout)
-                    .trim()
-                    .to_string(),
-            )
-        } else {
-            warn!(
-                "Failed to resolve parent for {}, using commit as base",
-                commit
-            );
-            Some(commit.to_string())
-        };
-
-        // Format: AuthorName%nAuthorEmail%nSubject%nBody...%n---SASHIKO-END-HEADER---%nDiff...
-        let format = "format:%an%n%ae%n%s%n%b%n---SASHIKO-END-HEADER---%n";
-
-        let output = Command::new("git")
-            .current_dir(&self.repo_path)
-            .args(["show", &format!("--format={}", format), commit])
-            .output()
-            .await?;
-
-        if !output.status.success() {
-            return Err(anyhow!(
-                "git show failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
-        }
-
-        let raw = String::from_utf8_lossy(&output.stdout).to_string();
-        let parts: Vec<&str> = raw.split("---SASHIKO-END-HEADER---\n").collect();
-
-        if parts.len() < 2 {
-            return Err(anyhow!("Failed to parse git show output structure"));
-        }
-
-        let header_part = parts[0];
-        let diff = parts[1..].join("---SASHIKO-END-HEADER---\n"); // Rejoin just in case
-
-        let mut lines = header_part.lines();
-        let author_name = lines.next().unwrap_or_default().trim();
-        let author_email = lines.next().unwrap_or("unknown@localhost").trim();
-        let subject = lines.next().unwrap_or("No Subject").trim();
-
-        // Body is the rest
-        let body: Vec<&str> = lines.collect();
-        let message = body.join("\n").trim().to_string();
-
-        let author = if author_name.is_empty() || author_name.to_lowercase() == "unknown" {
-            author_email.to_string()
-        } else {
-            format!("{} <{}>", author_name, author_email)
-        };
+        let meta = crate::git_ops::extract_patch_metadata(&self.repo_path, commit).await?;
 
         Ok(Event::PatchSubmitted {
             group: "git-fetch".to_string(),
             article_id: article_id.to_string(),
             message_id: String::new(), // Set by caller
-            subject: subject.to_string(),
-            author,
-            message,
-            diff,
-            base_commit,
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)?
-                .as_secs() as i64,
+            subject: meta.subject,
+            author: meta.author,
+            message: meta.message,
+            diff: meta.diff,
+            base_commit: meta.base_commit,
+            timestamp: meta.timestamp,
             index,
             total,
         })

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -789,6 +789,122 @@ pub async fn git_tag(repo_path: &Path) -> Result<String> {
     }
 }
 
+/// Metadata extracted from a single git commit.
+pub struct PatchMetadata {
+    pub author: String,
+    pub subject: String,
+    pub message: String,
+    pub diff: String,
+    pub base_commit: Option<String>,
+    pub timestamp: i64,
+}
+
+/// Resolve a git range (e.g. "HEAD~3..HEAD") to an ordered list of commit SHAs.
+pub async fn resolve_git_range(repo_path: &Path, range: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["-c", "safe.bareRepository=all"])
+        .args(["rev-list", "--reverse", range])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Failed to resolve git range '{}': {}",
+            range,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let shas: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect();
+
+    if shas.is_empty() {
+        return Err(anyhow!("Git range '{}' is empty", range));
+    }
+
+    Ok(shas)
+}
+
+/// Extract patch metadata from a commit using `git show`.
+pub async fn extract_patch_metadata(repo_path: &Path, commit: &str) -> Result<PatchMetadata> {
+    // Resolve parent to use as base_commit
+    let parent_output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["rev-parse", &format!("{}^", commit)])
+        .output()
+        .await?;
+
+    let base_commit = if parent_output.status.success() {
+        Some(
+            String::from_utf8_lossy(&parent_output.stdout)
+                .trim()
+                .to_string(),
+        )
+    } else {
+        warn!(
+            "Failed to resolve parent for {}, using commit as base",
+            commit
+        );
+        Some(commit.to_string())
+    };
+
+    let format = "format:%an%n%ae%n%s%n%b%n---SASHIKO-END-HEADER---%n";
+
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["show", &format!("--format={}", format), commit])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git show failed for {}: {}",
+            commit,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let parts: Vec<&str> = raw.split("---SASHIKO-END-HEADER---\n").collect();
+
+    if parts.len() < 2 {
+        return Err(anyhow!("Failed to parse git show output for {}", commit));
+    }
+
+    let header_part = parts[0];
+    let diff = parts[1..].join("---SASHIKO-END-HEADER---\n");
+
+    let mut lines = header_part.lines();
+    let author_name = lines.next().unwrap_or_default().trim();
+    let author_email = lines.next().unwrap_or("unknown@localhost").trim();
+    let subject = lines.next().unwrap_or("No Subject").trim();
+
+    let body: Vec<&str> = lines.collect();
+    let message = body.join("\n").trim().to_string();
+
+    let author = if author_name.is_empty() || author_name.to_lowercase() == "unknown" {
+        author_email.to_string()
+    } else {
+        format!("{} <{}>", author_name, author_email)
+    };
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs() as i64;
+
+    Ok(PatchMetadata {
+        author,
+        subject: subject.to_string(),
+        message,
+        diff,
+        base_commit,
+        timestamp,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -653,16 +653,24 @@ impl Reviewer {
             // Cleanup worktree here since we kept it alive for reuse
             let _ = worktree.remove().await;
 
-            let final_status = if review_success {
-                ReviewStatus::Reviewed.as_str().to_string()
+            let current_status = ctx.db.get_patchset_status(patchset_id).await.ok().flatten();
+            if current_status.as_deref() == Some(ReviewStatus::Cancelled.as_str()) {
+                info!(
+                    "Patchset {} was cancelled during review, preserving status",
+                    patchset_id
+                );
             } else {
-                ReviewStatus::Failed.as_str().to_string()
-            };
+                let final_status = if review_success {
+                    ReviewStatus::Reviewed.as_str().to_string()
+                } else {
+                    ReviewStatus::Failed.as_str().to_string()
+                };
 
-            let _ = ctx
-                .db
-                .update_patchset_status(patchset_id, &final_status)
-                .await;
+                let _ = ctx
+                    .db
+                    .update_patchset_status(patchset_id, &final_status)
+                    .await;
+            }
         } else {
             // No baseline found
             warn!("No working baseline found for patchset {}", patchset_id);

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -60,6 +60,13 @@ pub struct PatchInput {
     pub commit_id: Option<String>,
 }
 
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ReviewInput {
+    pub id: i64,
+    pub subject: String,
+    pub patches: Vec<PatchInput>,
+}
+
 fn validate_inline_format(content: &str) -> std::result::Result<(), String> {
     if content.lines().any(|l| l.trim_start().starts_with("```")) {
         return Err("The output contains Markdown code blocks ('```'). It must be plain text as per `inline-template.md`.".to_string());


### PR DESCRIPTION
This series enhances the sashiko-cli tool.
The primary focus is on  improving observability, surfacing actionable feedback directly in 
the terminal, and introducing an agentic loop for rapid patch iteration.

Key improvements:

Observability: Added a --watch (-w) flag to show. This allows 
users to track asynchronous review progress via linear status 
updates, eliminating the need for manual polling.

Visibility Parity: The CLI's text output now provides parity with 
the WebUI by surfacing detailed finding locations (file:line) and 
suggested fixes directly in the terminal.

Re-review: Introduced a rerun command to easily re-queue 
patchsets after addressing feedback or to trigger fresh reviews.

Agentic Interaction: Added an --interactive flag to the local 
command. This enables a "review-fix-re-run" loop where the CLI 
pauses on findings, allows for code modifications or rebuttals, 
and automatically restarts the review process.

Technical Cleanliness: Includes minor clippy fixes and updates to 
the CLI design documentation (DESIGN_CLI_TOOL_V2.md) to maintain 
alignment between implementation and architecture.

These changes bridge the gap between passive automated review and 
active local development, making Sashiko a more effective tool for 
pre-submission validation.

CC: @acmel 