### PR TITLE
Add input subsystem to email_policy.toml

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -89,3 +89,8 @@ cc = ["linux-pci@vger.kernel.org"]
 lists = ["linux-watchdog@vger.kernel.org"]
 reply_to_author = true
 cc = ["linux-watchdog@vger.kernel.org"]
+
+[subsystems.linux-input]
+lists = ["linux-input@vger.kernel.org"]
+reply_to_author = true
+cc = ["dmitry.torokhov@gmail.com", "linux-input@vger.kernel.org"]


### PR DESCRIPTION
Add the input subsystem to the email policy, sending replies to authors, to the mailing list, and to myself.

This also covers HID patches since we are sharing the same mailing list.