### PR TITLE
WIP: Fix Claude provider bugs, add Vertex AI backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -215,19 +215,20 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -374,11 +375,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -448,7 +449,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -767,6 +768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +876,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +895,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -894,7 +916,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -957,6 +979,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -1059,6 +1087,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,12 +1146,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1123,9 +1213,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1153,6 +1254,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1448,6 +1555,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1469,6 +1577,84 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "google-cloud-auth"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd4f8c914f230834828771125168eaa39bc6602e32cb0316ceeff2add10d449"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "reqwest",
+ "rustc_version",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d597e9e4758fc778a60d8c28a8677629675ae40d8652ec000ae5f53f5ae7ec"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "pin-project",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b177796075b7bfc02bf2e405db665ee850a924fa44cedfc5282b473c5ab203"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5daa3084991800bcc5333d7e77bb19259a02b34ee35f35c27b49d602732306e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1666,7 +1852,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1769,6 +1964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,7 +2061,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -2014,6 +2218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2268,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2170,6 +2381,21 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
 ]
 
 [[package]]
@@ -2488,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2734,7 +2960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2902,7 +3128,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -2923,7 +3149,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2995,6 +3221,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,12 +3270,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3078,9 +3341,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3099,11 +3362,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3126,7 +3390,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3229,11 +3493,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
@@ -3296,7 +3561,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.9",
@@ -3319,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3330,7 +3595,7 @@ checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3342,7 +3607,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3382,6 +3647,7 @@ dependencies = [
  "fastrand",
  "flate2",
  "futures",
+ "google-cloud-auth",
  "grep",
  "grep-matcher",
  "grep-regex",
@@ -3394,7 +3660,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "termcolor",
  "thiserror 2.0.18",
@@ -3419,6 +3685,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,7 +3721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3574,14 +3864,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3607,6 +3939,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3842,6 +4183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3901,9 +4243,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3928,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3974,7 +4316,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4323,9 +4665,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -4365,6 +4707,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "sashiko"
 [features]
 default = ["bedrock"]
 bedrock = ["aws-config", "aws-sdk-bedrockruntime", "aws-smithy-types"]
+vertex = ["google-cloud-auth"]
 
 [dependencies]
 anyhow = "1.0.100"
@@ -18,6 +19,7 @@ axum = "0.8.8"
 chrono = "0.4.43"
 clap = { version = "4.5.54", features = ["derive", "env"] }
 config = "0.15.19"
+google-cloud-auth = { version = "1.10", optional = true }
 fastrand = "2.3.0"
 flate2 = "1.1.9"
 futures = "0.3.31"

--- a/README.md
+++ b/README.md
@@ -123,17 +123,20 @@ Running an automated review system like Sashiko can be computationally expensive
     [ai]
     provider = "claude"
     model = "claude-sonnet-4-6"
-    max_input_tokens = 950000
+    max_input_tokens = 40000
 
     [ai.claude]
     prompt_caching = true
+    # thinking = "enabled"    # Optional: enable extended thinking
+    # effort = "high"         # Optional: thinking effort level
     ```
 
     **Features**:
     - Automatic prompt caching (5-minute TTL) reduces costs for repeated context
     - Full tool/function calling support for git operations
     - Automatic retry logic for rate limits and API overload
-    - 1M context window for claude-sonnet-4-6 (use max_input_tokens = 950000 for safety margin)
+    - 200K context window for Claude models (use max_input_tokens = 40000 for cost-conscious defaults)
+    - Extended thinking support via `thinking` and `effort` settings
 
     ### AWS Bedrock Setup
 
@@ -157,7 +160,7 @@ Running an automated review system like Sashiko can be computationally expensive
     [ai]
     provider = "bedrock"
     model = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
-    max_input_tokens = 950000
+    max_input_tokens = 40000
 
     [ai.bedrock]
     region = "us-east-1"  # Optional, falls back to AWS SDK defaults
@@ -168,6 +171,43 @@ Running an automated review system like Sashiko can be computationally expensive
     - No API key needed — uses standard AWS IAM authentication
     - Supports cross-region inference profiles (e.g., `us.anthropic.claude-*`)
     - Full tool/function calling support for git operations
+
+    ### Google Cloud Vertex AI Setup
+
+    Sashiko supports Google Cloud Vertex AI, which provides access to Claude models (and potentially other model families) via Google Cloud infrastructure. Build with `--features vertex`.
+
+    **Prerequisites**: Enable the Vertex AI API and model access in the [Vertex AI Model Garden](https://cloud.google.com/model-garden) for your desired model and region.
+
+    **Configure GCP credentials**:
+    ```bash
+    gcloud auth application-default login
+    ```
+
+    **Configure environment**:
+    ```bash
+    export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+    export CLOUD_ML_REGION="us-east5"  # or "global" for global endpoints
+    ```
+
+    **Update Settings.toml**:
+    ```toml
+    [ai]
+    provider = "vertex"
+    model = "claude-sonnet-4-6"
+    max_input_tokens = 40000
+
+    [ai.vertex]
+    prompt_caching = true
+    # project_id = "my-gcp-project"  # Falls back to ANTHROPIC_VERTEX_PROJECT_ID
+    # region = "us-east5"            # Falls back to CLOUD_ML_REGION
+    ```
+
+    **Features**:
+    - Model-agnostic routing layer — currently supports Claude, extensible to other model families
+    - No API key needed — uses Google Cloud Application Default Credentials (ADC)
+    - Supports global, multi-region, and regional endpoints
+    - 1M context window for Claude Opus 4.7/4.6 and Sonnet 4.6 on Vertex
+    - Full tool/function calling and prompt caching support
 
 3.  **Build**:
     ```bash

--- a/Settings.toml
+++ b/Settings.toml
@@ -30,14 +30,33 @@ max_input_tokens = 900000
 max_interactions = 50
 temperature = 1.0
 
+# To use Claude API directly:
+# provider = "claude"
+# model = "claude-sonnet-4-6"
+# max_input_tokens = 40000
+# max_interactions = 50
+
 # To use Claude Code CLI (fixed-cost subscription, no API key needed):
 # provider = "claude-cli"
 # model = "claude-sonnet-4-6"
-# max_input_tokens = 180000
+# max_input_tokens = 40000
 # max_interactions = 150
+
+# To use Claude via Google Cloud Vertex AI (requires --features vertex):
+# provider = "vertex"
+# model = "claude-sonnet-4-6"
+# max_input_tokens = 40000
+# max_interactions = 50
 
 [ai.claude]
 prompt_caching = true
+# thinking = "enabled"    # Enable extended thinking (or "adaptive" for Sonnet 4.6+)
+# effort = "high"         # Thinking effort: "low", "medium", "high"
+
+# [ai.vertex]
+# project_id = "my-gcp-project"  # Or set ANTHROPIC_VERTEX_PROJECT_ID env var
+# region = "us-east5"            # Or set CLOUD_ML_REGION env var (default: "us-east5")
+# prompt_caching = true
 
 [server]
 host = "::"

--- a/designs/DESIGN_CLAUDE_PROVIDER.md
+++ b/designs/DESIGN_CLAUDE_PROVIDER.md
@@ -1,0 +1,124 @@
+# DESIGN: Claude Provider
+
+## Context
+
+Sashiko accesses Claude models through multiple paths: the direct Anthropic
+Messages API, the Claude Code CLI, AWS Bedrock (Converse API), and Google
+Cloud Vertex AI (rawPredict). This document covers the direct API and CLI
+providers. Vertex AI and Bedrock have their own design documents.
+
+## Architecture
+
+### Direct API (`src/ai/claude.rs`)
+
+`ClaudeClient` sends HTTP requests to the Anthropic Messages API
+(`https://api.anthropic.com/v1/messages`). The client handles:
+
+- Request/response translation between Sashiko's generic `AiRequest`/`AiResponse`
+  and Claude's wire format (`ClaudeRequest`/`ClaudeResponse`)
+- Prompt caching via ephemeral cache control markers
+- Extended thinking via `ThinkingConfig`
+- Rate limit and overload retry signaling
+
+#### Wire Format Types
+
+All Claude-compatible providers (direct API, Vertex AI) share these types:
+
+| Type | Purpose |
+|------|---------|
+| `ClaudeRequest` | Top-level request body (model, messages, system, tools, thinking) |
+| `ClaudeMessage` | A message with role and content blocks |
+| `ClaudeContent` | Tagged enum: Text, Thinking, ToolUse, ToolResult |
+| `ClaudeResponse` | Response with content blocks and usage |
+| `ThinkingConfig` | Optional thinking type and effort level |
+| `SystemBlock` | System prompt text with optional cache control |
+| `ClaudeTool` | Tool definition with input schema |
+| `ClaudeError` | Typed errors: rate limit, overload, invalid request, auth |
+
+#### Translation Functions
+
+These are `pub` for reuse by Vertex AI:
+
+- `translate_ai_request()` -- converts `AiRequest` to `ClaudeRequest`
+- `translate_ai_response()` -- converts `ClaudeResponse` to `AiResponse`
+- `apply_cache_control()` -- adds ephemeral cache markers to last system/tool/message
+- `estimate_tokens_generic()` -- token estimation using cl100k_base tokenizer
+
+#### ThinkingConfig Handling
+
+The `ThinkingConfig` struct has two optional fields: `type` (renamed via serde
+from `thinking`) and `effort`. Both use `skip_serializing_if = "Option::is_none"`.
+
+The outer `ClaudeRequest.thinking` field is `Option<ThinkingConfig>` with
+`skip_serializing_if = "Option::is_none"`. When both inner fields are None,
+the entire config is set to `None` to avoid emitting an empty `"thinking": {}`
+object, which the API rejects.
+
+#### Authentication
+
+Uses `ANTHROPIC_API_KEY` or `LLM_API_KEY` environment variables. Sent as
+`x-api-key` header alongside `anthropic-version: 2023-06-01`.
+
+### Prompt Caching
+
+Cache control markers are applied to the last element of each category:
+1. Last system block
+2. Last tool definition
+3. Last message content block
+
+The Anthropic API provides a 5-minute TTL ephemeral cache. Cached tokens
+appear in the response usage as `cache_read_input_tokens` and
+`cache_creation_input_tokens`.
+
+### Claude CLI Provider (`src/ai/claude_cli.rs`)
+
+`ClaudeCliProvider` shells out to the `claude --print` command, which runs
+in text-completion mode (no tools, no file access, no session persistence).
+The CLI reads a prompt from stdin and writes JSON to stdout.
+
+#### Prompt Construction
+
+`build_prompt()` constructs a text prompt with XML-style tags:
+- `<system>` for system prompts
+- `<user>`, `<assistant>`, `<tool_result>`, `<tool_call>` for messages
+- `<available_tools>` for tool definitions
+- `RESPONSE FORMAT` instructions for JSON output
+
+JSON format instructions are emitted when:
+1. Tools are present (tool_calls/content format)
+2. `response_format` is `AiResponseFormat::Json` without tools (schema-aware)
+
+#### Error Handling
+
+The CLI writes JSON to stdout even on non-zero exit. The provider reads stdout
+before checking exit status and extracts the `result` field from the JSON
+for structured error messages.
+
+## Settings
+
+```toml
+[ai.claude]
+prompt_caching = true              # Default: true
+max_tokens = 4096                  # Max output tokens per request
+base_url = "https://..."           # Override API endpoint
+thinking = "enabled"               # "enabled" or "adaptive"
+effort = "high"                    # "low", "medium", "high"
+```
+
+## Error Handling
+
+| HTTP Status | Error Type | Retry Strategy |
+|-------------|-----------|----------------|
+| 429 | RateLimitExceeded | Use Retry-After header, default 60s |
+| 529 | OverloadedError | Exponential backoff starting at 5s |
+| 400 | InvalidRequest | No retry |
+| 401/403 | AuthenticationError | No retry |
+
+## Testing
+
+Tests are in `src/ai/claude.rs` and `src/ai/claude_cli.rs`:
+- ThinkingConfig serialization (omitted when both None, present when set)
+- Request translation (system, user, assistant, tool calls, tool results)
+- Response translation (text, tool calls, thinking, usage with cache)
+- Cache control (applied when enabled, absent when disabled)
+- `build_prompt()` format instructions (with/without tools, with/without JSON format)

--- a/designs/DESIGN_VERTEX_PROVIDER.md
+++ b/designs/DESIGN_VERTEX_PROVIDER.md
@@ -145,10 +145,15 @@ that the `google-cloud-auth` crate discovers automatically.
 
 ```bash
 export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
-export CLOUD_ML_REGION="us-east5"  # or "global" for global endpoints
+export CLOUD_ML_REGION="us-east5"  # Regional endpoint (recommended)
 ```
 
 These can alternatively be set in `[ai.vertex]` in Settings.toml.
+
+**Note on endpoint selection**: Regional endpoints (e.g., `us-east5`) are
+recommended over `global`. The global endpoint may not be available for all
+projects or models and can return 404 even when the model is enabled.
+Regional endpoints have a 10% pricing premium but provide reliable routing.
 
 ### Settings.toml Configuration
 
@@ -180,6 +185,9 @@ cargo build --features vertex --release
 | 403 Forbidden | Model not enabled | Enable model in Vertex AI Model Garden console |
 | 403 Permission denied | Missing IAM role | Grant `roles/aiplatform.user` to your principal |
 | "Unsupported model family" | Model prefix not recognized | Check model name starts with `claude-` |
+| 404 Not Found on global endpoint | Global endpoint not available for project/model | Use a regional endpoint (e.g., `us-east5`) instead of `"global"`. Global endpoint availability depends on project configuration and model enablement. |
+| 404 with `@version` suffix in model name | Versioned model IDs not supported for all endpoints | Use the base model name without version suffix (e.g., `claude-sonnet-4-6` not `claude-sonnet-4-6@20250514`) |
+| "quota_exceeded" or "API not enabled" after ADC warning | ADC account lacks `serviceusage.services.use` on project | Run `gcloud auth application-default set-quota-project PROJECT_ID` or grant the permission |
 
 ## Developer Guide: Adding a New Model Family
 
@@ -271,3 +279,20 @@ Requires GCP credentials. Manual testing steps:
 2. Export `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION`
 3. Run `cargo run --features vertex` and submit a patch for review
 4. Verify response in logs (token counts, no errors)
+
+## Verified Behavior
+
+End-to-end integration test performed on 2026-05-07:
+
+- **Region**: `us-east5` (regional endpoint; `global` returned 404 for this project)
+- **Model**: `claude-sonnet-4-6` (no version suffix)
+- **Auth**: `google-cloud-auth` ADC via `gcloud auth application-default login`
+- **Result**: Full multi-stage review completed successfully
+
+Key observations:
+- Global endpoint (`global-aiplatform.googleapis.com`) returned 404; regional
+  endpoint (`us-east5-aiplatform.googleapis.com`) worked immediately
+- Model name with `@version` suffix (e.g., `claude-sonnet-4-6@20250514`) also
+  returned 404; bare model name worked
+- ADC quota project warning did not block API access
+- Prompt caching active and growing across successive calls within a review

--- a/designs/DESIGN_VERTEX_PROVIDER.md
+++ b/designs/DESIGN_VERTEX_PROVIDER.md
@@ -1,0 +1,273 @@
+# DESIGN: Vertex AI Provider
+
+## Context
+
+Google Cloud Vertex AI is GCP's managed model hosting platform, equivalent
+to AWS Bedrock. It provides access to Claude, Gemini, and other model
+families through Google Cloud infrastructure with IAM-based authentication.
+
+Unlike Bedrock's unified Converse API, Vertex AI uses per-publisher wire
+formats: Claude models use `rawPredict` with Claude's native Messages API
+format, while Gemini models use `generateContent` with Gemini's format.
+
+The Vertex provider is a model-agnostic routing layer that handles shared
+concerns (authentication, endpoint construction) and delegates wire-format
+translation to existing provider modules.
+
+## Architecture
+
+```
+AiRequest
+    |
+    v
+VertexClient
+    |
+    +-- detect_model_family(model_name)
+    |       |
+    |       +-- Claude  --> claude::translate_ai_request()
+    |       |                  --> VertexClaudeRequest (no model, + anthropic_version)
+    |       |                  --> HTTP POST rawPredict
+    |       |                  --> claude::translate_ai_response()
+    |       |
+    |       +-- Gemini  --> (future: gemini translation functions)
+    |       |                  --> HTTP POST generateContent
+    |       |
+    |       +-- Others  --> (future: per-publisher translation)
+    |
+    +-- Google OAuth (ADC) --> Authorization: Bearer {token}
+    |
+    v
+AiResponse
+```
+
+### Comparison with Bedrock
+
+| Aspect | Bedrock (AWS) | Vertex AI (GCP) |
+|--------|--------------|-----------------|
+| Wire format | Unified Converse API (all models) | Per-publisher (rawPredict, generateContent) |
+| Auth | AWS IAM SDK (aws-config crate) | Google OAuth ADC (google-cloud-auth crate) |
+| Code reuse from providers | 0% -- full custom translation | ~95% -- reuses existing translation functions |
+| Model-agnostic | Yes (Converse handles all) | Yes (routing layer dispatches per family) |
+| Feature flag | `bedrock` | `vertex` |
+| Dependencies | 3 AWS SDK crates | 1 auth crate (google-cloud-auth) |
+
+### Model Family Detection
+
+The `detect_model_family()` function maps model names to families:
+
+```rust
+enum ModelFamily {
+    Claude,   // claude-* --> publishers/anthropic, rawPredict
+    // Future:
+    // Gemini, // gemini-* --> publishers/google, generateContent
+    // Llama,  // llama-*  --> publishers/meta, rawPredict
+}
+```
+
+### Shared Auth Layer
+
+All model families use the same authentication: Google Cloud Application
+Default Credentials (ADC) via the `google-cloud-auth` crate. The crate
+handles credential discovery, token refresh, and caching internally.
+
+Token acquisition:
+1. `Builder::default().build_access_token_credentials()` at construction
+2. `credentials.access_token().await?.token` per request
+3. Sent as `Authorization: Bearer {token}` header
+
+## Supported Model Families
+
+### Claude (implemented)
+
+| Property | Value |
+|----------|-------|
+| Publisher | `anthropic` |
+| API method | `rawPredict` |
+| Wire format | Claude Messages API (same as direct API) |
+| Request wrapper | `VertexClaudeRequest` (no `model`, adds `anthropic_version`) |
+| Translation | Reuses `claude::translate_ai_request/response()` |
+
+Vertex API differences from direct Claude API:
+1. `model` is NOT in the request body -- specified in URL only
+2. `anthropic_version: "vertex-2023-10-16"` is in the request body (not a header)
+3. Auth: Bearer token (not `x-api-key`)
+4. No `anthropic-version` header
+
+Context window on Vertex:
+- 1M tokens: Claude Opus 4.7, Opus 4.6, Sonnet 4.6
+- 200K tokens: Sonnet 4.5, Sonnet 4, Haiku 4.5, older models
+
+### Gemini (future)
+
+The existing `gemini.rs` handles the Gemini wire format. Adding Gemini on
+Vertex requires:
+1. Making gemini.rs translation functions `pub`
+2. Adding `ModelFamily::Gemini` variant
+3. Adding the dispatch branch in `generate_content()`
+4. Using `publishers/google` and `generateContent` in endpoint URL
+
+No structural changes to the Vertex provider needed.
+
+## Endpoint Types
+
+Vertex AI offers three endpoint types, with pricing implications:
+
+| Type | Region value | URL pattern | Premium |
+|------|-------------|-------------|---------|
+| Global (recommended) | `"global"` | `https://global-aiplatform.googleapis.com/...` | None |
+| Multi-region | `"us"` or `"eu"` | `https://aiplatform.{region}.rep.googleapis.com/...` | 10% |
+| Regional | e.g. `"us-east5"` | `https://{region}-aiplatform.googleapis.com/...` | 10% |
+
+Full URL pattern:
+```
+{base}/v1/projects/{PROJECT}/locations/{REGION}/publishers/{PUBLISHER}/models/{MODEL}:{METHOD}
+```
+
+## User Setup Guide
+
+### Prerequisites
+
+1. A Google Cloud project with billing enabled
+2. Vertex AI API enabled: `gcloud services enable aiplatform.googleapis.com`
+3. Model access enabled in the [Vertex AI Model Garden](https://cloud.google.com/model-garden)
+4. `gcloud` CLI installed
+
+### Authentication
+
+```bash
+gcloud auth application-default login
+```
+
+This creates credentials at `~/.config/gcloud/application_default_credentials.json`
+that the `google-cloud-auth` crate discovers automatically.
+
+### Environment Variables
+
+```bash
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+export CLOUD_ML_REGION="us-east5"  # or "global" for global endpoints
+```
+
+These can alternatively be set in `[ai.vertex]` in Settings.toml.
+
+### Settings.toml Configuration
+
+```toml
+[ai]
+provider = "vertex"
+model = "claude-sonnet-4-6"
+max_input_tokens = 40000
+
+[ai.vertex]
+# project_id = "my-gcp-project"  # Falls back to ANTHROPIC_VERTEX_PROJECT_ID
+# region = "us-east5"            # Falls back to CLOUD_ML_REGION
+prompt_caching = true
+# thinking = "enabled"
+# effort = "high"
+```
+
+### Build
+
+```bash
+cargo build --features vertex --release
+```
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Failed to initialize Google Cloud credentials" | No ADC found | Run `gcloud auth application-default login` |
+| 403 Forbidden | Model not enabled | Enable model in Vertex AI Model Garden console |
+| 403 Permission denied | Missing IAM role | Grant `roles/aiplatform.user` to your principal |
+| "Unsupported model family" | Model prefix not recognized | Check model name starts with `claude-` |
+
+## Developer Guide: Adding a New Model Family
+
+To add a new model publisher (e.g., Llama via Meta):
+
+### Step 1: Add ModelFamily variant
+
+In `src/ai/vertex.rs`:
+```rust
+enum ModelFamily {
+    Claude,
+    Gemini,
+    Llama,  // New
+}
+```
+
+### Step 2: Update detection
+
+```rust
+fn detect_model_family(model: &str) -> Result<ModelFamily> {
+    if model.starts_with("claude") { Ok(ModelFamily::Claude) }
+    else if model.starts_with("gemini") { Ok(ModelFamily::Gemini) }
+    else if model.starts_with("llama") { Ok(ModelFamily::Llama) }  // New
+    else { bail!("Unsupported model family: {}", model) }
+}
+```
+
+### Step 3: Define endpoint info
+
+```rust
+fn endpoint_info(family: ModelFamily) -> EndpointInfo {
+    match family {
+        ModelFamily::Claude => EndpointInfo {
+            publisher: "anthropic",
+            method: "rawPredict",
+        },
+        ModelFamily::Llama => EndpointInfo {  // New
+            publisher: "meta",
+            method: "rawPredict",
+        },
+    }
+}
+```
+
+### Step 4: Implement or reuse translation
+
+If the model uses a wire format already supported by an existing provider
+module, make that module's translation functions `pub` and reuse them.
+Otherwise, implement new translation functions.
+
+### Step 5: Add dispatch branch
+
+```rust
+async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+    match self.model_family {
+        ModelFamily::Claude => self.generate_claude(request).await,
+        ModelFamily::Llama => self.generate_llama(request).await,  // New
+    }
+}
+```
+
+### Step 6: Add tests
+
+- Model family detection test
+- Endpoint URL construction test
+- Request serialization test (if new wire format)
+
+### Step 7: Update documentation
+
+- Update this design doc with the new family entry
+- Add setup instructions to README.md
+- Add commented example to Settings.toml
+
+## Testing Strategy
+
+### Unit Tests (`src/ai/vertex.rs`)
+
+- Model family detection (Claude, unsupported)
+- Endpoint URL construction (global, regional, multi-region us/eu)
+- VertexClaudeRequest serialization (no model field, has anthropic_version)
+- Request conversion from translate_ai_request output
+- Context window detection (1M vs 200K models)
+
+### Integration Testing
+
+Requires GCP credentials. Manual testing steps:
+
+1. Set `provider = "vertex"` and `model = "claude-sonnet-4-6"` in Settings.toml
+2. Export `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION`
+3. Run `cargo run --features vertex` and submit a patch for review
+4. Verify response in logs (token counts, no errors)

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -12,7 +12,7 @@ pub fn fmt_thousands(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
     for (i, c) in s.chars().enumerate() {
-        if i > 0 && (s.len() - i) % 3 == 0 {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
             result.push('.');
         }
         result.push(c);
@@ -70,13 +70,13 @@ impl CachingAiProvider {
                 libsql::params![cutoff],
             )
             .await;
-        if let Ok(reaped) = result {
-            if reaped > 0 {
-                info!(
-                    "Response cache: reaped {} expired entries (>{} days old)",
-                    reaped, ttl_days
-                );
-            }
+        if let Ok(reaped) = result
+            && reaped > 0
+        {
+            info!(
+                "Response cache: reaped {} expired entries (>{} days old)",
+                reaped, ttl_days
+            );
         }
 
         let session_start = SystemTime::now()

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -278,7 +278,7 @@ impl ClaudeClient {
 
 // --- Translation Functions ---
 
-fn translate_ai_request(
+pub fn translate_ai_request(
     request: &AiRequest,
     enable_caching: bool,
     max_tokens: u32,
@@ -417,7 +417,7 @@ fn translate_ai_request(
     Ok(claude_request)
 }
 
-fn apply_cache_control(request: &mut ClaudeRequest) {
+pub fn apply_cache_control(request: &mut ClaudeRequest) {
     // Mark last system block for caching
     if let Some(system) = &mut request.system
         && let Some(last_block) = system.last_mut()
@@ -449,7 +449,7 @@ fn apply_cache_control(request: &mut ClaudeRequest) {
     }
 }
 
-fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
+pub fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
     let mut thought_signature = String::new();
     let mut content = String::new();
     let mut thought = String::new();
@@ -521,7 +521,7 @@ fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
     })
 }
 
-fn estimate_tokens_generic(request: &AiRequest) -> usize {
+pub fn estimate_tokens_generic(request: &AiRequest) -> usize {
     use crate::ai::token_budget::TokenBudget;
 
     let mut total = 0;

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -402,7 +402,11 @@ fn translate_ai_request(
             Some(system_blocks)
         },
         tools,
-        thinking: Some(ThinkingConfig { thinking, effort }),
+        thinking: if thinking.is_some() || effort.is_some() {
+            Some(ThinkingConfig { thinking, effort })
+        } else {
+            None
+        },
     };
 
     // Apply cache control if enabled
@@ -652,5 +656,410 @@ impl AiProvider for StdioClaudeClient {
             model_name: "stdio-claude".to_string(),
             context_window_size: 200_000,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{AiMessage, AiRequest, AiRole, AiTool, ToolCall};
+    use serde_json::json;
+
+    fn make_request(messages: Vec<AiMessage>) -> AiRequest {
+        AiRequest {
+            system: None,
+            messages,
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    // --- ThinkingConfig tests (Bug 1 regression) ---
+
+    #[test]
+    fn test_thinking_config_omitted_when_both_none() {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None).unwrap();
+        assert!(claude_req.thinking.is_none());
+
+        let json = serde_json::to_value(&claude_req).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("thinking"));
+    }
+
+    #[test]
+    fn test_thinking_config_present_when_thinking_set() {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let claude_req =
+            translate_ai_request(&req, false, 4096, Some("enabled".to_string()), None).unwrap();
+        assert!(claude_req.thinking.is_some());
+        let tc = claude_req.thinking.unwrap();
+        assert_eq!(tc.thinking.as_deref(), Some("enabled"));
+        assert!(tc.effort.is_none());
+    }
+
+    #[test]
+    fn test_thinking_config_present_when_effort_set() {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let claude_req =
+            translate_ai_request(&req, false, 4096, None, Some("high".to_string())).unwrap();
+        assert!(claude_req.thinking.is_some());
+        let tc = claude_req.thinking.unwrap();
+        assert!(tc.thinking.is_none());
+        assert_eq!(tc.effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn test_thinking_config_serialization_populated() {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+
+        let claude_req = translate_ai_request(
+            &req,
+            false,
+            4096,
+            Some("enabled".to_string()),
+            Some("high".to_string()),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&claude_req).unwrap();
+        let thinking = &json["thinking"];
+        assert_eq!(thinking["type"], "enabled");
+        assert_eq!(thinking["effort"], "high");
+    }
+
+    // --- Request translation tests ---
+
+    #[test]
+    fn test_translate_system_and_user() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("Hello!".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.system = Some("You are helpful.".to_string());
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+
+        let sys = claude_req.system.unwrap();
+        assert_eq!(sys.len(), 1);
+        assert_eq!(sys[0].text, "You are helpful.");
+
+        assert_eq!(claude_req.messages.len(), 1);
+        assert_eq!(claude_req.messages[0].role, "user");
+        assert_eq!(claude_req.messages[0].content.len(), 1);
+        if let ClaudeContent::Text { text, .. } = &claude_req.messages[0].content[0] {
+            assert_eq!(text, "Hello!");
+        } else {
+            panic!("Expected Text content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_assistant_with_tool_calls() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::Assistant,
+            content: Some("Let me check.".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".to_string(),
+                function_name: "git_log".to_string(),
+                arguments: json!({"n": 5}),
+                thought_signature: None,
+            }]),
+            tool_call_id: None,
+        }]);
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+        let content = &claude_req.messages[0].content;
+        assert_eq!(content.len(), 2);
+
+        if let ClaudeContent::Text { text, .. } = &content[0] {
+            assert_eq!(text, "Let me check.");
+        } else {
+            panic!("Expected Text block");
+        }
+
+        if let ClaudeContent::ToolUse { id, name, input } = &content[1] {
+            assert_eq!(id, "call_1");
+            assert_eq!(name, "git_log");
+            assert_eq!(input, &json!({"n": 5}));
+        } else {
+            panic!("Expected ToolUse block");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_tool_result() -> Result<()> {
+        let req = make_request(vec![AiMessage {
+            role: AiRole::Tool,
+            content: Some("commit abc123".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: Some("call_1".to_string()),
+        }]);
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+        assert_eq!(claude_req.messages.len(), 1);
+        assert_eq!(claude_req.messages[0].role, "user");
+
+        if let ClaudeContent::ToolResult {
+            tool_use_id,
+            content,
+            ..
+        } = &claude_req.messages[0].content[0]
+        {
+            assert_eq!(tool_use_id, "call_1");
+            assert_eq!(content, "commit abc123");
+        } else {
+            panic!("Expected ToolResult block");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_tools() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.tools = Some(vec![AiTool {
+            name: "read_file".to_string(),
+            description: "Read a file".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"path": {"type": "string"}}
+            }),
+        }]);
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+        let tools = claude_req.tools.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "read_file");
+        assert_eq!(tools[0].description, "Read a file");
+
+        Ok(())
+    }
+
+    // --- Response translation tests ---
+
+    #[test]
+    fn test_translate_response_text() -> Result<()> {
+        let resp = ClaudeResponse {
+            id: "msg_1".to_string(),
+            content: vec![ClaudeContent::Text {
+                text: "Hello!".to_string(),
+                cache_control: None,
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: ClaudeUsage {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            },
+        };
+
+        let ai_resp = translate_ai_response(&resp)?;
+        assert_eq!(ai_resp.content.as_deref(), Some("Hello!"));
+        assert!(ai_resp.thought.is_none());
+        assert!(ai_resp.tool_calls.is_none());
+
+        let usage = ai_resp.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_tool_calls() -> Result<()> {
+        let resp = ClaudeResponse {
+            id: "msg_2".to_string(),
+            content: vec![ClaudeContent::ToolUse {
+                id: "call_1".to_string(),
+                name: "git_log".to_string(),
+                input: json!({"n": 5}),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: ClaudeUsage {
+                input_tokens: 20,
+                output_tokens: 10,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            },
+        };
+
+        let ai_resp = translate_ai_response(&resp)?;
+        assert!(ai_resp.content.is_none());
+        let calls = ai_resp.tool_calls.unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].function_name, "git_log");
+        assert_eq!(calls[0].arguments, json!({"n": 5}));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_thinking() -> Result<()> {
+        let resp = ClaudeResponse {
+            id: "msg_3".to_string(),
+            content: vec![
+                ClaudeContent::Thinking {
+                    thinking: "Let me think...".to_string(),
+                    signature: "sig_abc".to_string(),
+                    cache_control: None,
+                },
+                ClaudeContent::Text {
+                    text: "Here's my answer.".to_string(),
+                    cache_control: None,
+                },
+            ],
+            stop_reason: Some("end_turn".to_string()),
+            usage: ClaudeUsage {
+                input_tokens: 30,
+                output_tokens: 15,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            },
+        };
+
+        let ai_resp = translate_ai_response(&resp)?;
+        assert_eq!(ai_resp.content.as_deref(), Some("Here's my answer."));
+        assert_eq!(ai_resp.thought.as_deref(), Some("Let me think..."));
+        assert_eq!(ai_resp.thought_signature.as_deref(), Some("sig_abc"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_usage_with_cache() -> Result<()> {
+        let resp = ClaudeResponse {
+            id: "msg_4".to_string(),
+            content: vec![ClaudeContent::Text {
+                text: "ok".to_string(),
+                cache_control: None,
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: ClaudeUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_input_tokens: Some(200),
+                cache_read_input_tokens: Some(500),
+            },
+        };
+
+        let ai_resp = translate_ai_response(&resp)?;
+        let usage = ai_resp.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 800); // 100 + 500 + 200
+        assert_eq!(usage.completion_tokens, 50);
+        assert_eq!(usage.total_tokens, 850);
+        assert_eq!(usage.cached_tokens, Some(500));
+
+        Ok(())
+    }
+
+    // --- Cache control tests ---
+
+    #[test]
+    fn test_cache_control_applied() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("Hello!".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.system = Some("System prompt.".to_string());
+
+        let claude_req = translate_ai_request(&req, true, 4096, None, None)?;
+
+        // Last system block should have cache_control
+        let sys = claude_req.system.unwrap();
+        assert!(sys.last().unwrap().cache_control.is_some());
+
+        // Last message content should have cache_control
+        let last_msg = claude_req.messages.last().unwrap();
+        if let ClaudeContent::Text { cache_control, .. } = last_msg.content.last().unwrap() {
+            assert!(cache_control.is_some());
+        } else {
+            panic!("Expected Text content with cache_control");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cache_control_not_applied_when_disabled() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("Hello!".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.system = Some("System prompt.".to_string());
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+
+        let sys = claude_req.system.unwrap();
+        assert!(sys.last().unwrap().cache_control.is_none());
+
+        let last_msg = claude_req.messages.last().unwrap();
+        if let ClaudeContent::Text { cache_control, .. } = last_msg.content.last().unwrap() {
+            assert!(cache_control.is_none());
+        } else {
+            panic!("Expected Text content");
+        }
+
+        Ok(())
     }
 }

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -87,7 +87,17 @@ impl AiProvider for ClaudeCliProvider {
             }
         }
 
+        let raw = String::from_utf8_lossy(&output.stdout);
+
         if !output.status.success() {
+            // Try to extract the actual error message from the JSON output.
+            // The CLI emits a JSON object with is_error=true and the reason
+            // in the "result" field even when it exits non-zero.
+            if let Ok(outer) = serde_json::from_str::<Value>(&raw) {
+                if let Some(msg) = outer["result"].as_str() {
+                    anyhow::bail!("claude CLI error: {}", msg);
+                }
+            }
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!(
                 "claude CLI exited with {}: {}",
@@ -95,8 +105,6 @@ impl AiProvider for ClaudeCliProvider {
                 stderr.trim()
             );
         }
-
-        let raw = String::from_utf8_lossy(&output.stdout);
         let outer: Value = serde_json::from_str(&raw).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to parse claude CLI JSON output: {}\nRaw: {}",

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -34,7 +34,8 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
+    AiProvider, AiRequest, AiResponse, AiResponseFormat, AiRole, AiUsage, ProviderCapabilities,
+    ToolCall,
 };
 
 pub struct ClaudeCliProvider {
@@ -93,10 +94,10 @@ impl AiProvider for ClaudeCliProvider {
             // Try to extract the actual error message from the JSON output.
             // The CLI emits a JSON object with is_error=true and the reason
             // in the "result" field even when it exits non-zero.
-            if let Ok(outer) = serde_json::from_str::<Value>(&raw) {
-                if let Some(msg) = outer["result"].as_str() {
-                    anyhow::bail!("claude CLI error: {}", msg);
-                }
+            if let Ok(outer) = serde_json::from_str::<Value>(&raw)
+                && let Some(msg) = outer["result"].as_str()
+            {
+                anyhow::bail!("claude CLI error: {}", msg);
             }
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!(
@@ -217,6 +218,23 @@ pub fn build_prompt(request: &AiRequest) -> String {
              For your final answer: {\"content\": \"YOUR RESPONSE\"}\n\
              Do not mix both. Output exactly one JSON object.\n",
         );
+    } else if matches!(request.response_format, Some(AiResponseFormat::Json { .. })) {
+        // No tools but JSON format required (e.g. Phase 0, Planning).
+        if let Some(AiResponseFormat::Json {
+            schema: Some(schema),
+        }) = &request.response_format
+        {
+            out.push_str(&format!(
+                "RESPONSE FORMAT: You MUST respond with valid JSON only matching this schema: {}. \
+                 Do not include any explanation, markdown, or code fences — output raw JSON.\n",
+                serde_json::to_string(schema).unwrap_or_default()
+            ));
+        } else {
+            out.push_str(
+                "RESPONSE FORMAT: You MUST respond with valid JSON only. \
+                 Do not include any explanation, markdown, or code fences — output raw JSON.\n",
+            );
+        }
     }
 
     out
@@ -370,4 +388,91 @@ fn extract_json(text: &str) -> String {
         }
     }
     normalized.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{AiMessage, AiRequest, AiResponseFormat, AiRole, AiTool};
+    use serde_json::json;
+
+    fn make_request(messages: Vec<AiMessage>) -> AiRequest {
+        AiRequest {
+            system: None,
+            messages,
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    fn simple_user_msg() -> Vec<AiMessage> {
+        vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]
+    }
+
+    #[test]
+    fn test_build_prompt_json_format_without_tools() {
+        let mut req = make_request(simple_user_msg());
+        req.response_format = Some(AiResponseFormat::Json { schema: None });
+
+        let prompt = build_prompt(&req);
+        assert!(prompt.contains("RESPONSE FORMAT"));
+        assert!(prompt.contains("valid JSON only"));
+        assert!(!prompt.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_build_prompt_json_format_with_schema() {
+        let mut req = make_request(simple_user_msg());
+        req.response_format = Some(AiResponseFormat::Json {
+            schema: Some(
+                json!({"type": "object", "properties": {"selected_prompts": {"type": "array"}}}),
+            ),
+        });
+
+        let prompt = build_prompt(&req);
+        assert!(prompt.contains("RESPONSE FORMAT"));
+        assert!(prompt.contains("selected_prompts"));
+        assert!(prompt.contains("matching this schema"));
+    }
+
+    #[test]
+    fn test_build_prompt_with_tools_includes_format() {
+        let mut req = make_request(simple_user_msg());
+        req.tools = Some(vec![AiTool {
+            name: "git_log".to_string(),
+            description: "Show git log".to_string(),
+            parameters: json!({"type": "object"}),
+        }]);
+
+        let prompt = build_prompt(&req);
+        assert!(prompt.contains("RESPONSE FORMAT"));
+        assert!(prompt.contains("tool_calls"));
+        assert!(prompt.contains("<available_tools>"));
+    }
+
+    #[test]
+    fn test_build_prompt_text_format_no_instruction() {
+        let mut req = make_request(simple_user_msg());
+        req.response_format = Some(AiResponseFormat::Text);
+
+        let prompt = build_prompt(&req);
+        assert!(!prompt.contains("RESPONSE FORMAT"));
+    }
+
+    #[test]
+    fn test_build_prompt_no_format_no_instruction() {
+        let req = make_request(simple_user_msg());
+
+        let prompt = build_prompt(&req);
+        assert!(!prompt.contains("RESPONSE FORMAT"));
+    }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -312,6 +312,37 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
         "codex-cli" => Ok(Arc::new(codex_cli::CodexCliProvider {
             model: settings.ai.model.clone(),
         })),
+        #[cfg(feature = "vertex")]
+        "vertex" => {
+            let model = settings.ai.model.clone();
+            let vertex = settings.ai.vertex.as_ref();
+            let project_id = vertex
+                .and_then(|v| v.project_id.clone())
+                .or_else(|| std::env::var("ANTHROPIC_VERTEX_PROJECT_ID").ok())
+                .context(
+                    "Vertex AI requires project_id in [ai.vertex] \
+                     or ANTHROPIC_VERTEX_PROJECT_ID env var",
+                )?;
+            let region = vertex
+                .and_then(|v| v.region.clone())
+                .or_else(|| std::env::var("CLOUD_ML_REGION").ok())
+                .unwrap_or_else(|| "us-east5".to_string());
+            let enable_caching = vertex.map(|v| v.prompt_caching).unwrap_or(true);
+            let max_tokens = vertex.map(|v| v.max_tokens).unwrap_or(8192);
+            let thinking = vertex.and_then(|v| v.thinking.clone());
+            let effort = vertex.and_then(|v| v.effort.clone());
+            Ok(Arc::new(vertex::VertexClient::new(
+                model,
+                project_id,
+                region,
+                enable_caching,
+                max_tokens,
+                thinking,
+                effort,
+            )?))
+        }
+        #[cfg(not(feature = "vertex"))]
+        "vertex" => bail!("vertex provider requires the 'vertex' feature"),
         p => bail!("Unsupported AI provider: {}", p),
     }
 }
@@ -327,6 +358,8 @@ pub mod proxy;
 pub mod quota;
 pub mod token_budget;
 pub mod truncator;
+#[cfg(feature = "vertex")]
+pub mod vertex;
 
 /// Recursively removes `thought_signature` and `thoughtSignature` fields from a JSON value.
 pub fn scrub_thought_signatures(val: &mut serde_json::Value) {

--- a/src/ai/vertex.rs
+++ b/src/ai/vertex.rs
@@ -1,0 +1,456 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Vertex AI provider — a model-agnostic routing layer for Google Cloud.
+//!
+//! Vertex AI hosts multiple model families (Claude, Gemini, etc.) behind
+//! different API endpoints. This provider handles shared concerns (auth,
+//! endpoint routing) and delegates wire-format translation to existing
+//! provider modules based on the detected model family.
+//!
+//! Currently supports Claude models via the `rawPredict` endpoint.
+//! Gemini support can be added by making gemini.rs translation functions
+//! public and adding the Gemini path — no structural changes required.
+
+use crate::ai::claude::{
+    self, ClaudeError, ClaudeMessage, ClaudeResponse, ClaudeTool, SystemBlock, ThinkingConfig,
+};
+use crate::ai::{AiProvider, AiRequest, AiResponse, ProviderCapabilities};
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use google_cloud_auth::credentials::{AccessTokenCredentials, Builder};
+use reqwest::Client;
+use serde::Serialize;
+use std::time::Duration;
+use tracing::info;
+
+// --- Model family detection ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelFamily {
+    Claude,
+    // Future: Gemini, Llama, Mistral, etc.
+}
+
+fn detect_model_family(model: &str) -> Result<ModelFamily> {
+    if model.starts_with("claude") {
+        Ok(ModelFamily::Claude)
+    } else {
+        bail!(
+            "Unsupported model family on Vertex AI: {}. \
+             Supported prefixes: claude-*",
+            model
+        )
+    }
+}
+
+// --- Vertex-specific request wrapper for Claude ---
+
+/// Claude request body for Vertex AI's rawPredict endpoint.
+///
+/// Differs from direct Claude API in two ways:
+/// 1. No `model` field — Vertex gets it from the URL
+/// 2. `anthropic_version` is in the body (not a header)
+#[derive(Debug, Serialize)]
+struct VertexClaudeRequest {
+    anthropic_version: String,
+    messages: Vec<ClaudeMessage>,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<Vec<SystemBlock>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ClaudeTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
+}
+
+// --- Endpoint construction ---
+
+struct EndpointInfo {
+    publisher: &'static str,
+    method: &'static str,
+}
+
+fn endpoint_info(family: ModelFamily) -> EndpointInfo {
+    match family {
+        ModelFamily::Claude => EndpointInfo {
+            publisher: "anthropic",
+            method: "rawPredict",
+        },
+    }
+}
+
+fn build_endpoint_url(region: &str, project_id: &str, model: &str, info: &EndpointInfo) -> String {
+    let path = format!(
+        "v1/projects/{}/locations/{}/publishers/{}/models/{}:{}",
+        project_id, region, info.publisher, model, info.method
+    );
+
+    match region {
+        "global" => format!("https://global-aiplatform.googleapis.com/{path}"),
+        "us" | "eu" => {
+            format!("https://aiplatform.{region}.rep.googleapis.com/{path}")
+        }
+        _ => format!("https://{region}-aiplatform.googleapis.com/{path}"),
+    }
+}
+
+// --- VertexClient ---
+
+pub struct VertexClient {
+    project_id: String,
+    region: String,
+    model: String,
+    model_family: ModelFamily,
+    client: Client,
+    enable_caching: bool,
+    max_tokens: u32,
+    thinking: Option<String>,
+    effort: Option<String>,
+    context_window_size: usize,
+    credentials: AccessTokenCredentials,
+}
+
+impl VertexClient {
+    pub fn new(
+        model: String,
+        project_id: String,
+        region: String,
+        enable_caching: bool,
+        max_tokens: u32,
+        thinking: Option<String>,
+        effort: Option<String>,
+    ) -> Result<Self> {
+        let model_family = detect_model_family(&model)?;
+
+        let context_window_size = match model_family {
+            ModelFamily::Claude => {
+                // Opus 4.7/4.6 and Sonnet 4.6 get 1M on Vertex
+                if model.contains("opus-4-7")
+                    || model.contains("opus-4-6")
+                    || model.contains("sonnet-4-6")
+                {
+                    1_000_000
+                } else {
+                    200_000
+                }
+            }
+        };
+
+        let credentials = Builder::default()
+            .build_access_token_credentials()
+            .map_err(|e| anyhow::anyhow!("Failed to initialize Google Cloud credentials: {e}"))?;
+
+        Ok(Self {
+            project_id,
+            region,
+            model,
+            model_family,
+            client: Client::new(),
+            enable_caching,
+            max_tokens,
+            thinking,
+            effort,
+            context_window_size,
+            credentials,
+        })
+    }
+
+    async fn get_access_token(&self) -> Result<String> {
+        let token = self
+            .credentials
+            .access_token()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get Google Cloud access token: {e}"))?;
+        Ok(token.token)
+    }
+
+    fn endpoint_url(&self) -> String {
+        let info = endpoint_info(self.model_family);
+        build_endpoint_url(&self.region, &self.project_id, &self.model, &info)
+    }
+
+    async fn post_claude_request(&self, body: &VertexClaudeRequest) -> Result<ClaudeResponse> {
+        let token = self.get_access_token().await?;
+        let url = self.endpoint_url();
+
+        let res = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(body)
+            .send()
+            .await
+            .context("Failed to send request to Vertex AI")?;
+
+        let status = res.status();
+
+        if status.is_success() {
+            let body_text = res.text().await?;
+            let response: ClaudeResponse = serde_json::from_str(&body_text)
+                .context("Failed to parse Vertex AI Claude response")?;
+
+            info!(
+                "Vertex AI response received. Tokens: in={}, out={}, cache_read={} cache_write={}",
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+                response.usage.cache_read_input_tokens.unwrap_or(0),
+                response.usage.cache_creation_input_tokens.unwrap_or(0),
+            );
+
+            Ok(response)
+        } else {
+            let retry_after_duration = if status.as_u16() == 429 {
+                res.headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|h| h.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(Duration::from_secs)
+            } else {
+                None
+            };
+
+            let error_body = res
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            match status.as_u16() {
+                429 => {
+                    let duration = retry_after_duration.unwrap_or(Duration::from_secs(60));
+                    Err(ClaudeError::RateLimitExceeded(duration))?
+                }
+                529 => {
+                    let duration = Duration::from_secs(5);
+                    Err(ClaudeError::OverloadedError(duration))?
+                }
+                400 => Err(ClaudeError::InvalidRequest(error_body))?,
+                401 | 403 => Err(ClaudeError::AuthenticationError(error_body))?,
+                _ => Err(ClaudeError::ApiError(status, error_body))?,
+            }
+        }
+    }
+
+    async fn generate_claude(&self, request: AiRequest) -> Result<AiResponse> {
+        let claude_req = claude::translate_ai_request(
+            &request,
+            self.enable_caching,
+            self.max_tokens,
+            self.thinking.clone(),
+            self.effort.clone(),
+        )?;
+
+        let vertex_req = VertexClaudeRequest {
+            anthropic_version: "vertex-2023-10-16".to_string(),
+            messages: claude_req.messages,
+            max_tokens: claude_req.max_tokens,
+            system: claude_req.system,
+            tools: claude_req.tools,
+            thinking: claude_req.thinking,
+        };
+
+        let response = self.post_claude_request(&vertex_req).await?;
+        claude::translate_ai_response(&response)
+    }
+}
+
+#[async_trait]
+impl AiProvider for VertexClient {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        match self.model_family {
+            ModelFamily::Claude => self.generate_claude(request).await,
+        }
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        claude::estimate_tokens_generic(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            model_name: self.model.clone(),
+            context_window_size: self.context_window_size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // --- Model family detection ---
+
+    #[test]
+    fn test_detect_model_family_claude() {
+        assert_eq!(
+            detect_model_family("claude-sonnet-4-6").unwrap(),
+            ModelFamily::Claude
+        );
+        assert_eq!(
+            detect_model_family("claude-opus-4-7").unwrap(),
+            ModelFamily::Claude
+        );
+    }
+
+    #[test]
+    fn test_detect_model_family_unsupported() {
+        assert!(detect_model_family("llama-3").is_err());
+        assert!(detect_model_family("mistral-large").is_err());
+    }
+
+    // --- Endpoint URL construction ---
+
+    #[test]
+    fn test_endpoint_url_global_claude() {
+        let info = endpoint_info(ModelFamily::Claude);
+        let url = build_endpoint_url("global", "my-project", "claude-sonnet-4-6", &info);
+        assert_eq!(
+            url,
+            "https://global-aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-sonnet-4-6:rawPredict"
+        );
+    }
+
+    #[test]
+    fn test_endpoint_url_regional_claude() {
+        let info = endpoint_info(ModelFamily::Claude);
+        let url = build_endpoint_url("us-east5", "my-project", "claude-sonnet-4-6", &info);
+        assert_eq!(
+            url,
+            "https://us-east5-aiplatform.googleapis.com/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6:rawPredict"
+        );
+    }
+
+    #[test]
+    fn test_endpoint_url_multi_region_us() {
+        let info = endpoint_info(ModelFamily::Claude);
+        let url = build_endpoint_url("us", "my-project", "claude-opus-4-7", &info);
+        assert_eq!(
+            url,
+            "https://aiplatform.us.rep.googleapis.com/v1/projects/my-project/locations/us/publishers/anthropic/models/claude-opus-4-7:rawPredict"
+        );
+    }
+
+    #[test]
+    fn test_endpoint_url_multi_region_eu() {
+        let info = endpoint_info(ModelFamily::Claude);
+        let url = build_endpoint_url("eu", "my-project", "claude-sonnet-4-6", &info);
+        assert_eq!(
+            url,
+            "https://aiplatform.eu.rep.googleapis.com/v1/projects/my-project/locations/eu/publishers/anthropic/models/claude-sonnet-4-6:rawPredict"
+        );
+    }
+
+    // --- VertexClaudeRequest serialization ---
+
+    #[test]
+    fn test_vertex_claude_request_no_model_field() {
+        let req = VertexClaudeRequest {
+            anthropic_version: "vertex-2023-10-16".to_string(),
+            messages: vec![],
+            max_tokens: 4096,
+            system: None,
+            tools: None,
+            thinking: None,
+        };
+
+        let json = serde_json::to_value(&req).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.contains_key("model"));
+    }
+
+    #[test]
+    fn test_vertex_claude_request_has_anthropic_version() {
+        let req = VertexClaudeRequest {
+            anthropic_version: "vertex-2023-10-16".to_string(),
+            messages: vec![],
+            max_tokens: 4096,
+            system: None,
+            tools: None,
+            thinking: None,
+        };
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["anthropic_version"], "vertex-2023-10-16");
+    }
+
+    #[test]
+    fn test_vertex_claude_request_from_translate() {
+        use crate::ai::{AiMessage, AiRole};
+
+        let ai_req = AiRequest {
+            system: Some("You are helpful.".to_string()),
+            messages: vec![AiMessage {
+                role: AiRole::User,
+                content: Some("Hello".to_string()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        };
+
+        let claude_req = claude::translate_ai_request(&ai_req, false, 4096, None, None).unwrap();
+
+        let vertex_req = VertexClaudeRequest {
+            anthropic_version: "vertex-2023-10-16".to_string(),
+            messages: claude_req.messages,
+            max_tokens: claude_req.max_tokens,
+            system: claude_req.system,
+            tools: claude_req.tools,
+            thinking: claude_req.thinking,
+        };
+
+        let json = serde_json::to_value(&vertex_req).unwrap();
+        assert_eq!(json["anthropic_version"], "vertex-2023-10-16");
+        assert!(!json.as_object().unwrap().contains_key("model"));
+        assert!(json["system"].is_array());
+        assert!(json["messages"].is_array());
+        assert_eq!(json["max_tokens"], 4096);
+        // thinking should be absent (both None)
+        assert!(!json.as_object().unwrap().contains_key("thinking"));
+    }
+
+    // --- Context window detection ---
+
+    #[test]
+    fn test_context_window_1m_for_new_models() {
+        // Can't fully test new() without GCP credentials, so test the logic directly
+        let models_1m = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"];
+        for model in models_1m {
+            let is_1m = model.contains("opus-4-7")
+                || model.contains("opus-4-6")
+                || model.contains("sonnet-4-6");
+            assert!(is_1m, "Expected 1M context for {model}");
+        }
+    }
+
+    #[test]
+    fn test_context_window_200k_for_older_models() {
+        let models_200k = [
+            "claude-sonnet-4-5@20250929",
+            "claude-sonnet-4@20250514",
+            "claude-haiku-4-5@20251001",
+        ];
+        for model in models_200k {
+            let is_1m = model.contains("opus-4-7")
+                || model.contains("opus-4-6")
+                || model.contains("sonnet-4-6");
+            assert!(!is_1m, "Expected 200K context for {model}");
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -153,6 +153,31 @@ fn default_prompt_caching() -> bool {
     true
 }
 
+#[cfg(feature = "vertex")]
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct VertexSettings {
+    /// GCP project ID. Falls back to ANTHROPIC_VERTEX_PROJECT_ID env var.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// GCP region (e.g., "us-east5", "global"). Falls back to CLOUD_ML_REGION env var.
+    #[serde(default)]
+    pub region: Option<String>,
+    #[serde(default = "default_prompt_caching")]
+    pub prompt_caching: bool,
+    #[serde(default = "default_vertex_max_tokens")]
+    pub max_tokens: u32,
+    #[serde(default)]
+    pub thinking: Option<String>,
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+#[cfg(feature = "vertex")]
+fn default_vertex_max_tokens() -> u32 {
+    8192
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
 pub struct OpenAiCompatSettings {
@@ -192,6 +217,8 @@ pub struct AiSettings {
     pub gemini: Option<GeminiSettings>,
     #[cfg(feature = "bedrock")]
     pub bedrock: Option<BedrockSettings>,
+    #[cfg(feature = "vertex")]
+    pub vertex: Option<VertexSettings>,
     pub openai_compat: Option<OpenAiCompatSettings>,
 }
 


### PR DESCRIPTION
The Claude API provider has been broken for users with default settings
since the thought_signature commit (4b254c1).

This series fixes all three bugs, adds a Vertex AI provider as a
model-agnostic routing layer, and brings Claude provider test coverage
from zero to 30 tests.

Bug fixes:

1. translate_ai_request() unconditionally wraps the thinking config in
Some(ThinkingConfig{...}). When both fields are None (the default),
this serializes to "thinking": {}, which the API rejects with
"thinking.type: Field required". Every request fails.
2. claude-cli never reads stdout on non-zero exit. The CLI writes the
error reason as JSON to stdout, but only stderr was reported,
producing opaque "exited with exit status: 1:" messages.
3. build_prompt() only emits JSON format instructions when tools are
present. Phase 0 and Planning use AiResponseFormat::Json without
tools, so the model returns prose that fails to parse.

Additionally, add Vertex AI endpoint backend.

Vertex AI is GCP's equivalent of AWS Bedrock. Unlike Bedrock's unified
Converse API, Vertex uses per-publisher wire formats. The provider is a
model-agnostic routing layer: it detects the model family from the name,
constructs the correct endpoint, and delegates wire-format translation to
existing provider modules.

Currently supports Claude via rawPredict, reusing 100% of the existing
translation functions from claude.rs. Architecture supports adding
Gemini and other model families without structural changes.

Feature-flagged behind --features vertex. Auth via google-cloud-auth
(Application Default Credentials). Supports global, multi-region, and
regional endpoints.

Testing:

Both Vertex AI and claude-cli backends were integration-tested end-to-end
with a kernel patch submitted through the full review pipeline. All review
stages completed successfully.