### PR TITLE
fix: support both abab7 and MiniMax model prefixes

### DIFF
--- a/designs/DESIGN_OPENAI_COMPAT_PROVIDER.md
+++ b/designs/DESIGN_OPENAI_COMPAT_PROVIDER.md
@@ -16,7 +16,7 @@ The official OpenAI API uses `max_completion_tokens` in the request body (introd
 | Stdio support | Not needed for OpenAI-compatible provider |
 | Thinking/reasoning support | Not included in initial implementation (`thought: None` always) |
 | Temperature | Always passed through from `AiRequest` when present |
-| URL configuration | `base_url` from settings → model-based default (glm-*, moonshot-*, abab7-*, others) |
+| URL configuration | `base_url` from settings → model-based default (glm-*, moonshot-*, abab7-*, MiniMax-*, others) |
 | API key | `OPENAI_API_KEY` env only (fallback to `LLM_API_KEY`), no provider-specific keys |
 
 ## Provider Compatibility
@@ -29,7 +29,7 @@ The official OpenAI API uses `max_completion_tokens` in the request body (introd
 | `gpt-3.5` | `https://api.openai.com/v1/chat/completions` | 16,385 |
 | `glm-` | `https://open.bigmodel.cn/api/paas/v4/chat/completions` | 128,000 |
 | `moonshot-` | `https://api.moonshot.cn/v1/chat/completions` | 128,000 |
-| `abab7-` | `https://api.minimax.chat/v1/text/chatcompletion_v2` | 245,760 |
+| `abab7-` / `MiniMax-` | `https://api.minimax.chat/v1/text/chatcompletion_v2` | 245,760 |
 
 All providers use `Authorization: Bearer <OPENAI_API_KEY>` for authentication.
 
@@ -355,7 +355,7 @@ base_url = "https://api.moonshot.cn/v1/chat/completions"
 # Minimax — uses max_tokens
 [ai]
 provider = "openai-compatible"
-model = "abab7-chat-preview"
+model = "abab7-chat-preview" # or "MiniMax-M2.7"
 
 [ai.openai_compat]
 base_url = "https://api.minimax.chat/v1/text/chatcompletion_v2"

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -172,7 +172,7 @@ impl OpenAiCompatClient {
             "https://open.bigmodel.cn/api/paas/v4/chat/completions".to_string()
         } else if model.starts_with("moonshot-") {
             "https://api.moonshot.cn/v1/chat/completions".to_string()
-        } else if model.starts_with("abab7-") {
+        } else if model.starts_with("abab7-") || model.starts_with("MiniMax-") {
             "https://api.minimax.chat/v1/text/chatcompletion_v2".to_string()
         } else {
             "https://api.openai.com/v1/chat/completions".to_string()
@@ -182,7 +182,7 @@ impl OpenAiCompatClient {
     pub fn default_context_window_for_model(model: &str) -> usize {
         if model.starts_with("glm-") || model.starts_with("moonshot-") {
             128_000
-        } else if model.starts_with("abab7-") {
+        } else if model.starts_with("abab7-") || model.starts_with("MiniMax-") {
             245_760
         } else if model.starts_with("gpt-4o") || model.starts_with("gpt-4-turbo") {
             128_000


### PR DESCRIPTION
Hi Dear Maintainers,

Thank you for your great work on this project! I'm submitting this PR to improve compatibility with MiniMax's recent model releases.

**Context:**
MiniMax has recently introduced new models (like MiniMax-M2.7 [1] and MiniMax-Text-01 [2]) using the `MiniMax-` prefix, alongside the legacy `abab7-` prefix models.

**The Issue:**
Previously, only the "abab7-" prefix was checked to route requests to the MiniMax API endpoint. This caused models with the new "MiniMax-" prefix to fall back to the default OpenAI endpoint, resulting in request failures.

**The Fix:**
This commit updates the prefix matching logic to recognize both "abab7-" and "MiniMax-" prefixes, ensuring correct API routing and context window assignment for both legacy and new MiniMax models. I have also updated the related design documentation (`DESIGN_OPENAI_COMPAT_PROVIDER.md`) to reflect this change.

Thanks for your time and consideration!

[1] https://minimaxi.com/news/minimax-m27-zh
[2] https://platform.minimaxi.com/document/ChatCompletion?key=667bdde33be2027f69b71d4c