### PR TITLE
AI: classify AI provider retry errors to handle Rate Limit responses

### DIFF
--- a/designs/DESIGN_AI_WORKER_INTERACTION.md
+++ b/designs/DESIGN_AI_WORKER_INTERACTION.md
@@ -106,13 +106,30 @@ The parent processes the request (handling authentication, networking, and quota
 If the parent fails to execute the request (e.g., network failure after retries, invalid request), it returns an error.
 
 *   **Direction**: Parent -> Child
-*   **Format**:
+*   **New Format**:
+    ```json
+    {
+      "type": "error",
+      "payload": {
+        "message": "Rate limit exceeded, retry after 60s",
+        "class": "rate_limit",
+        "retry_after_secs": 60
+      }
+    }
+    ```
+*   **Error Classes**:
+    *   `fatal`: Permanent failure. `retry_after_secs` is omitted.
+    *   `rate_limit`: Provider quota or rate-limit failure. `retry_after_secs` is required.
+    *   `transient`: Retryable provider or transport failure. `retry_after_secs` is required.
+*   **Receive Semantics**: Object payloads are decoded into a typed `RemoteAiError`, preserving the message and error class for callers that need structured handling.
+*   **Legacy Format**:
     ```json
     {
       "type": "error",
       "payload": "Detailed error message string"
     }
     ```
+    String payloads remain accepted for backward compatibility and surface as a plain `Remote AI Error: ...` error.
 
 ### 5. Final Result (Worker -> Parent)
 Upon completion, the worker outputs the final review data. This message **does not** have a `type` wrapper, allowing it to be distinct from protocol messages, or identified by specific fields (e.g., `patchset_id`).

--- a/designs/DESIGN_AI_WORKER_INTERACTION.md
+++ b/designs/DESIGN_AI_WORKER_INTERACTION.md
@@ -31,7 +31,7 @@ sequenceDiagram
             P->>P: Handle Quota (Wait & Retry)
             P->>C: (Delayed Response)
         else Fatal Error
-            P->>C: {"type": "error", "payload": "Description"}
+            P->>C: {"type": "error", "payload": {"message": "Description", "class": "fatal"}}
         end
     end
 
@@ -106,7 +106,7 @@ The parent processes the request (handling authentication, networking, and quota
 If the parent fails to execute the request (e.g., network failure after retries, invalid request), it returns an error.
 
 *   **Direction**: Parent -> Child
-*   **New Format**:
+*   **Format**:
     ```json
     {
       "type": "error",
@@ -121,15 +121,7 @@ If the parent fails to execute the request (e.g., network failure after retries,
     *   `fatal`: Permanent failure. `retry_after_secs` is omitted.
     *   `rate_limit`: Provider quota or rate-limit failure. `retry_after_secs` is required.
     *   `transient`: Retryable provider or transport failure. `retry_after_secs` is required.
-*   **Receive Semantics**: Object payloads are decoded into a typed `RemoteAiError`, preserving the message and error class for callers that need structured handling.
-*   **Legacy Format**:
-    ```json
-    {
-      "type": "error",
-      "payload": "Detailed error message string"
-    }
-    ```
-    String payloads remain accepted for backward compatibility and surface as a plain `Remote AI Error: ...` error.
+*   **Receive Semantics**: Error payloads are decoded into a typed `RemoteAiError`, preserving the message and error class for callers that need structured handling. String payloads are not accepted.
 
 ### 5. Final Result (Worker -> Parent)
 Upon completion, the worker outputs the final review data. This message **does not** have a `type` wrapper, allowing it to be distinct from protocol messages, or identified by specific fields (e.g., `patchset_id`).

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -14,6 +14,7 @@
 
 use crate::ai::{
     AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
+    decode_stdio_ai_response,
 };
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
@@ -620,16 +621,7 @@ trait GenClaudeClient: Send + Sync {
                 bail!("Unexpected EOF from stdin waiting for AI response");
             }
 
-            let resp_msg: Value = serde_json::from_str(&line)?;
-            if resp_msg["type"] == "ai_response" {
-                let payload = serde_json::from_value(resp_msg["payload"].clone())?;
-                Ok(payload)
-            } else if resp_msg["type"] == "error" {
-                let err_msg = resp_msg["payload"].as_str().unwrap_or("Unknown error");
-                bail!("Remote AI Error: {}", err_msg)
-            } else {
-                bail!("Unexpected response type: {:?}", resp_msg["type"])
-            }
+            decode_stdio_ai_response(&line)
         })
         .await?
     }

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
-    decode_stdio_ai_response,
+    AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ClassifyAiError,
+    ProviderCapabilities, ToolCall, classify_status_code, decode_stdio_ai_response,
 };
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
@@ -153,6 +153,24 @@ pub enum ClaudeError {
     AuthenticationError(String),
     #[error("API error {0}: {1}")]
     ApiError(reqwest::StatusCode, String),
+}
+
+impl ClassifyAiError for ClaudeError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        match self {
+            ClaudeError::RateLimitExceeded(retry_after) => AiErrorClass::RateLimit {
+                retry_after: *retry_after,
+            },
+            ClaudeError::OverloadedError(retry_after) => AiErrorClass::Transient {
+                retry_after: *retry_after,
+            },
+            ClaudeError::InvalidRequest(_) => AiErrorClass::Fatal,
+            ClaudeError::AuthenticationError(_) => AiErrorClass::Fatal,
+            ClaudeError::ApiError(status, _) => {
+                classify_status_code(*status).unwrap_or(AiErrorClass::Fatal)
+            }
+        }
+    }
 }
 
 // --- ClaudeClient ---
@@ -654,7 +672,10 @@ impl AiProvider for StdioClaudeClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::{AiMessage, AiRequest, AiRole, AiTool, ToolCall};
+    use crate::ai::{
+        AiErrorClass, AiMessage, AiRequest, AiRole, AiTool, ClassifyAiError, DEFAULT_RETRY_AFTER,
+        ToolCall,
+    };
     use serde_json::json;
 
     fn make_request(messages: Vec<AiMessage>) -> AiRequest {
@@ -666,6 +687,65 @@ mod tests {
             response_format: None,
             context_tag: None,
         }
+    }
+
+    #[test]
+    fn test_rate_limit_exceeded_classifies_as_rate_limit() {
+        let retry_after = Duration::from_secs(7);
+        let err = ClaudeError::RateLimitExceeded(retry_after);
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::RateLimit { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_overloaded_error_classifies_as_transient() {
+        let retry_after = Duration::from_secs(11);
+        let err = ClaudeError::OverloadedError(retry_after);
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_invalid_request_classifies_as_fatal() {
+        let err = ClaudeError::InvalidRequest("bad request".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_authentication_error_classifies_as_fatal() {
+        let err = ClaudeError::AuthenticationError("bad key".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_api_error_server_status_classifies_as_transient() {
+        let err = ClaudeError::ApiError(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "unavailable".to_string(),
+        );
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient {
+                retry_after: DEFAULT_RETRY_AFTER,
+            }
+        );
+    }
+
+    #[test]
+    fn test_api_error_client_status_classifies_as_fatal() {
+        let err =
+            ClaudeError::ApiError(reqwest::StatusCode::BAD_REQUEST, "bad request".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
     }
 
     // --- ThinkingConfig tests (Bug 1 regression) ---

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -15,6 +15,7 @@
 use crate::ai::token_budget::TokenBudget;
 use crate::ai::{
     AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
+    decode_stdio_ai_response,
 };
 use crate::utils::redact_secret;
 use anyhow::{Context, Result};
@@ -453,16 +454,7 @@ impl StdioGeminiClient {
                 anyhow::bail!("Unexpected EOF from stdin waiting for AI response");
             }
 
-            let resp_msg: Value = serde_json::from_str(&line)?;
-            if resp_msg["type"] == "ai_response" {
-                let payload = serde_json::from_value(resp_msg["payload"].clone())?;
-                Ok(payload)
-            } else if resp_msg["type"] == "error" {
-                let err_msg = resp_msg["payload"].as_str().unwrap_or("Unknown error");
-                anyhow::bail!("Remote AI Error: {}", err_msg)
-            } else {
-                anyhow::bail!("Unexpected response type: {:?}", resp_msg["type"])
-            }
+            decode_stdio_ai_response(&line)
         })
         .await?
     }

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -14,8 +14,8 @@
 
 use crate::ai::token_budget::TokenBudget;
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ProviderCapabilities, ToolCall,
-    decode_stdio_ai_response,
+    AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ClassifyAiError,
+    ProviderCapabilities, ToolCall, classify_status_code, decode_stdio_ai_response,
 };
 use crate::utils::redact_secret;
 use anyhow::{Context, Result};
@@ -217,6 +217,24 @@ impl std::fmt::Display for GeminiError {
 }
 
 impl std::error::Error for GeminiError {}
+
+impl ClassifyAiError for GeminiError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        match self {
+            GeminiError::QuotaExceeded(retry_after) => AiErrorClass::RateLimit {
+                retry_after: *retry_after,
+            },
+            GeminiError::TransientError(retry_after, _) => AiErrorClass::Transient {
+                retry_after: *retry_after,
+            },
+            GeminiError::PermissionDenied(_) => AiErrorClass::Fatal,
+            GeminiError::ApiError(status, _) => {
+                classify_status_code(*status).unwrap_or(AiErrorClass::Fatal)
+            }
+            GeminiError::Other(_) => AiErrorClass::Fatal,
+        }
+    }
+}
 
 pub struct GeminiClient {
     model: String,
@@ -767,8 +785,70 @@ impl AiProvider for GeminiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::{AiMessage, AiResponseFormat, AiRole, AiTool, ToolCall};
+    use crate::ai::{
+        AiErrorClass, AiMessage, AiResponseFormat, AiRole, AiTool, ClassifyAiError,
+        DEFAULT_RETRY_AFTER, ToolCall,
+    };
     use serde_json::json;
+
+    #[test]
+    fn test_quota_exceeded_classifies_as_rate_limit() {
+        let retry_after = Duration::from_secs(7);
+        let err = GeminiError::QuotaExceeded(retry_after);
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::RateLimit { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_transient_error_classifies_as_transient() {
+        let retry_after = Duration::from_secs(11);
+        let err = GeminiError::TransientError(retry_after, "busy".to_string());
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_permission_denied_classifies_as_fatal() {
+        let err = GeminiError::PermissionDenied("forbidden".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_api_error_server_status_classifies_as_transient() {
+        let err = GeminiError::ApiError(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "unavailable".to_string(),
+        );
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient {
+                retry_after: DEFAULT_RETRY_AFTER,
+            }
+        );
+    }
+
+    #[test]
+    fn test_api_error_client_status_classifies_as_fatal() {
+        let err =
+            GeminiError::ApiError(reqwest::StatusCode::BAD_REQUEST, "bad request".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_other_classifies_as_fatal() {
+        let err = GeminiError::Other("unknown".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
 
     #[test]
     fn test_translate_ai_request_system_and_user() -> Result<()> {

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -207,6 +207,36 @@ pub struct RemoteAiError {
     pub class: AiErrorClass,
 }
 
+pub(crate) const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+pub trait ClassifyAiError {
+    fn ai_error_class(&self) -> AiErrorClass;
+}
+
+impl ClassifyAiError for RemoteAiError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        self.class
+    }
+}
+
+pub(crate) fn classify_status_code(status: reqwest::StatusCode) -> Option<AiErrorClass> {
+    match status {
+        reqwest::StatusCode::TOO_MANY_REQUESTS => Some(AiErrorClass::RateLimit {
+            retry_after: DEFAULT_RETRY_AFTER,
+        }),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        | reqwest::StatusCode::BAD_GATEWAY
+        | reqwest::StatusCode::SERVICE_UNAVAILABLE
+        | reqwest::StatusCode::GATEWAY_TIMEOUT => Some(AiErrorClass::Transient {
+            retry_after: DEFAULT_RETRY_AFTER,
+        }),
+        status if status.as_u16() == 529 => Some(AiErrorClass::Transient {
+            retry_after: DEFAULT_RETRY_AFTER,
+        }),
+        _ => None,
+    }
+}
+
 /// Decodes a single line of the stdio AI protocol into an [`AiResponse`].
 ///
 /// Error payloads in the legacy string form surface as
@@ -688,6 +718,53 @@ mod tests {
 
         assert!(err.to_string().contains("retry_after_secs"));
         Ok(())
+    }
+
+    #[test]
+    fn test_remote_ai_error_classifies_from_payload_class() {
+        let retry_after = Duration::from_secs(42);
+        let err = RemoteAiError {
+            message: "remote rate limit".to_string(),
+            class: AiErrorClass::RateLimit { retry_after },
+        };
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::RateLimit { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_classify_status_code_rate_limit() {
+        assert_eq!(
+            classify_status_code(reqwest::StatusCode::TOO_MANY_REQUESTS),
+            Some(AiErrorClass::RateLimit {
+                retry_after: DEFAULT_RETRY_AFTER,
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_status_code_server_error() {
+        assert_eq!(
+            classify_status_code(reqwest::StatusCode::SERVICE_UNAVAILABLE),
+            Some(AiErrorClass::Transient {
+                retry_after: DEFAULT_RETRY_AFTER,
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_status_code_other() {
+        assert_eq!(classify_status_code(reqwest::StatusCode::BAD_REQUEST), None);
+    }
+
+    #[test]
+    fn test_classify_status_code_not_implemented_is_fatal() {
+        assert_eq!(
+            classify_status_code(reqwest::StatusCode::NOT_IMPLEMENTED),
+            None
+        );
     }
 
     #[test]

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -186,7 +186,6 @@ pub(crate) struct RemoteAiErrorPayload {
 }
 
 impl RemoteAiErrorPayload {
-    #[allow(dead_code)]
     pub fn new(message: String, class: AiErrorClass) -> Self {
         Self { message, class }
     }
@@ -237,23 +236,37 @@ pub(crate) fn classify_status_code(status: reqwest::StatusCode) -> Option<AiErro
     }
 }
 
+/// Classifies AI errors through typed provider and stdio error downcasts.
+pub fn classify_ai_error(error: &anyhow::Error) -> AiErrorClass {
+    if let Some(e) = error.downcast_ref::<RemoteAiError>() {
+        return e.ai_error_class();
+    }
+    if let Some(e) = error.downcast_ref::<openai::OpenAiCompatError>() {
+        return e.ai_error_class();
+    }
+    if let Some(e) = error.downcast_ref::<claude::ClaudeError>() {
+        return e.ai_error_class();
+    }
+    if let Some(e) = error.downcast_ref::<gemini::GeminiError>() {
+        return e.ai_error_class();
+    }
+    if let Some(e) = error.downcast_ref::<crate::worker::prompts::ReviewError>() {
+        return e.ai_error_class();
+    }
+    AiErrorClass::Fatal
+}
+
 /// Decodes a single line of the stdio AI protocol into an [`AiResponse`].
 ///
-/// Error payloads in the legacy string form surface as
-/// `Remote AI Error: ...` for backward compatibility with older parents.
-/// Typed object payloads surface as [`RemoteAiError`].
+/// Typed error payloads surface as [`RemoteAiError`].
 pub(crate) fn decode_stdio_ai_response(line: &str) -> Result<AiResponse> {
     let resp_msg: serde_json::Value = serde_json::from_str(line)?;
     match resp_msg["type"].as_str() {
         Some("ai_response") => Ok(serde_json::from_value(resp_msg["payload"].clone())?),
         Some("error") => {
-            let payload = &resp_msg["payload"];
-            if payload.is_object() {
-                let payload: RemoteAiErrorPayload = serde_json::from_value(payload.clone())?;
-                return Err(payload.into_error().into());
-            }
-            let err_msg = payload.as_str().unwrap_or("Unknown error");
-            bail!("Remote AI Error: {}", err_msg)
+            let payload: RemoteAiErrorPayload =
+                serde_json::from_value(resp_msg["payload"].clone())?;
+            Err(payload.into_error().into())
         }
         _ => bail!("Unexpected response type: {:?}", resp_msg["type"]),
     }
@@ -500,6 +513,8 @@ pub fn scrub_thought_signatures(val: &mut serde_json::Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker::prompts::ReviewError;
+    use anyhow::anyhow;
     use serde_json::json;
 
     #[test]
@@ -686,7 +701,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_stdio_ai_response_legacy_string_error_payload() -> Result<()> {
+    fn test_decode_stdio_ai_response_rejects_non_object_error_payload() -> Result<()> {
         let raw_json = json!({
             "type": "error",
             "payload": "Rate limit exceeded, retry after 60s"
@@ -695,10 +710,7 @@ mod tests {
 
         let err = decode_stdio_ai_response(&serialized).unwrap_err();
 
-        assert_eq!(
-            err.to_string(),
-            "Remote AI Error: Rate limit exceeded, retry after 60s"
-        );
+        assert!(err.to_string().contains("invalid type"));
         assert!(err.downcast_ref::<RemoteAiError>().is_none());
         Ok(())
     }
@@ -757,6 +769,85 @@ mod tests {
     #[test]
     fn test_classify_status_code_other() {
         assert_eq!(classify_status_code(reqwest::StatusCode::BAD_REQUEST), None);
+    }
+
+    fn assert_ai_error_class(error: impl Into<anyhow::Error>, expected: AiErrorClass) {
+        let error = error.into();
+        assert_eq!(classify_ai_error(&error), expected);
+    }
+
+    #[test]
+    fn test_classify_ai_error_remote_rate_limit() {
+        let retry_after = Duration::from_secs(42);
+        assert_ai_error_class(
+            RemoteAiError {
+                message: "remote rate limit".to_string(),
+                class: AiErrorClass::RateLimit { retry_after },
+            },
+            AiErrorClass::RateLimit { retry_after },
+        );
+    }
+
+    #[test]
+    fn test_classify_ai_error_remote_transient() {
+        let retry_after = Duration::from_secs(15);
+        assert_ai_error_class(
+            RemoteAiError {
+                message: "remote transient".to_string(),
+                class: AiErrorClass::Transient { retry_after },
+            },
+            AiErrorClass::Transient { retry_after },
+        );
+    }
+
+    #[test]
+    fn test_classify_ai_error_remote_fatal() {
+        assert_ai_error_class(
+            RemoteAiError {
+                message: "remote fatal".to_string(),
+                class: AiErrorClass::Fatal,
+            },
+            AiErrorClass::Fatal,
+        );
+    }
+
+    #[test]
+    fn test_classify_ai_error_provider_cascade() {
+        assert_ai_error_class(
+            openai::OpenAiCompatError::RateLimitExceeded(Duration::from_secs(7)),
+            AiErrorClass::RateLimit {
+                retry_after: Duration::from_secs(7),
+            },
+        );
+        assert_ai_error_class(
+            claude::ClaudeError::OverloadedError(Duration::from_secs(9)),
+            AiErrorClass::Transient {
+                retry_after: Duration::from_secs(9),
+            },
+        );
+        assert_ai_error_class(
+            gemini::GeminiError::TransientError(Duration::from_secs(11), "busy".to_string()),
+            AiErrorClass::Transient {
+                retry_after: Duration::from_secs(11),
+            },
+        );
+        assert_ai_error_class(
+            ReviewError::FormatRejection("bad response".to_string()),
+            AiErrorClass::Fatal,
+        );
+    }
+
+    #[test]
+    fn test_classify_ai_error_unrelated_error_is_fatal() {
+        assert_ai_error_class(anyhow!("totally unrelated error"), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_classify_ai_error_string_shaped_remote_error_is_fatal() {
+        assert_ai_error_class(
+            anyhow!("Remote AI Error: rate limit exceeded"),
+            AiErrorClass::Fatal,
+        );
     }
 
     #[test]

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -18,6 +18,7 @@ use anyhow::{Result, bail};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::settings::Settings;
 
@@ -144,16 +145,84 @@ pub struct AiResponse {
     pub usage: Option<AiUsage>,
 }
 
+/// Classifies a remote AI error using the typed stdio protocol payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "class", rename_all = "snake_case")]
+pub enum AiErrorClass {
+    /// The request failed permanently and should not be retried.
+    Fatal,
+    /// The provider is rate limited until the specified backoff expires.
+    RateLimit {
+        #[serde(rename = "retry_after_secs", with = "duration_secs")]
+        retry_after: Duration,
+    },
+    /// The provider returned a transient failure that may succeed later.
+    Transient {
+        #[serde(rename = "retry_after_secs", with = "duration_secs")]
+        retry_after: Duration,
+    },
+}
+
+mod duration_secs {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(duration.as_secs())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+/// Typed payload for remote AI errors sent over the stdio protocol.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RemoteAiErrorPayload {
+    pub message: String,
+    #[serde(flatten)]
+    pub class: AiErrorClass,
+}
+
+impl RemoteAiErrorPayload {
+    #[allow(dead_code)]
+    pub fn new(message: String, class: AiErrorClass) -> Self {
+        Self { message, class }
+    }
+
+    pub fn into_error(self) -> RemoteAiError {
+        RemoteAiError {
+            message: self.message,
+            class: self.class,
+        }
+    }
+}
+
+/// Error returned by a remote AI provider through the typed stdio protocol.
+#[derive(Debug, thiserror::Error)]
+#[error("Remote AI Error: {message}")]
+pub struct RemoteAiError {
+    pub message: String,
+    pub class: AiErrorClass,
+}
+
 /// Decodes a single line of the stdio AI protocol into an [`AiResponse`].
 ///
 /// Error payloads in the legacy string form surface as
 /// `Remote AI Error: ...` for backward compatibility with older parents.
+/// Typed object payloads surface as [`RemoteAiError`].
 pub(crate) fn decode_stdio_ai_response(line: &str) -> Result<AiResponse> {
     let resp_msg: serde_json::Value = serde_json::from_str(line)?;
     match resp_msg["type"].as_str() {
         Some("ai_response") => Ok(serde_json::from_value(resp_msg["payload"].clone())?),
         Some("error") => {
-            let err_msg = resp_msg["payload"].as_str().unwrap_or("Unknown error");
+            let payload = &resp_msg["payload"];
+            if payload.is_object() {
+                let payload: RemoteAiErrorPayload = serde_json::from_value(payload.clone())?;
+                return Err(payload.into_error().into());
+            }
+            let err_msg = payload.as_str().unwrap_or("Unknown error");
             bail!("Remote AI Error: {}", err_msg)
         }
         _ => bail!("Unexpected response type: {:?}", resp_msg["type"]),
@@ -483,6 +552,109 @@ mod tests {
         Ok(())
     }
 
+    fn assert_remote_ai_error_payload_wire_format(
+        class: AiErrorClass,
+        expected: serde_json::Value,
+    ) -> Result<()> {
+        let payload = RemoteAiErrorPayload::new("x".to_string(), class);
+        let serialized = serde_json::to_value(&payload)?;
+
+        assert_eq!(serialized, expected);
+
+        let round_trip: RemoteAiErrorPayload = serde_json::from_value(serialized)?;
+        assert_eq!(round_trip, payload);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remote_ai_error_payload_rate_limit_wire_format() -> Result<()> {
+        assert_remote_ai_error_payload_wire_format(
+            AiErrorClass::RateLimit {
+                retry_after: Duration::from_secs(42),
+            },
+            json!({
+                "message": "x",
+                "class": "rate_limit",
+                "retry_after_secs": 42
+            }),
+        )
+    }
+
+    #[test]
+    fn test_remote_ai_error_payload_transient_wire_format() -> Result<()> {
+        assert_remote_ai_error_payload_wire_format(
+            AiErrorClass::Transient {
+                retry_after: Duration::from_secs(15),
+            },
+            json!({
+                "message": "x",
+                "class": "transient",
+                "retry_after_secs": 15
+            }),
+        )
+    }
+
+    #[test]
+    fn test_remote_ai_error_payload_fatal_wire_format() -> Result<()> {
+        assert_remote_ai_error_payload_wire_format(
+            AiErrorClass::Fatal,
+            json!({
+                "message": "x",
+                "class": "fatal"
+            }),
+        )
+    }
+
+    #[test]
+    fn test_remote_ai_error_payload_requires_retry_after() {
+        let err = serde_json::from_value::<RemoteAiErrorPayload>(json!({
+            "message": "x",
+            "class": "rate_limit"
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("retry_after_secs"));
+    }
+
+    fn assert_typed_stdio_error_downcasts(class: AiErrorClass) -> Result<()> {
+        let raw_json = json!({
+            "type": "error",
+            "payload": RemoteAiErrorPayload::new("typed failure".to_string(), class)
+        });
+        let serialized = serde_json::to_string(&raw_json)?;
+
+        let err = decode_stdio_ai_response(&serialized).unwrap_err();
+        let remote = err
+            .downcast_ref::<RemoteAiError>()
+            .expect("typed payload should downcast to RemoteAiError");
+
+        assert_eq!(remote.message, "typed failure");
+        assert_eq!(remote.class, class);
+        assert_eq!(err.to_string(), "Remote AI Error: typed failure");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_stdio_ai_response_typed_rate_limit_error_payload() -> Result<()> {
+        assert_typed_stdio_error_downcasts(AiErrorClass::RateLimit {
+            retry_after: Duration::from_secs(60),
+        })
+    }
+
+    #[test]
+    fn test_decode_stdio_ai_response_typed_transient_error_payload() -> Result<()> {
+        assert_typed_stdio_error_downcasts(AiErrorClass::Transient {
+            retry_after: Duration::from_secs(5),
+        })
+    }
+
+    #[test]
+    fn test_decode_stdio_ai_response_typed_fatal_error_payload() -> Result<()> {
+        assert_typed_stdio_error_downcasts(AiErrorClass::Fatal)
+    }
+
     #[test]
     fn test_decode_stdio_ai_response_legacy_string_error_payload() -> Result<()> {
         let raw_json = json!({
@@ -497,6 +669,24 @@ mod tests {
             err.to_string(),
             "Remote AI Error: Rate limit exceeded, retry after 60s"
         );
+        assert!(err.downcast_ref::<RemoteAiError>().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_stdio_ai_response_malformed_typed_error_payload() -> Result<()> {
+        let raw_json = json!({
+            "type": "error",
+            "payload": {
+                "message": "try again later",
+                "class": "transient"
+            }
+        });
+        let serialized = serde_json::to_string(&raw_json)?;
+
+        let err = decode_stdio_ai_response(&serialized).unwrap_err();
+
+        assert!(err.to_string().contains("retry_after_secs"));
         Ok(())
     }
 

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -144,6 +144,22 @@ pub struct AiResponse {
     pub usage: Option<AiUsage>,
 }
 
+/// Decodes a single line of the stdio AI protocol into an [`AiResponse`].
+///
+/// Error payloads in the legacy string form surface as
+/// `Remote AI Error: ...` for backward compatibility with older parents.
+pub(crate) fn decode_stdio_ai_response(line: &str) -> Result<AiResponse> {
+    let resp_msg: serde_json::Value = serde_json::from_str(line)?;
+    match resp_msg["type"].as_str() {
+        Some("ai_response") => Ok(serde_json::from_value(resp_msg["payload"].clone())?),
+        Some("error") => {
+            let err_msg = resp_msg["payload"].as_str().unwrap_or("Unknown error");
+            bail!("Remote AI Error: {}", err_msg)
+        }
+        _ => bail!("Unexpected response type: {:?}", resp_msg["type"]),
+    }
+}
+
 /// Token usage statistics for an AI interaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiUsage {
@@ -464,6 +480,23 @@ mod tests {
         assert_eq!(usage.completion_tokens, 50);
         assert_eq!(usage.total_tokens, 150);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_stdio_ai_response_legacy_string_error_payload() -> Result<()> {
+        let raw_json = json!({
+            "type": "error",
+            "payload": "Rate limit exceeded, retry after 60s"
+        });
+        let serialized = serde_json::to_string(&raw_json)?;
+
+        let err = decode_stdio_ai_response(&serialized).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Remote AI Error: Rate limit exceeded, retry after 60s"
+        );
         Ok(())
     }
 

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -14,8 +14,8 @@
 
 use crate::ai::token_budget::TokenBudget;
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiResponseFormat, AiRole, AiUsage, ProviderCapabilities,
-    ToolCall,
+    AiErrorClass, AiProvider, AiRequest, AiResponse, AiResponseFormat, AiRole, AiUsage,
+    ClassifyAiError, ProviderCapabilities, ToolCall, classify_status_code,
 };
 use crate::utils::redact_secret;
 use anyhow::Result;
@@ -111,6 +111,23 @@ pub enum OpenAiCompatError {
     AuthenticationError(String),
     #[error("API error {0}: {1}")]
     ApiError(reqwest::StatusCode, String),
+}
+
+impl ClassifyAiError for OpenAiCompatError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        match self {
+            OpenAiCompatError::RateLimitExceeded(retry_after) => AiErrorClass::RateLimit {
+                retry_after: *retry_after,
+            },
+            OpenAiCompatError::TransientError(retry_after, _) => AiErrorClass::Transient {
+                retry_after: *retry_after,
+            },
+            OpenAiCompatError::AuthenticationError(_) => AiErrorClass::Fatal,
+            OpenAiCompatError::ApiError(status, _) => {
+                classify_status_code(*status).unwrap_or(AiErrorClass::Fatal)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -501,8 +518,62 @@ impl AiProvider for OpenAiCompatClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::{AiMessage, AiTool};
+    use crate::ai::{AiErrorClass, AiMessage, AiTool, ClassifyAiError, DEFAULT_RETRY_AFTER};
     use serde_json::json;
+
+    #[test]
+    fn test_rate_limit_exceeded_classifies_as_rate_limit() {
+        let retry_after = Duration::from_secs(7);
+        let err = OpenAiCompatError::RateLimitExceeded(retry_after);
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::RateLimit { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_transient_error_classifies_as_transient() {
+        let retry_after = Duration::from_secs(11);
+        let err = OpenAiCompatError::TransientError(retry_after, "busy".to_string());
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient { retry_after }
+        );
+    }
+
+    #[test]
+    fn test_authentication_error_classifies_as_fatal() {
+        let err = OpenAiCompatError::AuthenticationError("bad key".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_api_error_server_status_classifies_as_transient() {
+        let err = OpenAiCompatError::ApiError(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "unavailable".to_string(),
+        );
+
+        assert_eq!(
+            err.ai_error_class(),
+            AiErrorClass::Transient {
+                retry_after: DEFAULT_RETRY_AFTER,
+            }
+        );
+    }
+
+    #[test]
+    fn test_api_error_client_status_classifies_as_fatal() {
+        let err = OpenAiCompatError::ApiError(
+            reqwest::StatusCode::BAD_REQUEST,
+            "bad request".to_string(),
+        );
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
 
     #[test]
     fn test_translate_request_system_and_user() -> Result<()> {

--- a/src/ai/proxy.rs
+++ b/src/ai/proxy.rs
@@ -48,8 +48,11 @@ pub async fn handle_generate(
                         state.quota_manager.report_quota_error(retry_after).await;
                         continue;
                     }
-                    AiErrorClass::Transient { .. } => {
-                        state.quota_manager.report_transient_error().await;
+                    AiErrorClass::Transient { retry_after } => {
+                        state
+                            .quota_manager
+                            .report_transient_error(retry_after)
+                            .await;
                         continue;
                     }
                     AiErrorClass::Fatal => {}

--- a/src/ai/proxy.rs
+++ b/src/ai/proxy.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ai::gemini::{GeminiClient, GeminiError, GenerateContentRequest};
+use crate::ai::gemini::{GeminiClient, GenerateContentRequest};
 use crate::ai::quota::QuotaManager;
+use crate::ai::{AiErrorClass, classify_ai_error};
 use axum::{
     extract::{Json, State},
     http::StatusCode,
@@ -42,18 +43,16 @@ pub async fn handle_generate(
                 return (StatusCode::OK, Json(response)).into_response();
             }
             Err(e) => {
-                if let Some(err) = e.downcast_ref::<GeminiError>() {
-                    match err {
-                        GeminiError::QuotaExceeded(duration) => {
-                            state.quota_manager.report_quota_error(*duration).await;
-                            continue;
-                        }
-                        GeminiError::TransientError(_, _) => {
-                            state.quota_manager.report_transient_error().await;
-                            continue;
-                        }
-                        _ => {}
+                match classify_ai_error(&e) {
+                    AiErrorClass::RateLimit { retry_after } => {
+                        state.quota_manager.report_quota_error(retry_after).await;
+                        continue;
                     }
+                    AiErrorClass::Transient { .. } => {
+                        state.quota_manager.report_transient_error().await;
+                        continue;
+                    }
+                    AiErrorClass::Fatal => {}
                 }
 
                 error!("Gemini Proxy Error: {}", e);

--- a/src/ai/quota.rs
+++ b/src/ai/quota.rs
@@ -96,14 +96,15 @@ impl QuotaManager {
         );
     }
 
-    pub async fn report_transient_error(&self) {
+    pub async fn report_transient_error(&self, retry_after: Duration) {
+        let retry_after = retry_after.min(MAX_RETRY_AFTER);
         let mut count_guard = self.consecutive_transient_errors.lock().await;
         *count_guard += 1;
         let count = *count_guard;
 
         // Exponential backoff: 1s, 2s, 4s, 8s... capped at 60s
         let backoff_secs = (1.0 * (2.0_f64.powi((count - 1) as i32))).min(60.0);
-        let backoff = Duration::from_secs_f64(backoff_secs);
+        let backoff = Duration::from_secs_f64(backoff_secs).max(retry_after);
 
         let mut block_guard = self.blocked_until.lock().await;
         let resume_time = Instant::now() + backoff;
@@ -118,7 +119,8 @@ impl QuotaManager {
 
         warn!(
             "AI provider transient error (streak: {}). Globally backing off for {:.2}s",
-            count, backoff_secs
+            count,
+            backoff.as_secs_f64()
         );
     }
 }

--- a/src/ai/quota.rs
+++ b/src/ai/quota.rs
@@ -16,6 +16,8 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(5 * 60);
+
 pub struct QuotaManager {
     // Stores the time when we can resume making requests.
     // If None or in the past, we are free to go.
@@ -76,6 +78,7 @@ impl QuotaManager {
     }
 
     pub async fn report_quota_error(&self, retry_after: Duration) {
+        let retry_after = retry_after.min(MAX_RETRY_AFTER);
         let mut guard = self.blocked_until.lock().await;
         let resume_time = Instant::now() + retry_after;
 

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -554,18 +554,31 @@ async fn process_entry(
 
         match client.generate_content(req).await {
             Ok(r) => break r,
-            Err(e) => {
-                let retry_after = match classify_ai_error(&e) {
-                    AiErrorClass::RateLimit { retry_after }
-                    | AiErrorClass::Transient { retry_after } => retry_after,
-                    AiErrorClass::Fatal => std::time::Duration::from_secs(30),
-                };
-                warn!(
-                    "API error ({}), pausing for {:?} before retry...",
-                    e, retry_after
-                );
-                tokio::time::sleep(retry_after).await;
-            }
+            Err(e) => match classify_ai_error(&e) {
+                AiErrorClass::RateLimit { retry_after }
+                | AiErrorClass::Transient { retry_after } => {
+                    warn!(
+                        "API error ({}), pausing for {:?} before retry...",
+                        e, retry_after
+                    );
+                    tokio::time::sleep(retry_after).await;
+                }
+                AiErrorClass::Fatal => {
+                    return BenchmarkResult {
+                        commit: entry.commit,
+                        problem_description,
+                        found: false,
+                        status: "UNKNOWN".to_string(),
+                        explanation: format!("Evaluation failed: {}", e),
+                        findings_count,
+                        concerns_count,
+                        tokens_in,
+                        tokens_out,
+                        turns,
+                        duration_secs,
+                    };
+                }
+            },
         }
     };
 

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -17,10 +17,9 @@ use clap::Parser;
 use futures::stream::StreamExt;
 use regex::Regex;
 use reqwest::Client;
-use sashiko::ai::claude::ClaudeError;
-use sashiko::ai::gemini::GeminiError;
-use sashiko::ai::openai::OpenAiCompatError;
-use sashiko::ai::{AiMessage, AiProvider, AiRequest, AiRole, create_provider};
+use sashiko::ai::{
+    AiErrorClass, AiMessage, AiProvider, AiRequest, AiRole, classify_ai_error, create_provider,
+};
 use sashiko::db::Database;
 use sashiko::settings::Settings;
 use serde::{Deserialize, Serialize};
@@ -556,36 +555,16 @@ async fn process_entry(
         match client.generate_content(req).await {
             Ok(r) => break r,
             Err(e) => {
-                let retry_duration =
-                    e.downcast_ref::<GeminiError>()
-                        .and_then(|err| match err {
-                            GeminiError::QuotaExceeded(d) | GeminiError::TransientError(d, _) => {
-                                Some(*d)
-                            }
-                            _ => None,
-                        })
-                        .or_else(|| {
-                            e.downcast_ref::<ClaudeError>().and_then(|err| match err {
-                                ClaudeError::RateLimitExceeded(d)
-                                | ClaudeError::OverloadedError(d) => Some(*d),
-                                _ => None,
-                            })
-                        })
-                        .or_else(|| {
-                            e.downcast_ref::<OpenAiCompatError>()
-                                .and_then(|err| match err {
-                                    OpenAiCompatError::RateLimitExceeded(d)
-                                    | OpenAiCompatError::TransientError(d, _) => Some(*d),
-                                    _ => None,
-                                })
-                        });
-
-                let duration = retry_duration.unwrap_or(std::time::Duration::from_secs(30));
+                let retry_after = match classify_ai_error(&e) {
+                    AiErrorClass::RateLimit { retry_after }
+                    | AiErrorClass::Transient { retry_after } => retry_after,
+                    AiErrorClass::Fatal => std::time::Duration::from_secs(30),
+                };
                 warn!(
                     "API error ({}), pausing for {:?} before retry...",
-                    e, duration
+                    e, retry_after
                 );
-                tokio::time::sleep(duration).await;
+                tokio::time::sleep(retry_after).await;
             }
         }
     };

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1682,9 +1682,9 @@ async fn run_review_tool(
                                             }
                                             Err(e) => {
                                                 match classify_ai_error(&e) {
-                                                    AiErrorClass::RateLimit { .. } => {
+                                                    AiErrorClass::RateLimit { retry_after } => {
                                                         quota_manager
-                                                            .report_quota_error(Duration::from_secs(60))
+                                                            .report_quota_error(retry_after)
                                                             .await;
                                                         continue;
                                                     }
@@ -2122,7 +2122,10 @@ mod tests {
     use async_trait::async_trait;
     use std::fs::Permissions;
     use std::os::unix::fs::PermissionsExt;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use tempfile::tempdir;
 
     struct MockProvider;
@@ -2156,6 +2159,41 @@ mod tests {
     impl AiProvider for FailingProvider {
         async fn generate_content(&self, _request: AiRequest) -> Result<AiResponse> {
             Err(anyhow::anyhow!("fatal provider failure"))
+        }
+
+        fn estimate_tokens(&self, _request: &AiRequest) -> usize {
+            0
+        }
+
+        fn get_capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                model_name: "mock".to_string(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    struct RateLimitThenSuccessProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl AiProvider for RateLimitThenSuccessProvider {
+        async fn generate_content(&self, _request: AiRequest) -> Result<AiResponse> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(crate::ai::openai::OpenAiCompatError::RateLimitExceeded(
+                    std::time::Duration::from_millis(1),
+                )
+                .into());
+            }
+
+            Ok(AiResponse {
+                content: Some("Recovered after rate limit".to_string()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                usage: None,
+            })
         }
 
         fn estimate_tokens(&self, _request: &AiRequest) -> usize {
@@ -2352,6 +2390,30 @@ fi
         let result = run_single_ai_request_mock(mock_script, Arc::new(FailingProvider)).await?;
 
         assert_eq!(result["patches"][0]["status"], "typed_fatal");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_run_review_tool_retries_rate_limits_without_child_error() -> Result<()> {
+        let mock_script = r#"#!/bin/bash
+read -r input
+echo '{"type":"ai_request","payload":{"messages":[{"role":"user","content":"hello"}]}}'
+read -r ai_response
+if [[ "$ai_response" == *'"type":"error"'* ]]; then
+    echo '{"patchset_id":1,"patches":[{"index":1,"status":"error_written"}]}'
+else
+    echo '{"patchset_id":1,"patches":[{"index":1,"status":"applied"}]}'
+fi
+"#;
+        let provider = Arc::new(RateLimitThenSuccessProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let provider_for_tool: Arc<dyn AiProvider> = provider.clone();
+
+        let result = run_single_ai_request_mock(mock_script, provider_for_tool).await?;
+
+        assert_eq!(result["patches"][0]["status"], "applied");
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
         Ok(())
     }
 

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1688,8 +1688,10 @@ async fn run_review_tool(
                                                             .await;
                                                         continue;
                                                     }
-                                                    AiErrorClass::Transient { .. } => {
-                                                        quota_manager.report_transient_error().await;
+                                                    AiErrorClass::Transient { retry_after } => {
+                                                        quota_manager
+                                                            .report_transient_error(retry_after)
+                                                            .await;
                                                         continue;
                                                     }
                                                     AiErrorClass::Fatal => break Err(e),

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -14,7 +14,10 @@
 
 use crate::ReviewStatus;
 use crate::ai::quota::QuotaManager;
-use crate::ai::{AiProvider, AiRequest, create_provider_cached};
+use crate::ai::{
+    AiErrorClass, AiProvider, AiRequest, RemoteAiErrorPayload, classify_ai_error,
+    create_provider_cached,
+};
 use crate::baseline::{BaselineRegistry, BaselineResolution, extract_files_from_diff};
 use crate::db::{AiInteractionParams, Database, Finding, PatchsetRow, Severity, ToolUsage};
 use crate::email_policy::EmailPolicyConfig;
@@ -1678,27 +1681,19 @@ async fn run_review_tool(
                                                 break Ok(resp);
                                             }
                                             Err(e) => {
-                                                let err_str = e.to_string();
-
-                                                // Categorize and report errors to QuotaManager
-                                                if err_str.contains("Quota exceeded")
-                                                    || err_str.contains("429")
-                                                {
-                                                    quota_manager
-                                                        .report_quota_error(Duration::from_secs(60))
-                                                        .await;
-                                                    continue;
+                                                match classify_ai_error(&e) {
+                                                    AiErrorClass::RateLimit { .. } => {
+                                                        quota_manager
+                                                            .report_quota_error(Duration::from_secs(60))
+                                                            .await;
+                                                        continue;
+                                                    }
+                                                    AiErrorClass::Transient { .. } => {
+                                                        quota_manager.report_transient_error().await;
+                                                        continue;
+                                                    }
+                                                    AiErrorClass::Fatal => break Err(e),
                                                 }
-                                                if err_str.contains("Transient error")
-                                                    || err_str.contains("503")
-                                                    || err_str.contains("529")
-                                                    || err_str.contains("overloaded")
-                                                {
-                                                    quota_manager.report_transient_error().await;
-                                                    continue;
-                                                }
-
-                                                break Err(e);
                                             }
                                         }
                                     }
@@ -1769,7 +1764,10 @@ async fn run_review_tool(
                                             json!({ "type": "ai_response", "payload": p })
                                         }
                                         Err(e) => {
-                                            json!({ "type": "error", "payload": e.to_string() })
+                                            let message = e.to_string();
+                                            let class = classify_ai_error(&e);
+                                            let payload = RemoteAiErrorPayload::new(message, class);
+                                            json!({ "type": "error", "payload": payload })
                                         }
                                     };
                                     let mut reply_str = serde_json::to_string(&reply)?;
@@ -2152,6 +2150,90 @@ mod tests {
         }
     }
 
+    struct FailingProvider;
+
+    #[async_trait]
+    impl AiProvider for FailingProvider {
+        async fn generate_content(&self, _request: AiRequest) -> Result<AiResponse> {
+            Err(anyhow::anyhow!("fatal provider failure"))
+        }
+
+        fn estimate_tokens(&self, _request: &AiRequest) -> usize {
+            0
+        }
+
+        fn get_capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                model_name: "mock".to_string(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    async fn run_single_ai_request_mock(
+        mock_script: &str,
+        provider: Arc<dyn AiProvider>,
+    ) -> Result<Value> {
+        let temp_dir = tempdir()?;
+        let bin_path = temp_dir.path().join("mock_review");
+
+        std::fs::write(&bin_path, mock_script)?;
+        std::fs::set_permissions(&bin_path, Permissions::from_mode(0o755))?;
+
+        let mut settings = Settings::new()?;
+        settings.database.url = ":memory:".to_string();
+        settings.review.review_tool_override = Some(bin_path);
+        settings.review.timeout_seconds = 5;
+
+        let db = Arc::new(Database::new(&settings.database).await?);
+        db.migrate().await?;
+        let quota_manager = Arc::new(QuotaManager::new());
+
+        let thread_id = db.create_thread("msg_id_1", "Subject", 1000).await?;
+        db.create_message(
+            "msg_id_p1",
+            thread_id,
+            None,
+            "Author",
+            "Subject",
+            1000,
+            "Body",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await?;
+        let ps_id = db
+            .create_patchset(
+                thread_id, None, "msg_id_1", "Subject", "Author", 1000, 1, 1, "", "", None, 1,
+                None, false, None, None,
+            )
+            .await?
+            .expect("Failed to create patchset");
+        let p_id = db
+            .create_patch(ps_id, "msg_id_p1", 1, "diff --git a/foo.c b/foo.c\n+int x;")
+            .await?;
+        let review_id = db
+            .create_review(ps_id, Some(p_id), "mock", "mock", None, None)
+            .await?;
+
+        run_review_tool(
+            ps_id,
+            &json!({}),
+            &settings,
+            db,
+            "HEAD",
+            Some(1),
+            None,
+            quota_manager,
+            review_id,
+            None,
+            provider,
+        )
+        .await
+    }
+
     #[tokio::test]
     async fn test_run_review_tool_concurrency() -> Result<()> {
         let temp_dir = tempdir()?;
@@ -2251,6 +2333,25 @@ echo '{"patchset_id": 1, "patches": [{"index": 1, "status": "applied"}]}'
         assert_eq!(result.unwrap()["patchset_id"], 1);
 
         child.wait().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_run_review_tool_sends_typed_fatal_error_payload() -> Result<()> {
+        let mock_script = r#"#!/bin/bash
+read -r input
+echo '{"type":"ai_request","payload":{"messages":[{"role":"user","content":"hello"}]}}'
+read -r ai_response
+if [[ "$ai_response" == *'"type":"error"'* && "$ai_response" == *'"message":"fatal provider failure"'* && "$ai_response" == *'"class":"fatal"'* ]]; then
+    echo '{"patchset_id":1,"patches":[{"index":1,"status":"typed_fatal"}]}'
+else
+    echo '{"patchset_id":1,"patches":[{"index":1,"status":"unexpected"}]}'
+fi
+"#;
+
+        let result = run_single_ai_request_mock(mock_script, Arc::new(FailingProvider)).await?;
+
+        assert_eq!(result["patches"][0]["status"], "typed_fatal");
         Ok(())
     }
 

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ai::{AiMessage, AiProvider, AiRequest, AiResponseFormat, AiRole};
+use crate::ai::{
+    AiErrorClass, AiMessage, AiProvider, AiRequest, AiResponseFormat, AiRole, ClassifyAiError,
+};
 use crate::worker::tools::ToolBox;
 use anyhow::{Context, Result};
 
@@ -32,6 +34,17 @@ pub enum ReviewError {
     #[error("Format validation failed: {0}")]
     FormatRejection(String),
 }
+
+impl ClassifyAiError for ReviewError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        match self {
+            ReviewError::LimitExceeded => AiErrorClass::Fatal,
+            ReviewError::BudgetExceeded(_) => AiErrorClass::Fatal,
+            ReviewError::FormatRejection(_) => AiErrorClass::Fatal,
+        }
+    }
+}
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -1598,6 +1611,27 @@ mod tests {
     }
 
     // ReviewError tests
+
+    #[test]
+    fn test_limit_exceeded_classifies_as_fatal() {
+        let err = ReviewError::LimitExceeded;
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_budget_exceeded_classifies_as_fatal() {
+        let err = ReviewError::BudgetExceeded("1000 tokens used (limit: 500)".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
+
+    #[test]
+    fn test_format_rejection_classifies_as_fatal() {
+        let err = ReviewError::FormatRejection("contains markdown code blocks".to_string());
+
+        assert_eq!(err.ai_error_class(), AiErrorClass::Fatal);
+    }
 
     #[test]
     fn test_limit_exceeded_downcasts_as_review_error() {


### PR DESCRIPTION
We have an OpenAI type LLM proxy that generates rate limit responses. Currently Sashiko just ignores the required delay and immediately resends the request, which gives another rate limit and eventually it blows up the whole review.

After this patch the rate limiting works more like I would expect:

 2026-05-10T13:30:55.155717Z  WARN sashiko::ai::openai: OpenAI 429 Rate Limit. Retry in 60s
 2026-05-10T13:30:55.155946Z  WARN sashiko::ai::quota: Quota exhausted! Blocking all LLM requests for 60.00s
 2026-05-10T13:30:55.155967Z  INFO sashiko::ai::quota: [ps:21 p:1 s:3] Global AI rate limit/quota active. Waiting for 60.00s...
 2026-05-10T13:31:55.158072Z  INFO sashiko::ai::openai: Sending OpenAI request...

I have to say I'm a little unconformable sending this, I don't know rust and the entire thing was written by Claude and Codex as a reviewer/implementer pair. I've tested it and confirmed it improves my situation. The AI generated plan that created the commit is in the commit message. I didn't think this was significant enough to qualify for a designs/ file?  I challenged the AI a bit and it seems to think this is a Rusty pattern. Though Claude did offer an alternative:

```
2. Unified enum with #[from]

#[derive(thiserror::Error)]
pub enum AiError {
    #[from] Claude(ClaudeError),
    #[from] OpenAi(OpenAiCompatError),
    #[from] Gemini(GeminiError),
    Wrapped(String),
}
Every provider call returns Result<_, AiError>. The classifier becomes a single exhaustive match — no downcasting at all.

This is the most "Rust-y" answer and is closest to what your "class hierarchy" instinct is reaching for. But the cost is high here: you'd have to change return types throughout src/ai/, src/reviewer.rs, the proxy, the benchmark, and the worker. Every ? that crosses the boundary needs the conversion. Given that the whole codebase is on anyhow, you'd be swimming upstream.
```

But it sounded scary so I left it. As far as I can tell the AI tool ran all the requested checks and they worked.