### PR TITLE
ai: unify claude JSON instructions and error handling

### DIFF
--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -174,18 +174,57 @@ fn translate_request(
     thinking: Option<&str>,
     effort: Option<&str>,
 ) -> Result<ConverseParams> {
-    let system = request.system.as_ref().map(|s| {
-        let mut blocks = vec![SystemContentBlock::Text(s.clone())];
-        if enable_caching {
-            blocks.push(SystemContentBlock::CachePoint(
-                CachePointBlock::builder()
-                    .r#type(CachePointType::Default)
-                    .build()
-                    .expect("CachePointBlock build"),
-            ));
+    let mut system_blocks = Vec::new();
+
+    if let Some(s) = &request.system {
+        system_blocks.push(SystemContentBlock::Text(s.clone()));
+    }
+
+    // Collect any system messages from the messages array
+    for msg in &request.messages {
+        if let (AiRole::System, Some(content)) = (&msg.role, &msg.content) {
+            system_blocks.push(SystemContentBlock::Text(content.clone()));
         }
-        blocks
-    });
+    }
+
+    // Handle response format by appending instructions to the system prompt
+    // since Bedrock doesn't support it natively for all models.
+    if let Some(format) = &request.response_format {
+        match format {
+            crate::ai::AiResponseFormat::Json { schema } => {
+                let instruction = if let Some(schema) = schema {
+                    format!(
+                        "\n\nYou MUST respond with ONLY a JSON object matching this schema: {}\nNo other text before or after the JSON.",
+                        serde_json::to_string(schema).unwrap_or_default()
+                    )
+                } else {
+                    "\n\nYou MUST respond with ONLY a JSON object.\nNo other text before or after the JSON.".to_string()
+                };
+
+                if let Some(SystemContentBlock::Text(text)) = system_blocks.last_mut() {
+                    text.push_str(&instruction);
+                } else {
+                    system_blocks.push(SystemContentBlock::Text(instruction.trim().to_string()));
+                }
+            }
+            crate::ai::AiResponseFormat::Text => {}
+        }
+    }
+
+    if enable_caching && !system_blocks.is_empty() {
+        system_blocks.push(SystemContentBlock::CachePoint(
+            CachePointBlock::builder()
+                .r#type(CachePointType::Default)
+                .build()
+                .expect("CachePointBlock build"),
+        ));
+    }
+
+    let system = if system_blocks.is_empty() {
+        None
+    } else {
+        Some(system_blocks)
+    };
 
     let mut messages: Vec<Message> = Vec::new();
 
@@ -529,37 +568,63 @@ mod tests {
 
     #[test]
     fn test_translate_system_and_user() -> Result<()> {
-        let mut req = make_request(vec![AiMessage {
-            role: AiRole::User,
-            content: Some("Hello!".to_string()),
-            thought: None,
-            thought_signature: None,
-            tool_calls: None,
-            tool_call_id: None,
-        }]);
-        req.system = Some("You are helpful.".to_string());
+        let mut req = make_request(vec![
+            AiMessage {
+                role: AiRole::System,
+                content: Some("System 2.".to_string()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            AiMessage {
+                role: AiRole::User,
+                content: Some("Hello!".to_string()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ]);
+        req.system = Some("System 1.".to_string());
         req.temperature = Some(0.5);
 
         let params = translate_request(&req, false, 4096, None, None)?;
 
         let sys = params.system.unwrap();
-        assert_eq!(sys.len(), 1);
+        assert_eq!(sys.len(), 2);
         if let SystemContentBlock::Text(t) = &sys[0] {
-            assert_eq!(t, "You are helpful.");
-        } else {
-            panic!("Expected Text system block");
+            assert_eq!(t, "System 1.");
+        }
+        if let SystemContentBlock::Text(t) = &sys[1] {
+            assert_eq!(t, "System 2.");
         }
 
         assert_eq!(params.messages.len(), 1);
         assert_eq!(params.messages[0].role(), &ConversationRole::User);
-        if let ContentBlock::Text(t) = &params.messages[0].content()[0] {
-            assert_eq!(t, "Hello!");
-        } else {
-            panic!("Expected Text content block");
-        }
 
-        let ic = params.inference_config.unwrap();
-        assert_eq!(ic.temperature(), Some(0.5));
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_request_json_format() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.response_format = Some(crate::ai::AiResponseFormat::Json { schema: None });
+
+        let params = translate_request(&req, false, 4096, None, None)?;
+        let sys = params.system.unwrap();
+        if let SystemContentBlock::Text(t) = &sys[0] {
+            assert!(t.contains("MUST respond with ONLY a JSON object"));
+        } else {
+            panic!("Expected Text system block");
+        }
 
         Ok(())
     }

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -352,6 +352,32 @@ pub fn translate_ai_request(
         });
     }
 
+    // Inject strict JSON formatting instruction if requested
+    if let Some(instruction) = request
+        .response_format
+        .as_ref()
+        .and_then(|f| f.format_json_schema_instruction())
+    {
+        if let Some(last_block) = system_blocks.last_mut() {
+            if last_block.block_type == "text" {
+                last_block.text.push_str("\n\n");
+                last_block.text.push_str(&instruction);
+            } else {
+                system_blocks.push(SystemBlock {
+                    block_type: "text".to_string(),
+                    text: instruction,
+                    cache_control: None,
+                });
+            }
+        } else {
+            system_blocks.push(SystemBlock {
+                block_type: "text".to_string(),
+                text: instruction,
+                cache_control: None,
+            });
+        }
+    }
+
     // Translate messages
     for msg in &request.messages {
         match msg.role {
@@ -445,34 +471,6 @@ pub fn translate_ai_request(
             })
             .collect()
     });
-
-    // Handle response format by appending instructions to the system prompt
-    // since Claude API doesn't support it natively.
-    if let Some(format) = &request.response_format {
-        match format {
-            crate::ai::AiResponseFormat::Json { schema } => {
-                let instruction = if let Some(schema) = schema {
-                    format!(
-                        "\n\nYou MUST respond with ONLY a JSON object matching this schema: {}\nNo other text before or after the JSON.",
-                        serde_json::to_string(schema).unwrap_or_default()
-                    )
-                } else {
-                    "\n\nYou MUST respond with ONLY a JSON object.\nNo other text before or after the JSON.".to_string()
-                };
-
-                if let Some(last_sys) = system_blocks.last_mut() {
-                    last_sys.text.push_str(&instruction);
-                } else {
-                    system_blocks.push(SystemBlock {
-                        block_type: "text".to_string(),
-                        text: instruction.trim().to_string(),
-                        cache_control: None,
-                    });
-                }
-            }
-            crate::ai::AiResponseFormat::Text => {}
-        }
-    }
 
     // Build the request
     let mut claude_request = ClaudeRequest {
@@ -1185,7 +1183,11 @@ mod tests {
 
         let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
         let sys = claude_req.system.unwrap();
-        assert!(sys[0].text.contains("MUST respond with ONLY a JSON object"));
+        assert!(
+            sys[0]
+                .text
+                .contains("MUST respond with ONLY a valid JSON object")
+        );
 
         Ok(())
     }

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -446,6 +446,34 @@ pub fn translate_ai_request(
             .collect()
     });
 
+    // Handle response format by appending instructions to the system prompt
+    // since Claude API doesn't support it natively.
+    if let Some(format) = &request.response_format {
+        match format {
+            crate::ai::AiResponseFormat::Json { schema } => {
+                let instruction = if let Some(schema) = schema {
+                    format!(
+                        "\n\nYou MUST respond with ONLY a JSON object matching this schema: {}\nNo other text before or after the JSON.",
+                        serde_json::to_string(schema).unwrap_or_default()
+                    )
+                } else {
+                    "\n\nYou MUST respond with ONLY a JSON object.\nNo other text before or after the JSON.".to_string()
+                };
+
+                if let Some(last_sys) = system_blocks.last_mut() {
+                    last_sys.text.push_str(&instruction);
+                } else {
+                    system_blocks.push(SystemBlock {
+                        block_type: "text".to_string(),
+                        text: instruction.trim().to_string(),
+                        cache_control: None,
+                    });
+                }
+            }
+            crate::ai::AiResponseFormat::Text => {}
+        }
+    }
+
     // Build the request
     let mut claude_request = ClaudeRequest {
         model: String::new(), // Will be set by the client
@@ -1143,7 +1171,24 @@ mod tests {
         Ok(())
     }
 
-    // --- Cache control tests ---
+    #[test]
+    fn test_translate_request_json_format() -> Result<()> {
+        let mut req = make_request(vec![AiMessage {
+            role: AiRole::User,
+            content: Some("hi".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }]);
+        req.response_format = Some(crate::ai::AiResponseFormat::Json { schema: None });
+
+        let claude_req = translate_ai_request(&req, false, 4096, None, None)?;
+        let sys = claude_req.system.unwrap();
+        assert!(sys[0].text.contains("MUST respond with ONLY a JSON object"));
+
+        Ok(())
+    }
 
     #[test]
     fn test_cache_control_applied() -> Result<()> {

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -34,8 +34,8 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::ai::{
-    AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage,
-    ClassifyAiError, ProviderCapabilities, ToolCall,
+    AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ClassifyAiError,
+    ProviderCapabilities, ToolCall,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -145,16 +145,15 @@ impl AiProvider for ClaudeCliProvider {
             .into());
         }
         let outer: Value = serde_json::from_str(&raw).map_err(|e| {
-            ClaudeCliError::Parse(format!(
-                "{}\nRaw: {}",
-                e,
-                &raw[..raw.len().min(200)]
-            ))
+            ClaudeCliError::Parse(format!("{}\nRaw: {}", e, &raw[..raw.len().min(200)]))
         })?;
 
         if outer["is_error"].as_bool().unwrap_or(false) {
             return Err(ClaudeCliError::Cli(
-                outer["result"].as_str().unwrap_or("unknown error").to_string(),
+                outer["result"]
+                    .as_str()
+                    .unwrap_or("unknown error")
+                    .to_string(),
             )
             .into());
         }

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -34,9 +34,39 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::ai::{
-    AiProvider, AiRequest, AiResponse, AiResponseFormat, AiRole, AiUsage, ProviderCapabilities,
-    ToolCall,
+    AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage,
+    ClassifyAiError, ProviderCapabilities, ToolCall,
 };
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClaudeCliError {
+    #[error("Failed to spawn claude CLI: {0}")]
+    Spawn(String),
+    #[error("claude CLI timed out after 10 minutes")]
+    Timeout,
+    #[error("claude CLI wait error: {0}")]
+    Wait(String),
+    #[error("claude CLI error: {0}")]
+    Cli(String),
+    #[error("Failed to parse claude CLI JSON output: {0}")]
+    Parse(String),
+}
+
+impl ClassifyAiError for ClaudeCliError {
+    fn ai_error_class(&self) -> AiErrorClass {
+        match self {
+            ClaudeCliError::Spawn(_) => AiErrorClass::Fatal,
+            ClaudeCliError::Timeout => AiErrorClass::Transient {
+                retry_after: Duration::from_secs(30),
+            },
+            ClaudeCliError::Wait(_) => AiErrorClass::Transient {
+                retry_after: Duration::from_secs(30),
+            },
+            ClaudeCliError::Cli(_) => AiErrorClass::Fatal,
+            ClaudeCliError::Parse(_) => AiErrorClass::Fatal,
+        }
+    }
+}
 
 pub struct ClaudeCliProvider {
     pub model: String,
@@ -72,7 +102,7 @@ impl AiProvider for ClaudeCliProvider {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| anyhow::anyhow!("Failed to spawn claude CLI: {}. Is it installed?", e))?;
+            .map_err(|e| ClaudeCliError::Spawn(e.to_string()))?;
 
         // Write prompt to stdin then close it
         if let Some(mut stdin) = child.stdin.take() {
@@ -83,8 +113,8 @@ impl AiProvider for ClaudeCliProvider {
         // 10-minute timeout per CLI call — a hung claude process won't block forever
         let output = timeout(Duration::from_secs(600), child.wait_with_output())
             .await
-            .map_err(|_| anyhow::anyhow!("claude CLI timed out after 10 minutes"))?
-            .map_err(|e| anyhow::anyhow!("claude CLI wait error: {}", e))?;
+            .map_err(|_| ClaudeCliError::Timeout)?
+            .map_err(|e| ClaudeCliError::Wait(e.to_string()))?;
 
         if !output.stderr.is_empty() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -104,28 +134,29 @@ impl AiProvider for ClaudeCliProvider {
             if let Ok(outer) = serde_json::from_str::<Value>(&raw)
                 && let Some(msg) = outer["result"].as_str()
             {
-                anyhow::bail!("claude CLI error: {}", msg);
+                return Err(ClaudeCliError::Cli(msg.to_string()).into());
             }
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "claude CLI exited with {}: {}",
+            return Err(ClaudeCliError::Cli(format!(
+                "exited with {}: {}",
                 output.status,
                 stderr.trim()
-            );
+            ))
+            .into());
         }
         let outer: Value = serde_json::from_str(&raw).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to parse claude CLI JSON output: {}\nRaw: {}",
+            ClaudeCliError::Parse(format!(
+                "{}\nRaw: {}",
                 e,
                 &raw[..raw.len().min(200)]
-            )
+            ))
         })?;
 
         if outer["is_error"].as_bool().unwrap_or(false) {
-            anyhow::bail!(
-                "claude CLI returned error: {}",
-                outer["result"].as_str().unwrap_or("unknown error")
-            );
+            return Err(ClaudeCliError::Cli(
+                outer["result"].as_str().unwrap_or("unknown error").to_string(),
+            )
+            .into());
         }
 
         let result_text = outer["result"].as_str().unwrap_or("").trim().to_string();
@@ -239,23 +270,13 @@ pub fn build_prompt(request: &AiRequest) -> String {
              For your final answer: {\"content\": \"YOUR RESPONSE\"}\n\
              Do not mix both. Output exactly one JSON object.\n",
         );
-    } else if matches!(request.response_format, Some(AiResponseFormat::Json { .. })) {
-        // No tools but JSON format required (e.g. Phase 0, Planning).
-        if let Some(AiResponseFormat::Json {
-            schema: Some(schema),
-        }) = &request.response_format
-        {
-            out.push_str(&format!(
-                "RESPONSE FORMAT: You MUST respond with valid JSON only matching this schema: {}. \
-                 Do not include any explanation, markdown, or code fences — output raw JSON.\n",
-                serde_json::to_string(schema).unwrap_or_default()
-            ));
-        } else {
-            out.push_str(
-                "RESPONSE FORMAT: You MUST respond with valid JSON only. \
-                 Do not include any explanation, markdown, or code fences — output raw JSON.\n",
-            );
-        }
+    } else if let Some(instruction) = request
+        .response_format
+        .as_ref()
+        .and_then(|f| f.format_json_schema_instruction())
+    {
+        out.push_str(&instruction);
+        out.push('\n');
     }
 
     out
@@ -452,7 +473,7 @@ mod tests {
 
         let prompt = build_prompt(&req);
         assert!(prompt.contains("RESPONSE FORMAT"));
-        assert!(prompt.contains("valid JSON only"));
+        assert!(prompt.contains("ONLY a valid JSON object"));
         assert!(!prompt.contains("tool_calls"));
     }
 

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -85,6 +85,36 @@ pub enum AiResponseFormat {
     },
 }
 
+impl AiResponseFormat {
+    /// Returns a strict instruction string to enforce JSON output for the given format.
+    pub fn format_json_schema_instruction(&self) -> Option<String> {
+        match self {
+            AiResponseFormat::Json {
+                schema: Some(schema),
+            } => {
+                if let Ok(schema_str) = serde_json::to_string(schema) {
+                    Some(format!(
+                        "RESPONSE FORMAT: You MUST respond with ONLY a valid JSON object matching this schema: {schema_str}. \
+                         Do not include any explanation, markdown, or code fences — output raw JSON."
+                    ))
+                } else {
+                    Some(
+                        "RESPONSE FORMAT: You MUST respond with ONLY a valid JSON object. \
+                         Do not include any explanation, markdown, or code fences — output raw JSON."
+                            .to_string(),
+                    )
+                }
+            }
+            AiResponseFormat::Json { schema: None } => Some(
+                "RESPONSE FORMAT: You MUST respond with ONLY a valid JSON object. \
+                     Do not include any explanation, markdown, or code fences — output raw JSON."
+                    .to_string(),
+            ),
+            AiResponseFormat::Text => None,
+        }
+    }
+}
+
 /// Definition of a tool that can be called by the AI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiTool {
@@ -248,6 +278,9 @@ pub fn classify_ai_error(error: &anyhow::Error) -> AiErrorClass {
         return e.ai_error_class();
     }
     if let Some(e) = error.downcast_ref::<claude::ClaudeError>() {
+        return e.ai_error_class();
+    }
+    if let Some(e) = error.downcast_ref::<claude_cli::ClaudeCliError>() {
         return e.ai_error_class();
     }
     if let Some(e) = error.downcast_ref::<gemini::GeminiError>() {

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -562,11 +562,11 @@ impl Worker {
                         subsystem_md, target_commit_diff
                     );
                     let schema = json!({
-                        "type": "OBJECT",
+                        "type": "object",
                         "properties": {
                             "selected_prompts": {
-                                "type": "ARRAY",
-                                "items": { "type": "STRING" }
+                                "type": "array",
+                                "items": { "type": "string" }
                             }
                         },
                         "required": ["selected_prompts"]
@@ -699,11 +699,11 @@ impl Worker {
         let mut planning_selected_stages: Option<Vec<u8>> = None;
         if self.stages.is_none() {
             let schema = serde_json::json!({
-                "type": "OBJECT",
+                "type": "object",
                 "properties": {
                     "relevant_stages": {
-                        "type": "ARRAY",
-                        "items": { "type": "INTEGER" },
+                        "type": "array",
+                        "items": { "type": "integer" },
                         "description": "Array of stage numbers from 4, 5, 6, 7 that are relevant to this patch. Err on the side of inclusion if unsure."
                     }
                 },


### PR DESCRIPTION
Centralizes JSON instruction logic in src/ai/mod.rs by adding AiResponseFormat::format_json_schema_instruction().

Improves claude-cli in src/ai/claude_cli.rs:
- Introduces ClaudeCliError implementing ClassifyAiError for better retry handling.
- Switches build_prompt to use the new centralized JSON instructions.

Unifies Claude API in src/ai/claude.rs:
- Injects the centralized JSON instructions into the system prompt.
- Removes redundant/duplicate formatting logic.

Updates error classification in src/ai/mod.rs to support the new ClaudeCliError.


fixes #171 