### PR TITLE
ai: add effort knob to claude-cli provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,53 @@ prompt_caching = true
 - 200K context window for Claude models (use max_input_tokens = 40000 for cost-conscious defaults)
 - Extended thinking support via `thinking` and `effort` settings
 
+#### Claude Code CLI Setup
+
+Sashiko can use a local [Claude Code](https://claude.com/claude-code) install as
+a completion backend. This path uses your Claude Code subscription, so there is
+no per-token API charge and no API key to configure.
+
+**Prerequisites**: Install Claude Code and sign in. Verify with `claude --version`.
+
+**Update Settings.toml**:
+```toml
+[ai]
+provider = "claude-cli"
+model = "claude-opus-4-7"
+max_input_tokens = 950000
+max_interactions = 150
+
+# [ai.claude_cli]
+# effort = "high"   # Optional: "low", "medium", "high", "xhigh", "max"
+```
+
+`model` accepts any identifier the CLI accepts via `--model`: aliases like
+`opus` or `sonnet`, or full names like `claude-opus-4-7`, `claude-sonnet-4-6`.
+
+Context window notes:
+- `claude-opus-4-7` gives you 1M tokens by default.
+- `claude-sonnet-4-6` and `claude-opus-4-6` have 1M capability per Anthropic's
+  docs, but the CLI defaults them to 200K. Append the `[1m]` suffix
+  (e.g. `claude-sonnet-4-6[1m]`) to opt into the 1M variant.
+- `claude-haiku-4-5` is 200K only; there is no 1M variant.
+- The CLI rejects pre-thinking models (Claude 3.x family) with HTTP 404.
+
+**Features**:
+- No API key needed. Uses Claude Code's subscription auth.
+- Stateless: spawns `claude --print --output-format json --no-session-persistence`
+  per request. No tool access, no file access, no session reuse.
+- Prompt caching is handled by Claude Code automatically.
+- `effort` is forwarded to `claude --effort` and controls the model's thinking
+  budget. The exact mode depends on the model: Opus 4.7 uses adaptive
+  thinking, Sonnet 4.6 and Haiku 4.5 use extended thinking. The CLI exposes
+  one knob (effort) for both; if you need to pick the mode explicitly or
+  disable thinking, use `provider = "claude"` (API) instead.
+- `[ai.claude]` settings (`prompt_caching`, `thinking`, etc.) are read only by
+  the API provider above. They are ignored on this path.
+
+**Notes**: Each review may spawn many CLI processes. Lower `review.concurrency`
+if you hit subscription rate limits.
+
 #### AWS Bedrock Setup
 
 Sashiko supports AWS Bedrock via the Converse API, which works with any Bedrock-hosted model (Claude, Llama, Mistral, etc.).

--- a/Settings.toml
+++ b/Settings.toml
@@ -65,6 +65,9 @@ prompt_caching = true
 # thinking = "enabled"    # Enable extended thinking (or "adaptive" for Sonnet 4.6+)
 # effort = "high"         # Thinking effort: "low", "medium", "high"
 
+# [ai.claude_cli]
+# effort = "high"   # Thinking effort: "low", "medium", "high", "xhigh", "max"
+
 # [ai.vertex]
 # project_id = "my-gcp-project"  # Or set ANTHROPIC_VERTEX_PROJECT_ID env var
 # region = "us-east5"            # Or set CLOUD_ML_REGION env var (default: "us-east5")

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -40,6 +40,7 @@ use crate::ai::{
 
 pub struct ClaudeCliProvider {
     pub model: String,
+    pub effort: Option<String>,
 }
 
 #[async_trait]
@@ -58,6 +59,11 @@ impl AiProvider for ClaudeCliProvider {
 
         args.push("--model".to_string());
         args.push(self.model.clone());
+
+        if let Some(effort) = &self.effort {
+            args.push("--effort".to_string());
+            args.push(effort.clone());
+        }
 
         let mut child = Command::new("claude")
             .args(&args)
@@ -143,8 +149,22 @@ impl AiProvider for ClaudeCliProvider {
     fn get_capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
             model_name: self.model.clone(),
-            context_window_size: 200_000,
+            context_window_size: context_window_for_model(&self.model),
         }
+    }
+}
+
+/// Pick the context window to advertise for a given model name. The value is
+/// currently metadata only (no consumer gates on it), so the mapping is coarse.
+/// Opus 4.7 ships with a 1M window by default via Claude Code, and any model
+/// can be selected with the `[1m]` suffix to opt into the 1M variant.
+/// Verified against Claude Code 2.1.132 for opus-4-7, sonnet-4-6, sonnet-4-6[1m],
+/// haiku-4-5.
+fn context_window_for_model(model: &str) -> usize {
+    if model.contains("[1m]") || model.contains("opus-4-7") {
+        1_000_000
+    } else {
+        200_000
     }
 }
 

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -436,9 +436,13 @@ pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
                 settings.ai.api_timeout_secs,
             )))
         }
-        "claude-cli" => Ok(Arc::new(claude_cli::ClaudeCliProvider {
-            model: settings.ai.model.clone(),
-        })),
+        "claude-cli" => {
+            let cfg = settings.ai.claude_cli.as_ref();
+            Ok(Arc::new(claude_cli::ClaudeCliProvider {
+                model: settings.ai.model.clone(),
+                effort: cfg.and_then(|c| c.effort.clone()),
+            }))
+        }
         "codex-cli" => Ok(Arc::new(codex_cli::CodexCliProvider {
             model: settings.ai.model.clone(),
         })),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -210,6 +210,15 @@ fn default_kiro_cli_context_window() -> usize {
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct ClaudeCliSettings {
+    /// Effort level passed to `claude --effort`. Valid values per Claude Code:
+    /// "low", "medium", "high", "xhigh", "max". Leave unset for the model default.
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct AiSettings {
     pub provider: String,
     pub model: String,
@@ -240,6 +249,7 @@ pub struct AiSettings {
     pub vertex: Option<VertexSettings>,
     pub openai_compat: Option<OpenAiCompatSettings>,
     pub kiro_cli: Option<KiroCliSettings>,
+    pub claude_cli: Option<ClaudeCliSettings>,
 }
 
 fn default_response_cache_ttl_days() -> u64 {


### PR DESCRIPTION
Add an optional [ai.claude_cli] config block with an `effort` field
that forwards to `claude --effort` for adaptive/extended thinking
control. Per Anthropic's docs, the thinking mode depends on the
model: Opus 4.7 uses adaptive thinking, Sonnet 4.6 supports both
adaptive and extended, Haiku 4.5 uses extended only.

Also replace the hardcoded 200K context window in the provider with
a model-aware helper so the reported window matches reality.
`claude-opus-4-7` ships with 1M by default via Claude Code; any
model selected with a `[1m]` suffix opts into the 1M variant. Today
no consumer gates on this value, so it is metadata-only, but the
correct number is reported for future use.

Verified against Claude Code 2.1.132: 35 model/effort combinations
tested (opus-4-7, sonnet-4-6, opus-4-6 each with and without `[1m]`,
plus haiku-4-5; each across low/medium/high/xhigh/max effort).