### PR TITLE
feature: allow for agnostic git backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.8.46",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -158,9 +158,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
@@ -183,7 +183,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.2",
  "ring",
  "time",
  "tokio",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -217,14 +217,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -244,7 +245,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -273,7 +274,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "regex-lite",
  "tracing",
@@ -298,7 +299,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -322,7 +323,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -347,7 +348,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -368,7 +369,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -410,7 +411,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -429,19 +430,19 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.3",
+ "rustls 0.23.41",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -492,7 +493,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -512,7 +513,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -530,7 +531,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -606,10 +607,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -654,7 +655,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -702,7 +703,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -714,7 +715,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
+ "shlex 1.3.0",
  "syn",
  "which",
 ]
@@ -742,9 +743,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -760,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -777,21 +778,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -801,9 +811,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -829,21 +839,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -868,9 +872,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -954,18 +958,18 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1109,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1165,7 +1169,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1186,17 +1189,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1226,9 +1229,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email-encoding"
@@ -1338,12 +1341,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1493,16 +1490,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1525,11 +1520,11 @@ dependencies = [
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonwebtoken",
  "reqwest",
  "rustc_version",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1550,7 +1545,7 @@ dependencies = [
  "futures",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project",
  "rand 0.10.1",
  "serde",
@@ -1600,7 +1595,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1609,17 +1604,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http 1.4.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1644,28 +1639,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
-name = "hashify"
-version = "0.2.7"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149e3ea90eb5a26ad354cfe3cb7f7401b9329032d0235f2687d03a35f30e5d4c"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
 dependencies = [
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1752,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1778,7 +1771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1789,7 +1782,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1820,9 +1813,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1853,22 +1846,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1909,16 +1901,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.3",
- "rustls-pki-types",
+ "rustls 0.23.41",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1946,14 +1937,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1987,12 +1978,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2000,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2013,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2027,15 +2019,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2047,15 +2039,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2065,12 +2057,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2091,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2112,12 +2098,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2155,31 +2141,58 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2193,11 +2206,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2214,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2225,6 +2239,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -2238,12 +2253,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
@@ -2265,19 +2274,19 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "rustls 0.23.40",
- "socket2 0.6.3",
+ "rustls 0.23.41",
+ "socket2 0.6.4",
  "tokio",
  "tokio-rustls 0.26.4",
  "url",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2300,7 +2309,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "chrono",
  "crc32fast",
@@ -2359,7 +2368,7 @@ version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b646f94fc1d266e481c38a2d44d6d9d1be3ad04b56b90457acfb310dc450030e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
  "hashlink 0.8.4",
@@ -2373,10 +2382,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cc",
  "fallible-iterator 0.3.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "phf",
@@ -2439,9 +2448,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2454,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2496,9 +2505,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -2534,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2573,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2745,7 +2754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2791,10 +2800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "potential_utf"
-version = "0.1.4"
+name = "pkg-config"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2811,7 +2826,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.46",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -2858,18 +2873,18 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.40",
- "socket2 0.6.3",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.41",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2878,18 +2893,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
- "rustls 0.23.40",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2907,25 +2922,25 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "quoted_printable"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
@@ -2941,9 +2956,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2952,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2967,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3021,7 +3036,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3089,12 +3104,12 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -3102,7 +3117,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -3136,11 +3151,11 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3166,9 +3181,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3185,7 +3200,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3198,7 +3213,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3233,16 +3248,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3262,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -3283,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3293,19 +3308,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.3",
+ "rustls 0.23.41",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3341,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3382,6 +3397,7 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "axum 0.8.9",
+ "bytes",
  "chrono",
  "clap",
  "config",
@@ -3466,7 +3482,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3479,7 +3495,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3498,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3550,7 +3566,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3592,15 +3608,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3611,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3659,6 +3676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,10 +3707,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3697,9 +3736,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -3713,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3747,9 +3786,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3788,7 +3827,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3810,7 +3849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3886,17 +3925,16 @@ dependencies = [
  "fancy-regex",
  "lazy_static",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3906,15 +3944,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3931,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3966,7 +4004,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4019,7 +4057,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -4053,7 +4091,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4144,7 +4182,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -4175,7 +4213,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4195,10 +4233,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower 0.5.3",
@@ -4213,11 +4251,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header 0.4.2",
@@ -4351,9 +4389,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4384,15 +4422,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -4438,11 +4470,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4493,27 +4525,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4524,23 +4547,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4548,9 +4567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4561,52 +4580,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4624,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4637,14 +4622,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4742,15 +4727,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4783,21 +4759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4835,12 +4796,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4853,12 +4808,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4868,12 +4817,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4901,12 +4844,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4916,12 +4853,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4937,12 +4868,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4952,12 +4877,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4973,106 +4892,24 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xmlparser"
@@ -5093,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5104,9 +4941,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5126,11 +4963,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.46"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5030500cb2d66bdfbb4ebc9563be6ce7005a4b5d0f26be0c523870fe372ca6"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
- "zerocopy-derive 0.8.46",
+ "zerocopy-derive 0.8.52",
 ]
 
 [[package]]
@@ -5146,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.46"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f86989a046a79640b9d8867c823349a139367bda96549794fcc3313ce91f4e"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5157,18 +4994,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5178,15 +5015,29 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5195,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5206,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ aws-config = { version = "1", features = ["behavior-version-latest"], optional =
 aws-sdk-bedrockruntime = { version = "1", optional = true }
 aws-smithy-types = { version = "1", optional = true }
 axum = "0.8.9"
+bytes = "1.9"
 chrono = "0.4.43"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 config = "0.15.23"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Please, note that as with any other LLM-based tools, Sashiko's output is probabi
 
 ## Features
 
-- **Automated Ingestion**: Monitors mailing lists (using `lore.kernel.org`) for new patch submissions.
-- **Manual Ingestion**: Can ingest patches from a local git repository.
-- **Self-contained**: Doesn't depend on 3rd-party tools and can work with various LLM providers (Gemini, Claude, GitHub Copilot CLI, and others).
-- **Web interface and CLI**: Provides a web interface and a CLI tool. Email support will be added soon.
+- **Automated Ingestion**: Monitors mailing lists (`lore.kernel.org`), GitHub PRs, and GitLab MRs for new patch submissions.
+- **Manual Ingestion**: Can ingest patches from local git repositories or specific PRs/MRs.
+- **Forge Integration**: Automatic PR/MR review via GitHub and GitLab webhooks.
+- **Self-contained**: Doesn't depend on 3rd-party tools and works with multiple LLM providers (Gemini, Claude, and GitHub Copilot CLI are currently supported).
+- **Web interface and CLI**: Provides a web interface for monitoring and a CLI tool for local development. Email support will be added soon.
 
 ## Prompts
 
@@ -88,8 +89,17 @@ cd sashiko
 *Note: The `--recursive` flag is important to initialize the `linux` kernel source submodule.*
 
 #### 2.  **Configuration**:
-Copy an example config to get started. For a full reference of every
-setting, see the [Configuration Reference](docs/configuration.md).
+Copy `Settings.toml` to customize your configuration. For a full reference of every
+setting, see the [Configuration Reference](docs/configuration.md). The default `Settings.toml` includes sections for:
+*   **Database**: SQLite database path (`sashiko.db`).
+*   **NNTP**: Server details and groups to monitor.
+*   **AI**: Provider and model selection.
+*   **Server**: API server host and port.
+*   **Git**: Path to the reference kernel repository.
+*   **Review**: Concurrency and worktree settings.
+    *   **Forge**: GitHub/GitLab webhook integration (optional). See forge setup guides below.
+        *   When enabling `[forge]`, the NNTP (mailing list) ingestor is disabled by default. If you need to monitor both, set `disable_nntp = false` in the `[forge]` section of your config.
+    *   **Subsystems**: Map file patterns to subsystems for targeted reviews (optional).
 
 #### Configuring the LLM Provider
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please, note that as with any other LLM-based tools, Sashiko's output is probabi
 
 - **Automated Ingestion**: Monitors mailing lists (`lore.kernel.org`), GitHub PRs, and GitLab MRs for new patch submissions.
 - **Manual Ingestion**: Can ingest patches from local git repositories or specific PRs/MRs.
-- **Forge Integration**: Automatic PR/MR review via GitHub and GitLab webhooks.
+- **Forge Integration** *(Experimental)*: Automatic PR/MR review via GitHub and GitLab webhooks. This feature is unofficial and unsupported — use at your own risk.
 - **Self-contained**: Doesn't depend on 3rd-party tools and works with multiple LLM providers (Gemini, Claude, and GitHub Copilot CLI are currently supported).
 - **Web interface and CLI**: Provides a web interface for monitoring and a CLI tool for local development. Email support will be added soon.
 
@@ -97,7 +97,7 @@ setting, see the [Configuration Reference](docs/configuration.md). The default `
 *   **Server**: API server host and port.
 *   **Git**: Path to the reference kernel repository.
 *   **Review**: Concurrency and worktree settings.
-    *   **Forge**: GitHub/GitLab webhook integration (optional). See forge setup guides below.
+    *   **Forge** *(Experimental)*: GitHub/GitLab webhook integration (optional, unsupported). See forge setup guides below.
         *   When enabling `[forge]`, the NNTP (mailing list) ingestor is disabled by default. If you need to monitor both, set `disable_nntp = false` in the `[forge]` section of your config.
     *   **Subsystems**: Map file patterns to subsystems for targeted reviews (optional).
 

--- a/Settings.toml
+++ b/Settings.toml
@@ -1,5 +1,22 @@
 log_level = "info"
 
+[project]
+name = "Sashiko"
+description = ""
+
+[forge]
+enabled = false
+# provider = "github"
+# webhook_secret = "your-webhook-secret"
+# api_token = "your-api-token"
+
+[subsystems]
+# Regex map: email address pattern -> subsystem name
+# mapping = [
+#     { pattern = ".*linux-kernel@vger.kernel.org.*", name = "LKML" },
+#     { pattern = ".*netdev@vger.kernel.org.*", name = "netdev" },
+# ]
+
 [database]
 url = "sashiko.db"
 token = ""

--- a/docs/FORGE_SETUP.md
+++ b/docs/FORGE_SETUP.md
@@ -1,0 +1,433 @@
+# Forge Integration Setup
+
+This guide explains how to integrate Sashiko with Git forges (GitHub, GitLab, etc.) for automatic code review.
+
+## Overview
+
+Sashiko can integrate with Git forges to automatically review Pull Requests (PRs) or Merge Requests (MRs) when they are opened or updated. This enables automated code review workflows for your development teams.
+
+## Supported Forges
+
+Currently supported:
+- **GitHub** - Full webhook integration ([GitHub Setup Guide](GITHUB_SETUP.md))
+- **GitLab** - Full webhook integration ([GitLab Setup Guide](GITLAB_SETUP.md))
+
+## Forge Requirements
+
+For a Git forge to be compatible with Sashiko, it must support:
+
+### 1. Webhook Delivery
+
+**Required capabilities:**
+- HTTP/HTTPS webhook delivery to external endpoints
+- JSON payload format
+- Custom headers (for event identification)
+- Configurable event triggers (PR/MR events)
+
+**Event triggers needed:**
+- Pull/Merge request opened
+- Pull/Merge request updated (new commits)
+- Pull/Merge request reopened
+
+**Optional but recommended:**
+- Webhook secret/signature validation
+- Webhook delivery retry logic
+- Webhook delivery status/logs
+
+### 2. API Access
+
+**Required endpoints:**
+- Fetch PR/MR details by ID
+- Retrieve commit information
+- Access diff/patch data
+
+**Authentication:**
+- Public repository access (no auth for public repos)
+- Token-based authentication (for private repos)
+- Rate limiting information
+
+**Optional but useful:**
+- Post comments on PRs/MRs
+- Update PR/MR status
+- Create review summaries
+
+### 3. Git Repository Access
+
+**Required:**
+- HTTP(S) clone URLs accessible from Sashiko server
+- Support for standard Git protocol
+- Ability to fetch specific commit ranges
+
+**Authentication options:**
+- Anonymous access for public repos
+- SSH key authentication
+- HTTP(S) token authentication
+- Deploy keys
+
+### 4. Webhook Payload Requirements
+
+The webhook must provide:
+
+**Minimal required fields:**
+```json
+{
+  "event_type": "pull_request|merge_request",
+  "action": "opened|updated|reopened",
+  "pr_or_mr": {
+    "id": "<unique identifier>",
+    "title": "<PR/MR title>",
+    "base_commit": "<base SHA>",
+    "head_commit": "<head SHA>",
+    "url": "<web URL to PR/MR>"
+  },
+  "repository": {
+    "clone_url": "<git clone URL>"
+  }
+}
+```
+
+**Recommended additional fields:**
+- Source branch name
+- Target branch name
+- Author information
+- Commit count
+- Changed files list
+- PR/MR state (open, closed, merged)
+
+## General Configuration
+
+### Enable Forge Integration
+
+Edit `Settings.toml`:
+
+```toml
+[forge]
+# Enable to accept webhooks from GitHub, GitLab, etc.
+enabled = true
+
+# If enabled, you can optionally disable the NNTP/mailing-list ingestor.
+# By default, running both is disabled to prevent duplicate reviews if a
+# patch from a PR is also sent to a mailing list.
+# Set to 'false' if you need to monitor both mailing lists and forges.
+disable_nntp = true
+
+# Optional: Configure subsystem mapping for targeted reviews
+[subsystems]
+mapping = [
+    { pattern = ".*drivers/.*", name = "Drivers" },
+    { pattern = ".*net/.*", name = "Networking" },
+    { pattern = ".*fs/.*", name = "Filesystems" },
+    { pattern = ".*mm/.*", name = "Memory Management" },
+]
+```
+
+### Server Configuration
+
+Ensure your server is configured to accept webhooks:
+
+```toml
+[server]
+host = "127.0.0.1"  # Listen address
+port = 8080          # Port for webhook endpoint
+```
+
+**Security considerations:**
+- By default, Sashiko only accepts webhooks from localhost
+- For production, use `--enable-unsafe-all-submit` flag (behind firewall/proxy)
+- Always use HTTPS in production with valid certificates
+- Implement webhook signature validation when available
+
+### Git Configuration
+
+Configure the reference repository:
+
+```toml
+[git]
+repository_path = "/path/to/kernel/repo"
+```
+
+**Note:** The repository must be accessible and contain the commits referenced in webhooks.
+
+### Review Configuration
+
+```toml
+[review]
+concurrency = 20                    # Parallel review capacity
+worktree_dir = "review_trees"      # Temporary worktrees
+timeout_seconds = 7200              # 2 hours per review
+```
+
+## Webhook Endpoints
+
+Sashiko provides the following webhook endpoints:
+
+- **GitHub**: `http://your-server:8080/api/webhook/github`
+- **GitLab**: `http://your-server:8080/api/webhook/gitlab`
+
+### Expected HTTP Headers
+
+**GitHub:**
+```
+X-GitHub-Event: pull_request
+Content-Type: application/json
+```
+
+**GitLab:**
+```
+X-Gitlab-Event: Merge Request Hook
+Content-Type: application/json
+```
+
+### Response Codes
+
+- `200 OK` - Webhook accepted, review queued
+- `400 Bad Request` - Invalid payload or missing required fields
+- `403 Forbidden` - Forge integration disabled
+- `500 Internal Server Error` - Server error processing webhook
+
+## Testing Integration
+
+### 1. Test with Synthetic Webhook
+
+Use the provided test scripts to verify the endpoint:
+
+**GitHub:**
+```bash
+./scripts/test_github_webhook.sh
+```
+
+**GitLab:**
+```bash
+./scripts/test_gitlab_webhook.sh
+```
+
+### 2. Test with Real PR/MR
+
+Trigger a review for a specific PR/MR:
+
+**GitHub:**
+```bash
+./scripts/trigger_github_pr_review.sh owner/repo 123
+```
+
+**GitLab:**
+```bash
+./scripts/trigger_gitlab_mr_review.sh 123
+```
+
+### 3. Verify Review Queue
+
+Check the web UI to confirm the review was queued:
+```
+http://localhost:8080/
+```
+
+Look for:
+- Review in "Pending" or "In Progress" state
+- Correct PR/MR number and title
+- Expected commit range
+
+## Implementing Support for New Forges
+
+To add support for a new Git forge, you need to:
+
+### 1. Understand the Forge's Webhook Format
+
+Document:
+- Webhook payload structure
+- HTTP headers used for event identification
+- Available event types and actions
+- Authentication/signature mechanism
+
+### 2. Create a ForgeProvider Implementation
+
+Implement the `ForgeProvider` trait in Rust:
+
+```rust
+pub trait ForgeProvider {
+    /// Parse the webhook payload and extract review information
+    fn parse_webhook(&self, headers: &HeaderMap, body: &[u8])
+        -> Result<WebhookEvent, Error>;
+
+    /// Optional: Post review results back to the forge
+    fn post_review(&self, pr_id: &str, review: &Review)
+        -> Result<(), Error>;
+}
+```
+
+### 3. Register the Webhook Handler
+
+Add a new endpoint in the API router:
+
+```rust
+// In src/api.rs or equivalent
+app.route("/api/webhook/yourforge", post(handle_yourforge_webhook))
+```
+
+### 4. Add Configuration
+
+Extend `Settings.toml` if forge-specific config is needed:
+
+```toml
+[forge.yourforge]
+api_token = "optional-token"
+api_endpoint = "https://api.yourforge.com"
+```
+
+### 5. Create Documentation and Scripts
+
+- Write setup guide (e.g., `docs/YOURFORGE_SETUP.md`)
+- Create test script (`scripts/test_yourforge_webhook.sh`)
+- Create trigger script (`scripts/trigger_yourforge_review.sh`)
+
+## Troubleshooting
+
+### Webhook Not Received
+
+**Symptoms:** No log entries when PR/MR is opened
+
+**Check:**
+- Server is running: `curl http://localhost:8080/`
+- Firewall allows inbound on configured port
+- Webhook URL is accessible from forge servers
+- Forge shows successful delivery in webhook logs
+
+**Solutions:**
+- Use ngrok/tunneling for local testing
+- Check server logs: `RUST_LOG=debug cargo run`
+- Verify webhook URL in forge configuration
+
+### Webhook Rejected (403 Forbidden)
+
+**Symptoms:** Forge shows 403 response
+
+**Cause:** Forge integration disabled or security restrictions
+
+**Solutions:**
+- Set `forge.enabled = true` in Settings.toml
+- Restart Sashiko daemon
+- Use `--enable-unsafe-all-submit` for testing (not production)
+
+### Review Not Starting
+
+**Symptoms:** Webhook accepted but review doesn't begin
+
+**Check:**
+- LLM API key configured: `echo $LLM_API_KEY`
+- Git repository contains referenced commits
+- Sashiko has network access to clone repository
+- Disk space available in worktree directory
+
+**Solutions:**
+- Check logs for specific errors
+- Verify git repository accessibility
+- Test LLM provider connection
+- Ensure commits exist in configured repository
+
+### Commits Not Found
+
+**Symptoms:** Review fails with "commit not found" error
+
+**Causes:**
+- Repository mismatch (webhook references different repo)
+- Commits not yet fetched to local repository
+- Shallow clone missing history
+
+**Solutions:**
+- Ensure `git.repository_path` points to correct repo
+- Run `git fetch --all` in repository
+- Use full clone (not shallow) for reference repository
+
+## Security Best Practices
+
+### Production Deployment
+
+1. **Use HTTPS with valid certificates**
+   - Set up reverse proxy (nginx, Apache, Caddy)
+   - Obtain SSL/TLS certificates (Let's Encrypt)
+   - Terminate TLS at proxy, forward to Sashiko
+
+2. **Implement authentication**
+   - Use webhook secrets when available
+   - Validate webhook signatures
+   - Restrict by source IP (if forge IPs are known)
+
+3. **Network isolation**
+   - Run Sashiko on private network
+   - Use VPN or SSH tunneling for access
+   - Firewall rules to limit exposure
+
+4. **Rate limiting**
+   - Configure at reverse proxy level
+   - Prevent abuse and DoS attempts
+   - Monitor webhook delivery rates
+
+5. **Audit logging**
+   - Log all webhook deliveries
+   - Track review queue metrics
+   - Monitor for unusual patterns
+
+### Example Nginx Configuration
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name sashiko.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/sashiko.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sashiko.example.com/privkey.pem;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=webhook:10m rate=10r/m;
+    limit_req zone=webhook burst=5;
+
+    location /api/webhook/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+## Forge Comparison
+
+| Feature | GitHub | GitLab | Requirements |
+|---------|--------|--------|--------------|
+| Webhook delivery | ✅ | ✅ | **Required** |
+| JSON payloads | ✅ | ✅ | **Required** |
+| Event filtering | ✅ | ✅ | **Required** |
+| Webhook secrets | ✅ | ✅ | Recommended |
+| Signature validation | ✅ | ✅ | Recommended |
+| Delivery logs | ✅ | ✅ | Recommended |
+| Public API | ✅ | ✅ | **Required** |
+| Token auth | ✅ | ✅ | **Required** |
+| SSH clone | ✅ | ✅ | **Required** |
+| HTTPS clone | ✅ | ✅ | **Required** |
+| Comment API | ✅ | ✅ | Optional |
+| Status API | ✅ | ✅ | Optional |
+
+## Related Documentation
+
+- [GitHub Setup Guide](GITHUB_SETUP.md) - Detailed GitHub integration
+- [GitLab Setup Guide](GITLAB_SETUP.md) - Detailed GitLab integration
+- [README.md](../README.md) - Main project documentation
+- [Settings.toml](../Settings.toml) - Configuration reference
+
+## Getting Help
+
+- **Mailing List:** sashiko@lists.linux.dev ([archive](https://lore.kernel.org/sashiko))
+- **GitHub Issues:** [Report bugs or request features](https://github.com/sashiko-dev/sashiko/issues)
+- **Community:** Join discussions about forge integration and feature requests

--- a/docs/FORGE_SETUP.md
+++ b/docs/FORGE_SETUP.md
@@ -1,5 +1,10 @@
 # Forge Integration Setup
 
+> **Experimental / Unsupported:** Git forge integration is experimental and
+> unofficial. It is provided as-is, without guarantees of stability or
+> correctness. Use it at your own risk. Breaking changes may occur without
+> notice, and community support is best-effort only.
+
 This guide explains how to integrate Sashiko with Git forges (GitHub, GitLab, etc.) for automatic code review.
 
 ## Overview

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -1,0 +1,319 @@
+# GitHub Integration Setup
+
+Complete guide for configuring Sashiko to automatically review GitHub Pull Requests via webhooks.
+
+> **Note:** For general forge integration requirements and architecture, see [FORGE_SETUP.md](FORGE_SETUP.md). This guide covers GitHub-specific configuration.
+
+## Quick Start (5 Minutes)
+
+Get Sashiko reviewing GitHub Pull Requests quickly.
+
+### Step 1: Configure LLM Provider
+
+Set your API key:
+```bash
+# For Gemini
+export LLM_API_KEY="your-gemini-api-key"
+
+# For Claude
+export ANTHROPIC_API_KEY="your-claude-api-key"
+```
+
+Verify `Settings.toml` has your LLM provider configured:
+```toml
+[ai]
+provider = "gemini"  # or "claude"
+model = "gemini-3.1-pro-preview"  # or "claude-sonnet-4-6"
+```
+
+### Step 2: Start Sashiko Server
+
+```bash
+cargo run --release
+```
+
+You should see output like:
+```
+Server running on http://127.0.0.1:8080
+```
+
+**Verify it's running:**
+```bash
+curl http://localhost:8080/
+```
+
+### Step 3: Test with a Pull Request
+
+#### Option A: Test with Real GitHub PR
+
+Use the trigger script to review any public GitHub PR:
+```bash
+./scripts/trigger_github_pr_review.sh torvalds/linux 12345
+```
+
+Replace `torvalds/linux` with `owner/repo` and `12345` with a PR number.
+
+#### Option B: Test with Synthetic Webhook
+
+Send a test webhook payload to verify the endpoint:
+```bash
+./scripts/test_github_webhook.sh
+```
+
+#### Option C: Test with Local Commits
+
+Review your own local changes:
+```bash
+# Review last 3 commits
+cargo run --bin sashiko-cli -- submit HEAD~3..HEAD
+```
+
+### Step 4: Monitor Progress
+
+Open your browser to the web UI:
+```
+http://localhost:8080/
+```
+
+You'll see:
+- Review queue status
+- Current review progress
+- Completed reviews with findings
+
+### Step 5: Configure Webhook (Optional)
+
+To automatically review PRs when they're opened on GitHub:
+
+1. Go to your GitHub repository → Settings → Webhooks
+2. Add webhook:
+   - **URL:** `http://your-server:8080/api/webhook/github`
+   - **Content type:** `application/json`
+   - **Events:** Pull requests only
+3. For local development, use ngrok or SSH tunnel:
+   ```bash
+   # Using ngrok
+   ngrok http 8080
+   # Use the ngrok URL in webhook configuration
+   ```
+
+## Prerequisites
+
+- Sashiko running in server mode (daemon)
+- Server accessible from GitHub (public URL or tunneling solution like ngrok)
+- Admin rights on GitHub repository (to configure webhooks)
+- Sashiko configured with valid LLM API credentials
+
+## Configuration
+
+### 1. Configure Server Settings
+
+Sashiko's webhook endpoints are available by default when running the daemon. The server configuration in `Settings.toml`:
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 8080
+```
+
+**Security Note:** By default, Sashiko only accepts webhook requests from `localhost` for security. To accept webhooks from GitHub's servers, you have two options:
+
+**Option A: SSH Tunnel (Recommended for testing)**
+```bash
+# On your development machine
+ssh -R 8080:localhost:8080 your-public-server.com
+
+# GitHub webhook URL would be:
+# http://your-public-server.com:8080/api/webhook/github
+```
+
+**Option B: Allow all submit (Use with caution)**
+```bash
+# Start Sashiko with the unsafe flag
+cargo run --release -- --enable-unsafe-all-submit
+```
+
+**⚠️ WARNING:** Option B allows anyone who can reach your server to trigger reviews. Only use this in trusted networks or behind authentication layers (reverse proxy with auth, firewall rules, etc.).
+
+### 2. Set up GitHub Webhook
+
+1. Navigate to your repository on GitHub
+2. Go to **Settings** → **Webhooks** → **Add webhook**
+3. Configure the webhook:
+   - **Payload URL:** `http://your-server:8080/api/webhook/github`
+     - Replace `your-server` with your actual server address
+     - Use port `8080` (or your configured server port)
+   - **Content type:** `application/json`
+   - **Secret:** Leave empty (signature validation not yet implemented)
+   - **Which events would you like to trigger this webhook?**
+     - Select: **Let me select individual events**
+     - Check: ✓ **Pull requests**
+     - Uncheck all other events
+   - **Active:** ✓ Enabled
+
+4. Click **Add webhook**
+
+### 3. Verify Webhook Delivery
+
+After creating the webhook, GitHub will immediately send a test `ping` event:
+
+1. In GitHub webhook settings, click on your newly created webhook
+2. Navigate to the **Recent Deliveries** tab
+3. You should see a `ping` event with a green checkmark
+4. If the delivery failed, check:
+   - Server is running: `curl http://localhost:8080/`
+   - Firewall allows incoming connections
+   - URL is correct and accessible from the internet
+
+### 4. Test the Integration
+
+**Option A: Use the test script**
+```bash
+./test_github_webhook.sh
+```
+
+This sends a synthetic webhook payload to verify the endpoint is working.
+
+**Option B: Trigger a real PR review**
+```bash
+./trigger_github_pr_review.sh owner/repo 123
+```
+
+This fetches real PR data from GitHub's API and triggers a review.
+
+**Option C: Open a real Pull Request**
+
+The most authentic test - simply open a new PR on your repository. Sashiko should:
+1. Receive the webhook
+2. Log the PR details
+3. Queue the review
+4. Fetch the commits
+5. Start the AI review process
+
+Check the web UI at `http://localhost:8080/` to see the review progress.
+
+## Troubleshooting
+
+### Webhook not received
+
+**Symptoms:** No logs in Sashiko output when PR is opened
+
+**Solutions:**
+- Verify server is running: `curl http://localhost:8080/`
+- Check firewall allows incoming connections on port 8080
+- Verify webhook URL is accessible from internet (use ngrok or similar for testing)
+- Check GitHub webhook delivery status in repository settings
+
+### Permission denied (403 Forbidden)
+
+**Symptoms:** GitHub shows delivery failed with 403 status
+
+**Cause:** Sashiko's default security blocks non-localhost requests
+
+**Solutions:**
+1. **Recommended:** Use SSH tunnel or reverse proxy from localhost
+2. **Quick test:** Run with `--enable-unsafe-all-submit` flag
+3. **Production:** Set up reverse proxy with TLS and authentication
+
+### Webhook received but review not starting
+
+**Symptoms:** Logs show webhook received but no review begins
+
+**Solutions:**
+- Check LLM API key is configured: `echo $LLM_API_KEY`
+- Verify git repository is accessible: check `git.repository_path` in `Settings.toml`
+- Look for errors in Sashiko logs
+- Check that the commit hash exists in your configured repository
+
+### Review fails immediately
+
+**Symptoms:** Review status shows "failed" in web UI
+
+**Solutions:**
+- Check Sashiko logs for specific error messages
+- Verify git repository has the referenced commits
+- Ensure LLM provider is accessible and API key is valid
+- Check disk space in `worktree_dir` directory
+
+## Security Considerations
+
+**⚠️ IMPORTANT:** GitHub webhook signature validation is not yet implemented.
+
+For production deployments:
+
+1. **Use HTTPS:** Set up a reverse proxy with TLS
+   ```nginx
+   # Example nginx config
+   server {
+       listen 443 ssl;
+       server_name sashiko.example.com;
+
+       ssl_certificate /path/to/cert.pem;
+       ssl_certificate_key /path/to/key.pem;
+
+       location /api/webhook/ {
+           proxy_pass http://localhost:8080;
+           proxy_set_header X-Real-IP $remote_addr;
+       }
+   }
+   ```
+
+2. **Implement webhook secrets:** Future enhancement - see GitHub's [webhook security guide](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)
+
+3. **Network isolation:** Run Sashiko on private network and use SSH tunneling or VPN
+
+4. **Rate limiting:** Configure reverse proxy or firewall to prevent abuse
+
+## Advanced Configuration
+
+### Custom Port
+
+Modify `Settings.toml`:
+```toml
+[server]
+host = "0.0.0.0"  # Listen on all interfaces
+port = 8080       # Custom port
+```
+
+Then update webhook URL: `http://your-server:8080/api/webhook/github`
+
+### Multiple Repositories
+
+Sashiko can handle webhooks from multiple repositories. Simply add the same webhook configuration to each repository you want to monitor.
+
+**Note:** All repositories must be accessible from the git repository configured in `Settings.toml` or Sashiko will fail to fetch the commits.
+
+## Webhook Payload Reference
+
+Sashiko processes the following fields from GitHub's `pull_request` webhook:
+
+```json
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 123,
+    "title": "Fix memory leak in driver",
+    "html_url": "https://github.com/owner/repo/pull/123",
+    "head": {
+      "sha": "abc123..."
+    },
+    "base": {
+      "sha": "def456..."
+    }
+  }
+}
+```
+
+Supported actions: `opened`, `reopened`, `synchronize` (new commits pushed)
+
+## See Also
+
+- Quick start content is now in the top section of this document
+- [FORGE_SETUP.md](FORGE_SETUP.md) - General forge integration guide
+- [GITLAB_SETUP.md](GITLAB_SETUP.md) - GitLab integration setup
+- [README.md](../README.md) - Main project documentation
+- [Settings.toml](../Settings.toml) - Configuration reference
+
+## Getting Help
+
+- **Mailing List:** sashiko@lists.linux.dev ([lore archive](https://lore.kernel.org/sashiko))
+- **GitHub Issues:** [Report bugs or request features](https://github.com/sashiko-dev/sashiko/issues)

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -1,5 +1,10 @@
 # GitHub Integration Setup
 
+> **Experimental / Unsupported:** Git forge integration is experimental and
+> unofficial. It is provided as-is, without guarantees of stability or
+> correctness. Use it at your own risk. Breaking changes may occur without
+> notice, and community support is best-effort only.
+
 Complete guide for configuring Sashiko to automatically review GitHub Pull Requests via webhooks.
 
 > **Note:** For general forge integration requirements and architecture, see [FORGE_SETUP.md](FORGE_SETUP.md). This guide covers GitHub-specific configuration.

--- a/docs/GITLAB_SETUP.md
+++ b/docs/GITLAB_SETUP.md
@@ -1,0 +1,244 @@
+# GitLab Webhook Setup for Sashiko
+
+This guide explains how to configure GitLab to automatically trigger Sashiko reviews for merge requests.
+
+> **Note:** For general forge integration requirements and architecture, see [FORGE_SETUP.md](FORGE_SETUP.md). This guide covers GitLab-specific configuration.
+
+## Quick Start (5 Minutes)
+
+### Step 1: Enable Forge Mode
+
+Edit `Settings.toml`:
+
+```toml
+[forge]
+enabled = true
+```
+
+Restart Sashiko.
+
+### Step 2: Verify Server is Ready
+
+```bash
+./scripts/check_server_config.sh
+```
+
+Expected output: "✓ Server is ready for GitLab webhooks!"
+
+### Step 3: Test with a Specific MR
+
+```bash
+# Replace 123 with an actual MR number
+./scripts/trigger_gitlab_mr_review.sh 123
+```
+
+This script will:
+1. Fetch MR details from GitLab API
+2. Send a simulated webhook to Sashiko
+3. Show the response
+
+### Step 4: Monitor Reviews
+
+View reviews at: http://localhost:9080/
+
+Reviews for GitLab MRs will display as:
+- **Subject**: `!<MR_NUMBER>: <MR_TITLE>`
+- **Author**: Original commit author
+- **Parts**: Number of commits in the MR
+
+## Prerequisites
+
+1. Sashiko server running and accessible
+2. `forge.enabled = true` in `Settings.toml`
+3. Admin/Maintainer access to your GitLab project
+
+## Configuration Steps
+
+### 1. Enable Forge Mode in Sashiko
+
+Edit `Settings.toml`:
+
+```toml
+[forge]
+enabled = true
+
+[subsystems]
+# Optional: Map file paths to subsystems
+mapping = [
+    { pattern = ".*drivers/.*", name = "Drivers" },
+    { pattern = ".*net/.*", name = "Networking" },
+    { pattern = ".*fs/.*", name = "Filesystems" },
+]
+```
+
+Restart Sashiko after changing the configuration.
+
+### 2. Configure GitLab Webhook
+
+1. Go to your GitLab project:
+   ```
+   https://gitlab.com/your-org/your-project/-/settings/integrations
+   ```
+
+2. Click **Add new webhook**
+
+3. Configure the webhook:
+
+   **URL:**
+   ```
+   http://localhost:9080/api/webhook/gitlab
+   ```
+
+   **Secret token:** (Optional - currently not validated, see security note below)
+
+   **Trigger:**
+   - ✓ Merge request events
+
+   **SSL verification:**
+   - If using HTTPS with valid cert: Enable
+   - If using HTTP or self-signed: Disable
+
+4. Click **Add webhook**
+
+### 3. Test the Webhook
+
+#### Option A: Use GitLab's Test Feature
+
+1. Scroll down to "Project Hooks"
+2. Find your webhook
+3. Click **Test** → **Merge Request events**
+4. Check the response (should be 200 OK)
+
+#### Option B: Use the Test Script
+
+```bash
+# Make the script executable
+chmod +x test_gitlab_webhook.sh
+
+# Run the test
+./test_gitlab_webhook.sh
+```
+
+#### Option C: Trigger Review for Specific MR
+
+```bash
+# Make the script executable
+chmod +x trigger_gitlab_mr_review.sh
+
+# Trigger review for MR !123
+./trigger_gitlab_mr_review.sh 123
+```
+
+### 4. Verify Reviews are Running
+
+1. Open a new MR or update an existing one
+2. Check Sashiko web UI: `http://localhost:9080/`
+3. Check Sashiko logs for:
+   ```
+   GitLab MR !123 open. Base: abc123..., Head: def456...
+   ```
+
+## Webhook Payload Details
+
+GitLab sends webhooks with:
+
+**Headers:**
+- `X-Gitlab-Event: Merge Request Hook`
+- `Content-Type: application/json`
+
+**Actions Handled:**
+- `open` - New MR created
+- `update` - MR updated with new commits
+- `reopen` - Closed MR reopened
+
+**Actions Ignored:**
+- `close` - MR closed
+- `merge` - MR merged
+- `approved`/`unapproved` - Approval state changes
+
+## Troubleshooting
+
+### Webhook Returns 403 Forbidden
+
+**Cause:** Forge integration is disabled
+
+**Fix:** Set `forge.enabled = true` in `Settings.toml` and restart Sashiko
+
+### Webhook Returns 400 Bad Request
+
+**Cause:** Invalid payload structure
+
+**Check:**
+1. Verify webhook is configured for "Merge request events"
+2. Check Sashiko logs for parsing errors
+3. Ensure `X-Gitlab-Event` header is set correctly
+
+### Reviews Not Appearing
+
+**Check:**
+1. Sashiko logs for errors
+2. Git repository is accessible from Sashiko server
+3. Base and head SHAs are valid
+4. FetchAgent is running (check logs)
+
+### Network Connectivity Issues
+
+If GitLab cannot reach your server:
+
+1. Ensure the server is publicly accessible (or use a tunnel)
+2. Check firewall rules allow inbound on port 9080
+3. Consider using ngrok for testing:
+   ```bash
+   ngrok http 9080
+   # Use the ngrok URL in webhook config
+   ```
+
+## Security Notes
+
+⚠️ **IMPORTANT:** The current implementation does NOT validate webhook signatures.
+
+This means anyone who knows your webhook URL can trigger reviews.
+
+**Recommended for production:**
+1. Implement webhook signature validation (see issue in code review)
+2. Use HTTPS with valid certificates
+3. Restrict network access to known GitLab IPs
+4. Set a strong webhook secret token in GitLab
+
+## Manual Testing
+
+You can manually trigger reviews without webhooks:
+
+```bash
+# Using the CLI tool (if implemented)
+sashiko review \
+  --repo https://gitlab.com/your-org/your-project.git \
+  --range abc123..def456
+
+# Or by directly calling the API
+curl -X POST http://localhost:9080/api/submit \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://...",
+    "commit_hash": "abc123..def456"
+  }'
+```
+
+## Example MRs to Test
+
+Test with a specific MR from your project:
+
+```bash
+# Test with a specific MR (use your URL-encoded project path)
+./trigger_gitlab_mr_review.sh 1234 your-org%2Fyour-project
+
+# Or manually find MRs at:
+# https://gitlab.com/your-org/your-project/-/merge_requests
+```
+
+## See Also
+
+- [FORGE_SETUP.md](FORGE_SETUP.md) - General forge integration guide
+- [GITHUB_SETUP.md](GITHUB_SETUP.md) - GitHub integration setup
+- [README.md](../README.md) - Main project documentation
+- [Settings.toml](../Settings.toml) - Configuration reference

--- a/docs/GITLAB_SETUP.md
+++ b/docs/GITLAB_SETUP.md
@@ -1,5 +1,10 @@
 # GitLab Webhook Setup for Sashiko
 
+> **Experimental / Unsupported:** Git forge integration is experimental and
+> unofficial. It is provided as-is, without guarantees of stability or
+> correctness. Use it at your own risk. Breaking changes may occur without
+> notice, and community support is best-effort only.
+
 This guide explains how to configure GitLab to automatically trigger Sashiko reviews for merge requests.
 
 > **Note:** For general forge integration requirements and architecture, see [FORGE_SETUP.md](FORGE_SETUP.md). This guide covers GitLab-specific configuration.

--- a/sashiko.dev/base/routing/sashiko-service-skeleton.yaml
+++ b/sashiko.dev/base/routing/sashiko-service-skeleton.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: sashiko
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
-    # yamllint disable-line rule:line-length
-    beta.cloud.google.com/backend-config: '{"default": "sashiko-backend-config"}'
+    beta.cloud.google.com/backend-config: |
+      '{"default": "sashiko-backend-config"}'
 spec:
   type: NodePort
   ports:

--- a/scripts/check_server_config.sh
+++ b/scripts/check_server_config.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Check if Sashiko server is properly configured for GitLab webhooks
+
+SERVER="http://localhost:9080"
+
+echo "Checking Sashiko server configuration..."
+echo "Server: ${SERVER}"
+echo "---"
+
+# Test 1: Check if server is reachable
+echo -n "1. Server reachable: "
+if curl -s -f -o /dev/null "${SERVER}/" --max-time 5; then
+    echo "✓ Yes"
+else
+    echo "✗ No - Server is not responding"
+    echo "   Make sure Sashiko is running and accessible"
+    exit 1
+fi
+
+# Test 2: Check forge configuration
+echo -n "2. Forge enabled: "
+config=$(curl -s "${SERVER}/api/config")
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to fetch config"
+    exit 1
+fi
+
+forge_enabled=$(echo "$config" | jq -r '.forge_enabled // false')
+if [ "$forge_enabled" = "true" ]; then
+    echo "✓ Yes"
+else
+    echo "✗ No"
+    echo "   Set forge.enabled = true in Settings.toml and restart Sashiko"
+    exit 1
+fi
+
+# Test 3: Check if webhook endpoint exists
+echo -n "3. GitLab webhook endpoint: "
+webhook_test=$(curl -s -w "%{http_code}" -o /dev/null \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Gitlab-Event: Merge Request Hook" \
+    -d '{}' \
+    "${SERVER}/api/webhook/gitlab")
+
+if [ "$webhook_test" = "400" ] || [ "$webhook_test" = "200" ]; then
+    # 400 is expected with empty payload, means endpoint exists
+    echo "✓ Available (HTTP ${webhook_test})"
+elif [ "$webhook_test" = "403" ]; then
+    echo "⚠ Forbidden - forge might be disabled"
+else
+    echo "✗ Unexpected response (HTTP ${webhook_test})"
+fi
+
+# Test 4: Show current configuration
+echo ""
+echo "Current Configuration:"
+echo "$config" | jq . 2>/dev/null || echo "$config"
+
+echo ""
+echo "---"
+echo "✓ Server is ready for GitLab webhooks!"
+echo ""
+echo "Next steps:"
+echo "  1. Configure webhook in GitLab project settings"
+echo "  2. Set URL to: ${SERVER}/api/webhook/gitlab"
+echo "  3. Enable 'Merge request events'"
+echo "  4. Test with: ./trigger_gitlab_mr_review.sh <MR_NUMBER>"
+echo ""
+echo "See GITLAB_SETUP.md for detailed instructions"

--- a/scripts/test_github_webhook.sh
+++ b/scripts/test_github_webhook.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Test GitHub webhook integration locally
+
+SERVER="http://localhost:9080"
+WEBHOOK_URL="${SERVER}/api/webhook/github"
+
+# Example GitHub PR webhook payload
+read -r -d '' PAYLOAD <<'EOF'
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 123,
+    "title": "Test PR for webhook",
+    "html_url": "https://github.com/owner/repo/pull/123",
+    "base": {
+      "sha": "6f6d7e7447811dbecc13cc7fbbe9f5e7a3d7c70b"
+    },
+    "head": {
+      "sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7"
+    }
+  },
+  "repository": {
+    "clone_url": "https://github.com/owner/repo.git"
+  }
+}
+EOF
+
+echo "Testing GitHub webhook at: ${WEBHOOK_URL}"
+echo "---"
+
+# Send the webhook
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: pull_request" \
+  -d "$PAYLOAD" \
+  "${WEBHOOK_URL}")
+
+# Extract HTTP code and body
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | grep -v "HTTP_CODE:")
+
+echo "Response Code: ${http_code}"
+echo "Response Body:"
+echo "$body" | jq . 2>/dev/null || echo "$body"
+
+if [ "$http_code" = "200" ]; then
+    echo ""
+    echo "✓ Webhook test successful!"
+    echo "Check sashiko logs to see if the review was queued."
+else
+    echo ""
+    echo "✗ Webhook test failed!"
+    echo "Make sure:"
+    echo "  1. Sashiko server is running"
+    echo "  2. forge.enabled = true in Settings.toml"
+    echo "  3. Server is accessible at ${SERVER}"
+fi

--- a/scripts/test_gitlab_webhook.sh
+++ b/scripts/test_gitlab_webhook.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test GitLab webhook integration locally
+
+SERVER="http://localhost:9080"
+WEBHOOK_URL="${SERVER}/api/webhook/gitlab"
+
+# Example GitLab MR webhook payload
+# This simulates what GitLab sends when an MR is opened or updated
+read -r -d '' PAYLOAD <<'EOF'
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "object_attributes": {
+    "iid": 123,
+    "action": "open",
+    "source_branch": "feature-branch",
+    "target_branch": "main",
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7"
+    },
+    "diff_refs": {
+      "base_sha": "6f6d7e7447811dbecc13cc7fbbe9f5e7a3d7c70b",
+      "head_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7"
+    }
+  },
+  "project": {
+    "git_http_url": "https://gitlab.example.com/org/project.git"
+  }
+}
+EOF
+
+echo "Testing GitLab webhook at: ${WEBHOOK_URL}"
+echo "---"
+
+# Send the webhook
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Gitlab-Event: Merge Request Hook" \
+  -d "$PAYLOAD" \
+  "${WEBHOOK_URL}")
+
+# Extract HTTP code and body
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | grep -v "HTTP_CODE:")
+
+echo "Response Code: ${http_code}"
+echo "Response Body:"
+echo "$body" | jq . 2>/dev/null || echo "$body"
+
+if [ "$http_code" = "200" ]; then
+    echo ""
+    echo "✓ Webhook test successful!"
+    echo "Check sashiko logs to see if the review was queued."
+else
+    echo ""
+    echo "✗ Webhook test failed!"
+    echo "Make sure:"
+    echo "  1. Sashiko server is running"
+    echo "  2. forge.enabled = true in Settings.toml"
+    echo "  3. Server is accessible at ${SERVER}"
+fi

--- a/scripts/trigger_github_pr_review.sh
+++ b/scripts/trigger_github_pr_review.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Manually trigger a review for a specific GitHub PR
+# Usage: ./trigger_github_pr_review.sh <OWNER/REPO> <PR_NUMBER>
+# Example: ./trigger_github_pr_review.sh torvalds/linux 12345
+
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <OWNER/REPO> <PR_NUMBER>"
+    echo "Example: $0 torvalds/linux 12345"
+    exit 1
+fi
+
+REPO=$1
+PR_NUMBER=$2
+SERVER="http://localhost:9080"
+WEBHOOK_URL="${SERVER}/api/webhook/github"
+
+echo "Fetching PR #${PR_NUMBER} details from GitHub..."
+
+# GitHub API (no auth needed for public repos, use GITHUB_TOKEN if available)
+GITHUB_API="https://api.github.com"
+AUTH_HEADER=""
+if [ -n "$GITHUB_TOKEN" ]; then
+    AUTH_HEADER="-H \"Authorization: Bearer $GITHUB_TOKEN\""
+fi
+
+# Fetch PR details
+pr_data=$(curl -s $AUTH_HEADER "${GITHUB_API}/repos/${REPO}/pulls/${PR_NUMBER}")
+
+# Extract required fields
+number=$(echo "$pr_data" | jq -r '.number // empty')
+title=$(echo "$pr_data" | jq -r '.title // empty')
+html_url=$(echo "$pr_data" | jq -r '.html_url // empty')
+base_sha=$(echo "$pr_data" | jq -r '.base.sha // empty')
+head_sha=$(echo "$pr_data" | jq -r '.head.sha // empty')
+state=$(echo "$pr_data" | jq -r '.state // empty')
+
+# Fetch repository details
+repo_data=$(curl -s $AUTH_HEADER "${GITHUB_API}/repos/${REPO}")
+clone_url=$(echo "$repo_data" | jq -r '.clone_url // empty')
+
+if [ -z "$number" ] || [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+    echo "Error: Could not fetch PR details. Check PR number and network connection."
+    echo "API Response:"
+    echo "$pr_data" | jq . 2>/dev/null || echo "$pr_data"
+    exit 1
+fi
+
+echo "PR #${number}: ${title}"
+echo "State: ${state}"
+echo "Base SHA: ${base_sha}"
+echo "Head SHA: ${head_sha}"
+echo "URL: ${html_url}"
+echo "---"
+
+# Build webhook payload
+read -r -d '' PAYLOAD <<EOF || true
+{
+  "action": "opened",
+  "pull_request": {
+    "number": ${number},
+    "title": $(echo "$title" | jq -R .),
+    "html_url": "${html_url}",
+    "base": {
+      "sha": "${base_sha}"
+    },
+    "head": {
+      "sha": "${head_sha}"
+    }
+  },
+  "repository": {
+    "clone_url": "${clone_url}"
+  }
+}
+EOF
+
+echo "Sending webhook to Sashiko..."
+
+# Send the webhook
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: pull_request" \
+  -d "$PAYLOAD" \
+  "${WEBHOOK_URL}")
+
+# Extract HTTP code and body
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | grep -v "HTTP_CODE:")
+
+echo "Response Code: ${http_code}"
+echo "Response Body:"
+echo "$body" | jq . 2>/dev/null || echo "$body"
+
+if [ "$http_code" = "200" ]; then
+    echo ""
+    echo "✓ Review queued successfully!"
+    echo "Monitor at: ${SERVER}/"
+else
+    echo ""
+    echo "✗ Failed to queue review"
+    exit 1
+fi

--- a/scripts/trigger_gitlab_mr_review.sh
+++ b/scripts/trigger_gitlab_mr_review.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Manually trigger a review for a specific GitLab MR
+# Usage: ./trigger_gitlab_mr_review.sh <MR_NUMBER> <GITLAB_PROJECT_PATH>
+#
+# GITLAB_PROJECT_PATH is the URL-encoded path to the GitLab project
+# (e.g., "my-org%2Fmy-group%2Fmy-project")
+
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <MR_NUMBER> <GITLAB_PROJECT_PATH>"
+    echo ""
+    echo "GITLAB_PROJECT_PATH is the URL-encoded project path."
+    echo "Example: $0 123 my-org%2Fmy-project"
+    echo "Example: $0 456 group%2Fsubgroup%2Fproject"
+    exit 1
+fi
+
+MR_NUMBER=$1
+GITLAB_PROJECT="$2"
+SERVER="http://localhost:9080"
+WEBHOOK_URL="${SERVER}/api/webhook/gitlab"
+
+GITLAB_API="https://gitlab.com/api/v4"
+
+# Set up authentication if GITLAB_TOKEN is available
+AUTH_HEADER=""
+if [ -n "$GITLAB_TOKEN" ]; then
+    AUTH_HEADER="-H \"PRIVATE-TOKEN: ${GITLAB_TOKEN}\""
+    echo "Using GitLab authentication token"
+fi
+
+echo "Fetching MR !${MR_NUMBER} details from GitLab..."
+
+# Fetch MR details from GitLab API
+if [ -n "$GITLAB_TOKEN" ]; then
+    mr_data=$(curl -s -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" "${GITLAB_API}/projects/${GITLAB_PROJECT}/merge_requests/${MR_NUMBER}")
+else
+    mr_data=$(curl -s "${GITLAB_API}/projects/${GITLAB_PROJECT}/merge_requests/${MR_NUMBER}")
+fi
+
+# Extract required fields
+iid=$(echo "$mr_data" | jq -r '.iid // empty')
+title=$(echo "$mr_data" | jq -r '.title // empty')
+base_sha=$(echo "$mr_data" | jq -r '.diff_refs.base_sha // empty')
+head_sha=$(echo "$mr_data" | jq -r '.diff_refs.head_sha // empty')
+source_branch=$(echo "$mr_data" | jq -r '.source_branch // empty')
+target_branch=$(echo "$mr_data" | jq -r '.target_branch // empty')
+state=$(echo "$mr_data" | jq -r '.state // empty')
+
+# Fetch project details to get repository URL
+echo "Fetching project details..."
+if [ -n "$GITLAB_TOKEN" ]; then
+    project_data=$(curl -s -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" "${GITLAB_API}/projects/${GITLAB_PROJECT}")
+else
+    project_data=$(curl -s "${GITLAB_API}/projects/${GITLAB_PROJECT}")
+fi
+git_http_url=$(echo "$project_data" | jq -r '.http_url_to_repo // empty')
+web_url=$(echo "$project_data" | jq -r '.web_url // empty')
+
+if [ -z "$iid" ] || [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+    echo "Error: Could not fetch MR details. Check MR number and network connection."
+    echo "API Response:"
+    echo "$mr_data" | jq . 2>/dev/null || echo "$mr_data"
+    if echo "$mr_data" | grep -q "404 Project Not Found" && [ -z "$GITLAB_TOKEN" ]; then
+        echo ""
+        echo "This appears to be a private repository. Set GITLAB_TOKEN to authenticate:"
+        echo "  export GITLAB_TOKEN='your_token_here'"
+        echo "Get a token at: https://gitlab.com/-/profile/personal_access_tokens"
+    fi
+    exit 1
+fi
+
+if [ -z "$git_http_url" ]; then
+    echo "Error: Could not fetch repository URL from project API."
+    echo "Project API Response:"
+    echo "$project_data" | jq . 2>/dev/null || echo "$project_data"
+    if echo "$project_data" | grep -q "404 Project Not Found" && [ -z "$GITLAB_TOKEN" ]; then
+        echo ""
+        echo "This appears to be a private repository. Set GITLAB_TOKEN to authenticate:"
+        echo "  export GITLAB_TOKEN='your_token_here'"
+        echo "Get a token at: https://gitlab.com/-/profile/personal_access_tokens"
+    fi
+    exit 1
+fi
+
+echo "MR !${iid}: ${title}"
+echo "Branches: ${source_branch} → ${target_branch} (${state})"
+echo "Base SHA: ${base_sha}"
+echo "Head SHA: ${head_sha}"
+echo "Repo: ${git_http_url}"
+echo "Web URL: ${web_url}"
+echo "---"
+
+# Build webhook payload
+# Construct MR URL from web_url and iid
+mr_url="${web_url}/-/merge_requests/${iid}"
+
+read -r -d '' PAYLOAD <<EOF || true
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "object_attributes": {
+    "iid": ${iid},
+    "title": $(echo "$title" | jq -R .),
+    "action": "open",
+    "source_branch": "${source_branch}",
+    "target_branch": "${target_branch}",
+    "url": "${mr_url}",
+    "last_commit": {
+      "id": "${head_sha}"
+    },
+    "diff_refs": {
+      "base_sha": "${base_sha}",
+      "head_sha": "${head_sha}"
+    }
+  },
+  "project": {
+    "git_http_url": "${git_http_url}",
+    "web_url": "${web_url}"
+  }
+}
+EOF
+
+echo "Sending webhook to Sashiko..."
+
+# Send the webhook
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Gitlab-Event: Merge Request Hook" \
+  -d "$PAYLOAD" \
+  "${WEBHOOK_URL}")
+
+# Extract HTTP code and body
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | grep -v "HTTP_CODE:")
+
+echo "Response Code: ${http_code}"
+echo "Response Body:"
+echo "$body" | jq . 2>/dev/null || echo "$body"
+
+if [ "$http_code" = "200" ]; then
+    echo ""
+    echo "✓ Review queued successfully!"
+    echo "Monitor at: ${SERVER}/"
+else
+    echo ""
+    echo "✗ Failed to queue review"
+    exit 1
+fi

--- a/src/api.rs
+++ b/src/api.rs
@@ -432,6 +432,10 @@ async fn submit_patch(
                     &format!("Fetching {} from {}...", &sha, repo_display),
                     skip_subjects.as_ref(),
                     only_subjects.as_ref(),
+                    None,
+                    None,
+                    None,
+                    None,
                 )
                 .await
             {
@@ -468,6 +472,10 @@ async fn submit_patch(
                 .create_fetching_patchset(
                     &clean_msgid,
                     &format!("Fetching thread {}...", clean_msgid),
+                    None,
+                    None,
+                    None,
+                    None,
                     None,
                     None,
                 )

--- a/src/api.rs
+++ b/src/api.rs
@@ -15,10 +15,9 @@
 use crate::db::Database;
 use crate::events::Event;
 use crate::fetcher::FetchRequest;
-use crate::settings::ServerSettings;
 use axum::{
     Json, Router,
-    extract::{ConnectInfo, Query, Request, State},
+    extract::{ConnectInfo, Path, Query, Request, State},
     http::StatusCode,
     middleware::{self, Next},
     response::{IntoResponse, Redirect},
@@ -30,7 +29,7 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tower_http::services::{ServeDir, ServeFile};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -124,9 +123,11 @@ impl<K: std::hash::Hash + Eq + Clone, V: Clone> AsyncMapCache<K, V> {
 }
 
 pub struct AppState {
+    pub settings: Arc<crate::settings::Settings>,
     pub db: Arc<Database>,
     pub sender: mpsc::Sender<Event>,
     pub fetch_sender: mpsc::Sender<FetchRequest>,
+    pub forge_registry: Arc<crate::forge::ForgeRegistry>,
     pub read_only: bool,
     pub allow_all_submit: bool,
     pub smtp_enabled: bool,
@@ -256,19 +257,24 @@ async fn redirect_www(req: Request, next: Next) -> impl IntoResponse {
 /// Extracted from [`run_server`] so that integration tests can construct the
 /// router independently (e.g. bind to port 0 for random-port testing).
 pub fn build_router(
+    settings: Arc<crate::settings::Settings>,
     db: Arc<Database>,
     sender: mpsc::Sender<Event>,
     fetch_sender: mpsc::Sender<FetchRequest>,
-    read_only: bool,
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
 ) -> Router {
+    let forge_registry = Arc::new(crate::forge::ForgeRegistry::new());
+    let read_only = settings.server.read_only;
+
     let state = Arc::new(AppState {
+        settings: settings.clone(),
         db,
         sender,
         fetch_sender,
         read_only,
+        forge_registry,
         allow_all_submit,
         smtp_enabled,
         dry_run,
@@ -282,6 +288,7 @@ pub fn build_router(
     });
 
     Router::new()
+        .route("/api/config", get(get_config))
         .route("/api/lists", get(list_mailing_lists))
         .route("/api/patchsets", get(list_patchsets))
         .route("/api/messages", get(list_messages))
@@ -298,6 +305,7 @@ pub fn build_router(
         .route("/api/patchset/rerun", post(rerun_patchset))
         .route("/api/patchset/cancel", post(cancel_patchset))
         .route("/api/patch/rerun", post(rerun_patch))
+        .route("/api/webhook/{provider}", post(forge_webhook))
         .route("/", get_service(ServeFile::new("static/index.html")))
         .nest_service("/static", ServeDir::new("static"))
         .layer(middleware::from_fn(redirect_www))
@@ -305,7 +313,7 @@ pub fn build_router(
 }
 
 pub async fn run_server(
-    settings: ServerSettings,
+    settings: Arc<crate::settings::Settings>,
     db: Arc<Database>,
     sender: mpsc::Sender<Event>,
     fetch_sender: mpsc::Sender<FetchRequest>,
@@ -314,16 +322,16 @@ pub async fn run_server(
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app = build_router(
+        settings.clone(),
         db,
         sender,
         fetch_sender,
-        settings.read_only,
         allow_all_submit,
         smtp_enabled,
         dry_run,
     );
 
-    let bind_addr = format!("{}:{}", settings.host, settings.port);
+    let bind_addr = format!("{}:{}", settings.server.host, settings.server.port);
     let addrs: Vec<SocketAddr> = bind_addr
         .to_socket_addrs()
         .map_err(|e| anyhow::anyhow!("invalid bind address '{}': {}", bind_addr, e))?
@@ -446,6 +454,9 @@ async fn submit_patch(
             let req = FetchRequest {
                 repo_url: repo,
                 commit_hash: sha,
+                mr_url: None,
+                mr_title: None,
+                mr_number: None,
             };
 
             if let Err(e) = state.fetch_sender.send(req).await {
@@ -702,6 +713,12 @@ async fn get_patchset(
         state
             .db
             .get_patchset_details(id_val, query.page, query.per_page)
+            .await
+    } else if query.id.contains('-') && !query.id.contains('@') {
+        info!("Fetching details for patchset slug: {}", query.id);
+        state
+            .db
+            .get_patchset_details_by_slug(&query.id, query.page, query.per_page)
             .await
     } else {
         info!("Fetching details for patchset msgid: {}", query.id);
@@ -1058,4 +1075,94 @@ async fn rerun_patch(
         })?;
 
     Ok(Json(serde_json::json!({ "status": "accepted" })))
+}
+
+async fn get_config(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    Ok(Json(serde_json::json!({
+        "project_name": state.settings.project.name,
+        "project_description": state.settings.project.description,
+        "forge_enabled": state.settings.forge.enabled,
+    })))
+}
+
+async fn forge_webhook(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<Arc<AppState>>,
+    Path(provider): Path<String>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if state.read_only {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if !state.allow_all_submit && !addr.ip().to_canonical().is_loopback() {
+        info!("Refused {} webhook from non-localhost: {}", provider, addr);
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let forge = state.forge_registry.get(&provider).ok_or_else(|| {
+        warn!("Unknown forge provider: {}", provider);
+        StatusCode::NOT_FOUND
+    })?;
+
+    forge.validate_event(&headers)?;
+
+    let (action, metadata) = forge.parse_payload(&body)?;
+
+    info!(
+        "{} {}: {} - {}",
+        forge.name(),
+        action,
+        metadata.pr_title.as_deref().unwrap_or("(no title)"),
+        metadata.pr_url.as_deref().unwrap_or("(no url)")
+    );
+
+    let default_subject = format!("{} #{}", forge.name(), metadata.pr_number);
+    let subject = metadata.pr_title.as_deref().unwrap_or(&default_subject);
+
+    let commit_range = format!("{}..{}", metadata.base_sha, metadata.head_sha);
+    let placeholder_id = format!("mr-{}-{}", metadata.pr_number, commit_range);
+
+    let slug = metadata.pr_url.as_ref().map(|url| {
+        let repo = crate::forge::extract_repo_name_from_url(url);
+        format!("{}-{}", repo, metadata.pr_number)
+    });
+
+    state
+        .db
+        .create_fetching_patchset(
+            &placeholder_id,
+            &format!("Fetching {} PR/MR: {}", forge.name(), subject),
+            None,
+            None,
+            metadata.pr_url.as_deref(),
+            Some(subject),
+            Some(metadata.pr_number),
+            slug.as_deref(),
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to create placeholder patchset: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let req = FetchRequest {
+        repo_url: metadata.repo_url,
+        commit_hash: commit_range,
+        mr_url: metadata.pr_url,
+        mr_title: metadata.pr_title,
+        mr_number: Some(metadata.pr_number),
+    };
+
+    state.fetch_sender.send(req).await.map_err(|e| {
+        error!("Failed to send fetch request to queue: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "status": "accepted",
+        "message": format!("{} {} queued for review", forge.name(), action)
+    })))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -48,6 +48,7 @@ pub struct PatchsetRow {
     pub findings_high: Option<i64>,
     pub findings_critical: Option<i64>,
     pub baseline_id: Option<i64>,
+    pub slug: Option<String>,
     pub failed_reason: Option<String>,
     pub skip_filters: Option<String>,
     pub only_filters: Option<String>,
@@ -58,6 +59,9 @@ pub struct PatchsetRow {
     pub provider: Option<String>,
     #[serde(skip)]
     pub embargo_until: Option<i64>,
+    pub mr_url: Option<String>,
+    pub mr_title: Option<String>,
+    pub mr_number: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -505,6 +509,11 @@ impl Database {
                 "patchsets",
                 "status, embargo_until",
             )
+            .await;
+        let _ = self.try_add_column("patchsets", "mr_url", "TEXT").await;
+        let _ = self.try_add_column("patchsets", "mr_title", "TEXT").await;
+        let _ = self
+            .try_add_column("patchsets", "mr_number", "INTEGER")
             .await;
 
         let _ = self
@@ -2419,7 +2428,7 @@ impl Database {
         let sql = format!(
             "SELECT p.id, p.subject, p.status, p.thread_id, p.author, p.date, p.cover_letter_message_id, p.total_parts, p.received_parts, GROUP_CONCAT(s.name, ','),
              COALESCE(f.low, 0), COALESCE(f.medium, 0), COALESCE(f.high, 0), COALESCE(f.critical, 0), p.baseline_id, p.failed_reason, p.target_review_count, p.skip_filters, p.only_filters,
-             p.embargo_until
+             p.embargo_until, p.mr_url, p.mr_title, p.mr_number, p.slug
              FROM (
                  SELECT id FROM patchsets p
                  {}
@@ -2519,6 +2528,10 @@ impl Database {
                         baseline_logs: None,
                         provider: None,
                         embargo_until: row.get(19).ok(),
+                        mr_url: row.get(20).ok(),
+                        mr_title: row.get(21).ok(),
+                        mr_number: row.get(22).ok(),
+                        slug: row.get(23).ok(),
                     });
                 }
                 Ok(None) => break,
@@ -2661,7 +2674,7 @@ impl Database {
                     p.author, p.date, p.cover_letter_message_id, p.thread_id,
                     p.total_parts, p.received_parts, p.failed_reason,
                     p.model_name, p.prompts_git_hash, p.baseline_logs, p.baseline_id, p.provider,
-                    p.embargo_until
+                    p.embargo_until, p.mr_url, p.slug
                 FROM patchsets p
                 WHERE p.id = ?",
                 libsql::params![id],
@@ -2687,6 +2700,8 @@ impl Database {
             let baseline_id: Option<i64> = row.get(15).ok();
             let provider: Option<String> = row.get(16).ok();
             let embargo_until: Option<i64> = row.get(17).ok();
+            let mr_url: Option<String> = row.get(18).ok();
+            let slug: Option<String> = row.get(19).ok();
             // Fetch baseline details if needed
             let baseline = if let Some(bid) = baseline_id {
                 let mut browse = self
@@ -2882,7 +2897,9 @@ impl Database {
                 "baseline_logs": baseline_logs,
                 "baseline": baseline,
                 "provider": provider,
-                "embargo_until": embargo_until
+                "embargo_until": embargo_until,
+                "mr_url": mr_url,
+                "slug": slug
             })))
         } else {
             Ok(None)
@@ -2902,7 +2919,7 @@ impl Database {
                     p.author, p.date, p.cover_letter_message_id, p.thread_id,
                     p.total_parts, p.received_parts, p.failed_reason,
                     p.model_name, p.prompts_git_hash, p.baseline_logs, p.baseline_id, p.provider,
-                    p.embargo_until
+                    p.embargo_until, p.mr_url, p.slug
                 FROM patchsets p
                 WHERE p.id = ?",
                 libsql::params![id],
@@ -2928,6 +2945,8 @@ impl Database {
             let baseline_id: Option<i64> = row.get(15).ok();
             let provider: Option<String> = row.get(16).ok();
             let embargo_until: Option<i64> = row.get(17).ok();
+            let mr_url: Option<String> = row.get(18).ok();
+            let slug: Option<String> = row.get(19).ok();
             let baseline = if let Some(bid) = baseline_id {
                 let mut browse = self
                     .conn
@@ -3117,7 +3136,9 @@ impl Database {
                 "baseline_logs": baseline_logs,
                 "baseline": baseline,
                 "provider": provider,
-                "embargo_until": embargo_until
+                "embargo_until": embargo_until,
+                "mr_url": mr_url,
+                "slug": slug
             })))
         } else {
             Ok(None)
@@ -3147,6 +3168,48 @@ impl Database {
             .query(
                 "SELECT patchset_id FROM patches WHERE message_id = ?",
                 libsql::params![msg_id],
+            )
+            .await?;
+        if let Ok(Some(row)) = rows.next().await {
+            let id: i64 = row.get(0)?;
+            return self.get_patchset_summary(id, page, limit).await;
+        }
+
+        Ok(None)
+    }
+
+    pub async fn get_patchset_details_by_slug(
+        &self,
+        slug: &str,
+        page: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<Option<serde_json::Value>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT id FROM patchsets WHERE slug = ?",
+                libsql::params![slug],
+            )
+            .await?;
+        if let Ok(Some(row)) = rows.next().await {
+            let id: i64 = row.get(0)?;
+            return self.get_patchset_details(id, page, limit).await;
+        }
+
+        Ok(None)
+    }
+
+    pub async fn get_patchset_summary_by_slug(
+        &self,
+        slug: &str,
+        page: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<Option<serde_json::Value>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT id FROM patchsets WHERE slug = ?",
+                libsql::params![slug],
             )
             .await?;
         if let Ok(Some(row)) = rows.next().await {
@@ -3254,7 +3317,7 @@ impl Database {
 
     pub async fn get_pending_patchsets(&self, limit: usize) -> Result<Vec<PatchsetRow>> {
         let mut rows = self.conn.query(
-            "SELECT id, subject, status, thread_id, author, date, cover_letter_message_id, total_parts, received_parts, baseline_id, failed_reason, target_review_count, skip_filters, only_filters, embargo_until
+            "SELECT id, subject, status, thread_id, author, date, cover_letter_message_id, total_parts, received_parts, baseline_id, failed_reason, target_review_count, skip_filters, only_filters, embargo_until, slug
              FROM patchsets WHERE status = 'Pending' ORDER BY date ASC LIMIT ?",
             libsql::params![limit as i64],
         ).await?;
@@ -3286,6 +3349,10 @@ impl Database {
                 baseline_logs: None,
                 provider: None,
                 embargo_until: row.get(14).ok(),
+                mr_url: None,
+                mr_title: None,
+                mr_number: None,
+                slug: row.get(15).ok(),
             });
         }
         Ok(patchsets)
@@ -3338,6 +3405,10 @@ impl Database {
                         baseline_logs: None,
                         provider: None,
                         embargo_until: row.get(14).ok(),
+                        mr_url: None,
+                        mr_title: None,
+                        mr_number: None,
+                        slug: None,
                     });
                 }
                 Ok(None) => break,
@@ -3549,12 +3620,17 @@ impl Database {
         self.rerun_patchset(patchset_id).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_fetching_patchset(
         &self,
         article_id: &str,
         subject: &str,
         skip_filters: Option<&Vec<String>>,
         only_filters: Option<&Vec<String>>,
+        mr_url: Option<&str>,
+        mr_title: Option<&str>,
+        mr_number: Option<i64>,
+        slug: Option<&str>,
     ) -> Result<i64> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
@@ -3589,8 +3665,8 @@ impl Database {
                 // We don't want to reset if it is already Incomplete, Pending, or Reviewed.
                 if status == "Failed" || status == "Fetching" {
                     self.conn.execute(
-                        "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ? WHERE id = ?",
-                        libsql::params![skip_filters_json.clone(), only_filters_json.clone(), id]
+                        "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
+                        libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
                     ).await?;
                 }
                 return Ok(id);
@@ -3603,9 +3679,9 @@ impl Database {
         // 3. Create the fetching patchset
         let mut rows = self.conn
             .query(
-                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters) 
-                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?) RETURNING id",
-                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json],
+                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters, mr_url, mr_title, mr_number, slug)
+                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json, mr_url, mr_title, mr_number, slug],
             )
             .await?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -503,6 +503,14 @@ impl Database {
         let _ = self
             .try_add_column("patchsets", "embargo_until", "INTEGER")
             .await;
+        let _ = self.try_add_column("patchsets", "slug", "TEXT").await;
+        let _ = self
+            .conn
+            .execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_patchsets_slug ON patchsets(slug) WHERE slug IS NOT NULL",
+                (),
+            )
+            .await;
         let _ = self
             .try_create_index(
                 "idx_patchsets_status_embargo_until",

--- a/src/events.rs
+++ b/src/events.rs
@@ -36,6 +36,9 @@ pub enum Event {
         timestamp: i64,
         index: u32,
         total: u32,
+        mr_url: Option<String>,
+        mr_title: Option<String>,
+        mr_number: Option<i64>,
     },
     RawMboxSubmitted {
         raw: String,
@@ -60,4 +63,7 @@ pub struct ParsedArticle {
     pub failed_error: Option<String>,
     pub skip_filters: Option<Vec<String>>,
     pub only_filters: Option<Vec<String>>,
+    pub mr_url: Option<String>,
+    pub mr_title: Option<String>,
+    pub mr_number: Option<i64>,
 }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -436,6 +436,9 @@ impl FetchAgent {
             timestamp: meta.timestamp,
             index,
             total,
+            mr_url: None,
+            mr_title: None,
+            mr_number: None,
         })
     }
 }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -27,6 +27,9 @@ use tracing::{error, info, warn};
 pub struct FetchRequest {
     pub repo_url: Option<String>,
     pub commit_hash: String,
+    pub mr_url: Option<String>,
+    pub mr_title: Option<String>,
+    pub mr_number: Option<i64>,
 }
 
 pub struct FetchAgent {

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -36,12 +36,16 @@ pub struct FetchAgent {
     repo_path: PathBuf,
     rx: mpsc::Receiver<FetchRequest>,
     main_tx: mpsc::Sender<Event>,
+    #[allow(clippy::type_complexity)]
+    mr_metadata: HashMap<String, (Option<String>, Option<String>, Option<i64>)>,
+    gitlab_token: Option<String>,
 }
 
 impl FetchAgent {
     pub fn new(
         repo_path: PathBuf,
         main_tx: mpsc::Sender<Event>,
+        gitlab_token: Option<String>,
     ) -> (Self, mpsc::Sender<FetchRequest>) {
         let (tx, rx) = mpsc::channel(100);
         (
@@ -49,6 +53,8 @@ impl FetchAgent {
                 repo_path,
                 rx,
                 main_tx,
+                mr_metadata: HashMap::new(),
+                gitlab_token,
             },
             tx,
         )
@@ -62,6 +68,12 @@ impl FetchAgent {
         loop {
             tokio::select! {
                 Some(req) = self.rx.recv() => {
+                    if req.mr_url.is_some() || req.mr_title.is_some() || req.mr_number.is_some() {
+                        self.mr_metadata.insert(
+                            req.commit_hash.clone(),
+                            (req.mr_url.clone(), req.mr_title.clone(), req.mr_number)
+                        );
+                    }
                     queue.entry(req.repo_url)
                         .or_default()
                         .insert(req.commit_hash);
@@ -92,9 +104,22 @@ impl FetchAgent {
                 url_display
             );
 
-            // Check existence first
+            // For ranges (base..head), we need to check both endpoints individually
+            let mut commits_to_check = Vec::new();
+            for commit_or_range in &commit_list {
+                if commit_or_range.contains("..") {
+                    let parts: Vec<&str> = commit_or_range.split("..").collect();
+                    if parts.len() == 2 {
+                        commits_to_check.push(parts[0].to_string());
+                        commits_to_check.push(parts[1].to_string());
+                    }
+                } else {
+                    commits_to_check.push(commit_or_range.clone());
+                }
+            }
+
             let mut missing_commits = Vec::new();
-            for commit in &commit_list {
+            for commit in &commits_to_check {
                 if !self.is_present(commit).await {
                     missing_commits.push(commit.clone());
                 }
@@ -196,8 +221,31 @@ impl FetchAgent {
                     let count = shas.len() as u32;
 
                     // Process each SHA
+                    let (mr_url, mr_title, mr_number) = self
+                        .mr_metadata
+                        .get(range)
+                        .cloned()
+                        .unwrap_or((None, None, None));
+
+                    let article_id = if let Some(number) = mr_number {
+                        format!("mr-{}-{}", number, range)
+                    } else {
+                        range.to_string()
+                    };
+
                     for (i, sha) in shas.iter().enumerate() {
-                        match self.extract_patch(sha, range, (i + 1) as u32, count).await {
+                        match self
+                            .extract_patch(
+                                sha,
+                                &article_id,
+                                (i + 1) as u32,
+                                count,
+                                mr_url.as_ref(),
+                                mr_title.as_ref(),
+                                mr_number,
+                            )
+                            .await
+                        {
                             Ok(mut event) => {
                                 if let Event::PatchSubmitted {
                                     ref mut message_id, ..
@@ -234,7 +282,30 @@ impl FetchAgent {
                         }
                     };
 
-                    match self.extract_patch(&full_sha, &commit_or_range, 1, 1).await {
+                    let (mr_url, mr_title, mr_number) = self
+                        .mr_metadata
+                        .get(&commit_or_range)
+                        .cloned()
+                        .unwrap_or((None, None, None));
+
+                    let article_id = if let Some(number) = mr_number {
+                        format!("mr-{}-{}", number, &commit_or_range)
+                    } else {
+                        commit_or_range.clone()
+                    };
+
+                    match self
+                        .extract_patch(
+                            &full_sha,
+                            &article_id,
+                            1,
+                            1,
+                            mr_url.as_ref(),
+                            mr_title.as_ref(),
+                            mr_number,
+                        )
+                        .await
+                    {
                         Ok(mut event) => {
                             if let Event::PatchSubmitted {
                                 ref mut message_id, ..
@@ -275,9 +346,21 @@ impl FetchAgent {
     }
 
     async fn ensure_remote(&self, name: &str, url: &str) -> Result<()> {
+        // Inject GitLab token if available
+        let authenticated_url = if let Some(token) = &self.gitlab_token {
+            if url.contains("gitlab.com") && url.starts_with("https://") {
+                url.replace("https://", &format!("https://oauth2:{}@", token))
+            } else {
+                url.to_string()
+            }
+        } else {
+            url.to_string()
+        };
+
         // Check if remote exists
         let status = Command::new("git")
             .current_dir(&self.repo_path)
+            .args(["-c", "safe.bareRepository=all"])
             .args(["remote", "get-url", name])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -285,32 +368,38 @@ impl FetchAgent {
             .await?;
 
         if status.success() {
-            // Check if URL matches, if not update it
             let output = Command::new("git")
                 .current_dir(&self.repo_path)
+                .args(["-c", "safe.bareRepository=all"])
                 .args(["remote", "get-url", name])
                 .output()
                 .await?;
             let current_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-            if current_url != url {
+            if current_url != authenticated_url {
                 info!(
                     "Updating remote {} from {} to {}",
                     name,
                     redact_secret(&current_url),
-                    redact_secret(url)
+                    redact_secret(&authenticated_url)
                 );
                 Command::new("git")
                     .current_dir(&self.repo_path)
-                    .args(["remote", "set-url", name, url])
+                    .args(["-c", "safe.bareRepository=all"])
+                    .args(["remote", "set-url", name, &authenticated_url])
                     .output()
                     .await?;
             }
         } else {
-            info!("Adding remote {} -> {}", name, redact_secret(url));
+            info!(
+                "Adding remote {} -> {}",
+                name,
+                redact_secret(&authenticated_url)
+            );
             let output = Command::new("git")
                 .current_dir(&self.repo_path)
-                .args(["remote", "add", name, url])
+                .args(["-c", "safe.bareRepository=all"])
+                .args(["remote", "add", name, &authenticated_url])
                 .output()
                 .await?;
 
@@ -363,15 +452,15 @@ impl FetchAgent {
     }
 
     async fn is_present(&self, commit_or_range: &str) -> bool {
+        let mut args = vec!["-c", "safe.bareRepository=all"];
         let arg_str: String;
-        let args = if let Some((start, end)) = commit_or_range.split_once("..") {
-            // For ranges, ensure both endpoints are commits
+
+        if let Some((start, end)) = commit_or_range.split_once("..") {
             arg_str = format!("{}^{{commit}}..{}^{{commit}}", start, end);
-            vec!["rev-list", "-n", "1", &arg_str]
+            args.extend(["rev-list", "-n", "1", &arg_str]);
         } else {
-            // For single commits, ensure it is a valid commit object
             arg_str = format!("{}^{{commit}}", commit_or_range);
-            vec!["rev-parse", "--verify", &arg_str]
+            args.extend(["rev-parse", "--verify", &arg_str]);
         };
 
         let output = Command::new("git")
@@ -404,6 +493,7 @@ impl FetchAgent {
     async fn resolve_sha(&self, commit: &str) -> Result<String> {
         let output = Command::new("git")
             .current_dir(&self.repo_path)
+            .args(["-c", "safe.bareRepository=all"])
             .args(["rev-parse", "--verify", commit])
             .output()
             .await?;
@@ -418,12 +508,16 @@ impl FetchAgent {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn extract_patch(
         &self,
         commit: &str,
         article_id: &str,
         index: u32,
         total: u32,
+        mr_url: Option<&String>,
+        mr_title: Option<&String>,
+        mr_number: Option<i64>,
     ) -> Result<Event> {
         let meta = crate::git_ops::extract_patch_metadata(&self.repo_path, commit).await?;
 
@@ -439,9 +533,9 @@ impl FetchAgent {
             timestamp: meta.timestamp,
             index,
             total,
-            mr_url: None,
-            mr_title: None,
-            mr_number: None,
+            mr_url: mr_url.cloned(),
+            mr_title: mr_title.cloned(),
+            mr_number,
         })
     }
 }
@@ -456,7 +550,7 @@ mod tests {
     async fn test_fetch_agent_lifecycle() {
         let (tx, _rx) = mpsc::channel(1);
         let repo_path = PathBuf::from("/tmp");
-        let (_agent, _sender) = FetchAgent::new(repo_path, tx);
+        let (_agent, _sender) = FetchAgent::new(repo_path, tx, None);
     }
 
     #[tokio::test]
@@ -497,7 +591,7 @@ mod tests {
             .await?;
 
         let (tx, _rx) = mpsc::channel(1);
-        let (agent, _) = FetchAgent::new(repo_path.clone(), tx);
+        let (agent, _) = FetchAgent::new(repo_path.clone(), tx, None);
 
         let output = Command::new("git")
             .current_dir(&repo_path)
@@ -506,7 +600,9 @@ mod tests {
             .await?;
         let head = String::from_utf8(output.stdout)?.trim().to_string();
 
-        let event = agent.extract_patch(&head, &head, 1, 1).await?;
+        let event = agent
+            .extract_patch(&head, &head, 1, 1, None, None, None)
+            .await?;
 
         match event {
             Event::PatchSubmitted {
@@ -567,7 +663,7 @@ mod tests {
             .await?;
 
         let (tx, _rx) = mpsc::channel(1);
-        let (agent, _) = FetchAgent::new(repo_path.clone(), tx);
+        let (agent, _) = FetchAgent::new(repo_path.clone(), tx, None);
 
         let output = Command::new("git")
             .current_dir(&repo_path)

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -1,0 +1,238 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use axum::http::{HeaderMap, StatusCode};
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Metadata extracted from forge webhook
+#[derive(Debug, Clone)]
+pub struct ForgeMetadata {
+    pub repo_url: Option<String>,
+    pub base_sha: String,
+    pub head_sha: String,
+    pub pr_number: i64,
+    pub pr_title: Option<String>,
+    pub pr_url: Option<String>,
+}
+
+/// Trait for forge provider implementations
+pub trait ForgeProvider: Send + Sync {
+    /// Provider name (e.g., "GitHub", "GitLab")
+    fn name(&self) -> &str;
+
+    /// Validate webhook event from headers
+    fn validate_event(&self, headers: &HeaderMap) -> Result<(), StatusCode>;
+
+    /// Parse webhook payload and extract metadata
+    fn parse_payload(&self, body: &Bytes) -> Result<(String, ForgeMetadata), StatusCode>;
+}
+
+/// GitHub forge provider
+pub struct GitHubForge;
+
+impl ForgeProvider for GitHubForge {
+    fn name(&self) -> &str {
+        "GitHub"
+    }
+
+    fn validate_event(&self, headers: &HeaderMap) -> Result<(), StatusCode> {
+        let event = headers
+            .get("x-github-event")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(StatusCode::BAD_REQUEST)?;
+
+        if event != "pull_request" {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+
+        Ok(())
+    }
+
+    fn parse_payload(&self, body: &Bytes) -> Result<(String, ForgeMetadata), StatusCode> {
+        use serde_json::Value;
+
+        let payload: Value = serde_json::from_slice(body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+        let action = payload["action"]
+            .as_str()
+            .ok_or(StatusCode::BAD_REQUEST)?
+            .to_string();
+
+        let pr = &payload["pull_request"];
+        if pr.is_null() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+
+        let head_sha = pr["head"]["sha"]
+            .as_str()
+            .ok_or(StatusCode::BAD_REQUEST)?
+            .to_string();
+
+        let base_sha = pr["base"]["sha"]
+            .as_str()
+            .ok_or(StatusCode::BAD_REQUEST)?
+            .to_string();
+
+        let pr_number = pr["number"].as_i64().ok_or(StatusCode::BAD_REQUEST)?;
+
+        let pr_title = pr["title"].as_str().map(|s| s.to_string());
+        let pr_url = pr["html_url"].as_str().map(|s| s.to_string());
+
+        let repo_url = payload["repository"]["clone_url"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let metadata = ForgeMetadata {
+            repo_url,
+            base_sha,
+            head_sha,
+            pr_number,
+            pr_title,
+            pr_url,
+        };
+
+        Ok((action, metadata))
+    }
+}
+
+/// GitLab forge provider
+pub struct GitLabForge;
+
+impl ForgeProvider for GitLabForge {
+    fn name(&self) -> &str {
+        "GitLab"
+    }
+
+    fn validate_event(&self, headers: &HeaderMap) -> Result<(), StatusCode> {
+        let event = headers
+            .get("x-gitlab-event")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(StatusCode::BAD_REQUEST)?;
+
+        if event != "Merge Request Hook" {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+
+        Ok(())
+    }
+
+    fn parse_payload(&self, body: &Bytes) -> Result<(String, ForgeMetadata), StatusCode> {
+        use serde_json::Value;
+
+        let payload: Value = serde_json::from_slice(body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+        let action = payload["object_kind"]
+            .as_str()
+            .ok_or(StatusCode::BAD_REQUEST)?
+            .to_string();
+
+        let attrs = &payload["object_attributes"];
+        if attrs.is_null() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+
+        let head_sha = attrs["last_commit"]["id"]
+            .as_str()
+            .ok_or(StatusCode::BAD_REQUEST)?
+            .to_string();
+
+        let base_sha = attrs["diff_refs"]["base_sha"]
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| head_sha.clone());
+
+        let pr_number = attrs["iid"].as_i64().ok_or(StatusCode::BAD_REQUEST)?;
+
+        let pr_title = attrs["title"].as_str().map(|s| s.to_string());
+        let pr_url = attrs["url"].as_str().map(|s| s.to_string());
+
+        let repo_url = payload["project"]["git_http_url"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let metadata = ForgeMetadata {
+            repo_url,
+            base_sha,
+            head_sha,
+            pr_number,
+            pr_title,
+            pr_url,
+        };
+
+        Ok((action, metadata))
+    }
+}
+
+/// Extract repository name from a URL
+pub fn extract_repo_name_from_url(url: &str) -> String {
+    url.trim_end_matches('/')
+        .split('/')
+        .next_back()
+        .map(|s| s.trim_end_matches(".git"))
+        .unwrap_or("repo")
+        .to_string()
+}
+
+/// Extract repository name from a GitLab MR URL
+pub fn extract_repo_name_from_mr_url(url: &str) -> Option<String> {
+    if let Some(before_sep) = url.split("/-/").next() {
+        let name = before_sep
+            .trim_end_matches('/')
+            .split('/')
+            .next_back()?
+            .to_string();
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// Registry for forge providers
+pub struct ForgeRegistry {
+    providers: HashMap<String, Arc<dyn ForgeProvider>>,
+}
+
+impl ForgeRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            providers: HashMap::new(),
+        };
+
+        registry.register("github", Arc::new(GitHubForge));
+        registry.register("gitlab", Arc::new(GitLabForge));
+
+        registry
+    }
+
+    pub fn register(&mut self, name: &str, provider: Arc<dyn ForgeProvider>) {
+        self.providers.insert(name.to_string(), provider);
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn ForgeProvider>> {
+        self.providers.get(name).cloned()
+    }
+
+    pub fn list_providers(&self) -> Vec<String> {
+        self.providers.keys().cloned().collect()
+    }
+}
+
+impl Default for ForgeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod email_policy;
 pub mod email_router;
 pub mod events;
 pub mod fetcher;
+pub mod forge;
 pub mod git_ops;
 pub mod ingestor;
 pub mod nntp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 failed_error: Some(error),
                                 skip_filters: None,
                                 only_filters: None,
+                                mr_url: None,
+                                mr_title: None,
+                                mr_number: None,
                             })
                             .await
                         {
@@ -242,6 +245,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         timestamp,
                         index,
                         total,
+                        mr_url: _,
+                        mr_title: _,
+                        mr_number: _,
                     } => {
                         let root_msg_id = format!("{}@sashiko.local", article_id);
 
@@ -287,6 +293,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 failed_error: None,
                                 skip_filters: None,
                                 only_filters: None,
+                                mr_url: None,
+                                mr_title: None,
+                                mr_number: None,
                             })
                             .await
                         {
@@ -346,6 +355,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             failed_error: None,
                                             skip_filters: skip_subjects_clone,
                                             only_filters: only_subjects_clone,
+                                            mr_url: None,
+                                            mr_title: None,
+                                            mr_number: None,
                                         })
                                         .await
                                     {
@@ -400,6 +412,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         failed_error: None,
                                         skip_filters: None,
                                         only_filters: None,
+                                        mr_url: None,
+                                        mr_title: None,
+                                        mr_number: None,
                                     })
                                     .await
                                 {
@@ -621,6 +636,9 @@ async fn process_parsed_article(
         failed_error,
         skip_filters,
         only_filters,
+        mr_url: _,
+        mr_title: _,
+        mr_number: _,
     } = article;
 
     // Handle ingestion failure

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Start Ingestor (feeds raw_tx)
-    let ingestor_handle = if !settings.forge.enabled {
+    let ingestor_handle = if !(settings.forge.enabled && settings.forge.disable_nntp) {
         let ingestor = Ingestor::new(
             settings.clone(),
             db.clone(),
@@ -934,7 +934,9 @@ async fn process_parsed_article(
                 },
                 false,
             )
-        } else if group == "git-fetch" && let (Some(title), Some(number)) = (&mr_title, &mr_number) {
+        } else if group == "git-fetch"
+            && let (Some(title), Some(number)) = (&mr_title, &mr_number)
+        {
             if metadata.total == 1 || metadata.index == 1 {
                 (
                     format!("!{}: {}", number, title),
@@ -1219,9 +1221,14 @@ fn identify_subsystems(
     all_recipients.push_str(", ");
     all_recipients.push_str(cc);
 
-    let compiled_rules: Vec<_> = mapping.iter().filter_map(|rule| {
-        regex::Regex::new(&rule.pattern).ok().map(|re| (re, &rule.name))
-    }).collect();
+    let compiled_rules: Vec<_> = mapping
+        .iter()
+        .filter_map(|rule| {
+            regex::Regex::new(&rule.pattern)
+                .ok()
+                .map(|re| (re, &rule.name))
+        })
+        .collect();
 
     for email in all_recipients.split(',') {
         let email = email.trim();
@@ -1233,8 +1240,7 @@ fn identify_subsystems(
         let mut matched = false;
 
         for (re, name) in &compiled_rules {
-            if re.is_match(&lower_email)
-            {
+            if re.is_match(&lower_email) {
                 subsystems.push(((*name).clone(), lower_email.clone()));
                 matched = true;
             }
@@ -1267,15 +1273,19 @@ fn identify_subsystems_from_paths(
     mapping: &[sashiko::settings::SubsystemMapping],
 ) -> Vec<(String, String)> {
     let mut subsystems = Vec::new();
-    let compiled_rules: Vec<_> = mapping.iter().filter_map(|rule| {
-        regex::Regex::new(&rule.pattern).ok().map(|re| (re, &rule.name))
-    }).collect();
+    let compiled_rules: Vec<_> = mapping
+        .iter()
+        .filter_map(|rule| {
+            regex::Regex::new(&rule.pattern)
+                .ok()
+                .map(|re| (re, &rule.name))
+        })
+        .collect();
 
     for path in paths {
         let lower_path = path.to_lowercase();
         for (re, name) in &compiled_rules {
-            if re.is_match(&lower_path)
-            {
+            if re.is_match(&lower_path) {
                 subsystems.push(((*name).clone(), (*name).clone() + "@forge.local"));
             }
         }
@@ -1392,7 +1402,10 @@ mod tests {
             name: "usb".to_string(),
         }];
 
-        let paths = vec!["drivers/usb/core/devio.c".to_string(), "README.md".to_string()];
+        let paths = vec![
+            "drivers/usb/core/devio.c".to_string(),
+            "README.md".to_string(),
+        ];
         let subsystems = identify_subsystems_from_paths(&paths, &mapping);
 
         assert_eq!(subsystems.len(), 1);
@@ -1478,5 +1491,23 @@ mod tests {
             calculate_embargo_hours("[RFC PATCH bpf-next] foo", &subs, &policy),
             0
         );
+    }
+
+    #[test]
+    fn test_nntp_ingestor_enabled_with_forge() {
+        let mut settings = Settings::new().unwrap();
+        settings.forge.enabled = true;
+        settings.forge.disable_nntp = false;
+        let should_start_ingestor = !(settings.forge.enabled && settings.forge.disable_nntp);
+        assert!(should_start_ingestor);
+    }
+
+    #[test]
+    fn test_nntp_ingestor_disabled_by_default_with_forge() {
+        let mut settings = Settings::new().unwrap();
+        settings.forge.enabled = true;
+        settings.forge.disable_nntp = true; // This is the default
+        let should_start_ingestor = !(settings.forge.enabled && settings.forge.disable_nntp);
+        assert!(!should_start_ingestor);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,7 +494,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Start Web API
-    let api_settings = settings.server.clone();
+    let api_settings = Arc::new(settings.clone());
     let api_db = db.clone();
     let api_tx = raw_tx.clone();
     let api_fetch_tx = fetch_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize FetchAgent
     let repo_path = std::path::PathBuf::from(&settings.git.repository_path);
-    let (fetch_agent, fetch_tx) = sashiko::fetcher::FetchAgent::new(repo_path, raw_tx.clone());
+    let (fetch_agent, fetch_tx) = sashiko::fetcher::FetchAgent::new(
+        repo_path,
+        raw_tx.clone(),
+        settings.forge.api_token.clone(),
+    );
 
     // Spawn FetchAgent
     tokio::spawn(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,9 +249,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         timestamp,
                         index,
                         total,
-                        mr_url: _,
-                        mr_title: _,
-                        mr_number: _,
+                        mr_url,
+                        mr_title,
+                        mr_number,
                     } => {
                         let root_msg_id = format!("{}@sashiko.local", article_id);
 
@@ -297,9 +297,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 failed_error: None,
                                 skip_filters: None,
                                 only_filters: None,
-                                mr_url: None,
-                                mr_title: None,
-                                mr_number: None,
+                                mr_url,
+                                mr_title,
+                                mr_number,
                             })
                             .await
                         {
@@ -441,6 +441,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // DB Worker (Transactional Batching)
     let worker_db = db.clone();
+    let mapping = settings.subsystems.mapping.clone();
     let _db_worker_handle = tokio::spawn(async move {
         info!("DB Worker started");
 
@@ -449,19 +450,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut total_ingested = 0;
         let mut total_errors = 0;
 
+        let policy =
+            sashiko::email_policy::EmailPolicyConfig::load("email_policy.toml").unwrap_or_default();
+
         loop {
             let count = parsed_rx.recv_many(&mut buffer, 100).await;
             if count == 0 {
                 break;
             }
 
-            // info!("Processing batch of {} parsed articles", count); // Too verbose
-
-            let policy = sashiko::email_policy::EmailPolicyConfig::load("email_policy.toml")
-                .unwrap_or_default();
-
             for article in buffer.drain(..) {
-                match process_parsed_article(&worker_db, article, &policy).await {
+                match process_parsed_article(&worker_db, article, &policy, &mapping).await {
                     ProcessStatus::Ingested => total_ingested += 1,
                     ProcessStatus::Error => total_errors += 1,
                 }
@@ -484,18 +483,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Start Ingestor (feeds raw_tx)
-    let ingestor = Ingestor::new(
-        settings.clone(),
-        db.clone(),
-        raw_tx.clone(),
-        cli.download,
-        cli.track,
-    );
-    let ingestor_handle = tokio::spawn(async move {
-        if let Err(e) = ingestor.run().await {
-            error!("Ingestor fatal error: {}", e);
-        }
-    });
+    let ingestor_handle = if !settings.forge.enabled {
+        let ingestor = Ingestor::new(
+            settings.clone(),
+            db.clone(),
+            raw_tx.clone(),
+            cli.download,
+            cli.track,
+        );
+        tokio::spawn(async move {
+            if let Err(e) = ingestor.run().await {
+                error!("Ingestor fatal error: {}", e);
+            }
+        })
+    } else {
+        info!("Forge integration is enabled. Lore/NNTP ingestor is disabled.");
+        tokio::spawn(async move {
+            std::future::pending::<()>().await;
+        })
+    };
 
     // Start Web API
     let api_settings = Arc::new(settings.clone());
@@ -630,6 +636,7 @@ async fn process_parsed_article(
     worker_db: &Database,
     article: ParsedArticle,
     policy: &sashiko::email_policy::EmailPolicyConfig,
+    subsystem_mapping: &[sashiko::settings::SubsystemMapping],
 ) -> ProcessStatus {
     let ParsedArticle {
         group,
@@ -640,9 +647,9 @@ async fn process_parsed_article(
         failed_error,
         skip_filters,
         only_filters,
-        mr_url: _,
-        mr_title: _,
-        mr_number: _,
+        mr_url,
+        mr_title,
+        mr_number,
     } = article;
 
     // Handle ingestion failure
@@ -804,10 +811,29 @@ async fn process_parsed_article(
     }
 
     // Subsystem Identification and Linking
-    let mut subsystems = identify_subsystems(&metadata.to, &metadata.cc);
-    if group.starts_with("git-import") {
-        subsystems.push(("from git".to_string(), "git-import".to_string()));
+    let mut subsystems = identify_subsystems(&metadata.to, &metadata.cc, subsystem_mapping);
+
+    if let Some(p) = patch_opt.as_ref() {
+        let files = sashiko::baseline::extract_files_from_diff(&p.diff);
+        let path_subsystems = identify_subsystems_from_paths(&files, subsystem_mapping);
+        subsystems.extend(path_subsystems);
     }
+
+    if group.starts_with("git-import") || group == "git-fetch" {
+        let (label, email) = if let Some(url) = &mr_url {
+            if let Some(repo_name) = sashiko::forge::extract_repo_name_from_mr_url(url) {
+                let email = format!("git-import-{}", repo_name);
+                (repo_name, email)
+            } else {
+                ("from git".to_string(), "git-import".to_string())
+            }
+        } else {
+            ("from git".to_string(), "git-import".to_string())
+        };
+        subsystems.push((label, email));
+    }
+    subsystems.sort();
+    subsystems.dedup();
 
     let mut subsystem_ids = Vec::new();
     for (name, email) in &subsystems {
@@ -877,7 +903,10 @@ async fn process_parsed_article(
     */
 
     let root_msg_id = format!("{}@sashiko.local", article_id);
-    let cover_letter_id = if group == "git-fetch" || group == "api-submit" {
+    let cover_letter_id = if group == "git-fetch" {
+        // Always use root_msg_id for git-fetch to match the placeholder ID
+        Some(root_msg_id.as_str())
+    } else if group == "api-submit" {
         if metadata.total == 1 {
             Some(metadata.message_id.as_str())
         } else {
@@ -905,6 +934,22 @@ async fn process_parsed_article(
                 },
                 false,
             )
+        } else if group == "git-fetch" && let (Some(title), Some(number)) = (&mr_title, &mr_number) {
+            if metadata.total == 1 || metadata.index == 1 {
+                (
+                    format!("!{}: {}", number, title),
+                    metadata.author.clone(),
+                    metadata.total,
+                    true,
+                )
+            } else {
+                (
+                    metadata.subject.clone(),
+                    metadata.author.clone(),
+                    metadata.total,
+                    !group.starts_with("git-import"),
+                )
+            }
         } else {
             (
                 metadata.subject.clone(),
@@ -1163,12 +1208,20 @@ fn calculate_embargo_hours(
     }
 }
 
-fn identify_subsystems(to: &str, cc: &str) -> Vec<(String, String)> {
+fn identify_subsystems(
+    to: &str,
+    cc: &str,
+    mapping: &[sashiko::settings::SubsystemMapping],
+) -> Vec<(String, String)> {
     let mut subsystems = Vec::new();
     let mut all_recipients = String::new();
     all_recipients.push_str(to);
     all_recipients.push_str(", ");
     all_recipients.push_str(cc);
+
+    let compiled_rules: Vec<_> = mapping.iter().filter_map(|rule| {
+        regex::Regex::new(&rule.pattern).ok().map(|re| (re, &rule.name))
+    }).collect();
 
     for email in all_recipients.split(',') {
         let email = email.trim();
@@ -1177,33 +1230,53 @@ fn identify_subsystems(to: &str, cc: &str) -> Vec<(String, String)> {
         }
 
         let lower_email = email.to_lowercase();
+        let mut matched = false;
 
-        // 1. Static Map (Mimic MAINTAINERS)
-        if lower_email.contains("linux-kernel@vger.kernel.org") {
-            subsystems.push((
-                "LKML".to_string(),
-                "linux-kernel@vger.kernel.org".to_string(),
-            ));
-        } else if lower_email.contains("netdev@vger.kernel.org") {
-            subsystems.push(("netdev".to_string(), "netdev@vger.kernel.org".to_string()));
-        } else if lower_email.contains("bpf@vger.kernel.org") {
-            subsystems.push(("bpf".to_string(), "bpf@vger.kernel.org".to_string()));
-        } else if lower_email.contains("linux-usb@vger.kernel.org") {
-            subsystems.push(("usb".to_string(), "linux-usb@vger.kernel.org".to_string()));
-        } else if lower_email.contains("linux-fsdevel@vger.kernel.org") {
-            subsystems.push((
-                "fsdevel".to_string(),
-                "linux-fsdevel@vger.kernel.org".to_string(),
-            ));
-        } else if lower_email.contains("linux-mm@kvack.org") {
-            subsystems.push(("linux-mm".to_string(), "linux-mm@kvack.org".to_string()));
-        } else if lower_email.ends_with("@vger.kernel.org")
-            || lower_email.ends_with("@lists.linux.dev")
-            || lower_email.ends_with("@lists.infradead.org")
-        {
-            // Fallback: derive name from email user part
-            if let Some(name) = lower_email.split('@').next() {
+        for (re, name) in &compiled_rules {
+            if re.is_match(&lower_email)
+            {
+                subsystems.push(((*name).clone(), lower_email.clone()));
+                matched = true;
+            }
+        }
+
+        // Fallback for known kernel lists if no mapping is provided
+        if !matched {
+            if lower_email.contains("linux-kernel@vger.kernel.org") {
+                subsystems.push(("LKML".to_string(), lower_email));
+            } else if lower_email.contains("netdev@vger.kernel.org") {
+                subsystems.push(("netdev".to_string(), lower_email));
+            } else if (lower_email.ends_with("@vger.kernel.org")
+                || lower_email.ends_with("@lists.linux.dev")
+                || lower_email.ends_with("@lists.infradead.org")
+                || lower_email.ends_with("@kvack.org"))
+                && let Some(name) = lower_email.split('@').next()
+            {
                 subsystems.push((name.to_string(), lower_email));
+            }
+        }
+    }
+
+    subsystems.sort();
+    subsystems.dedup();
+    subsystems
+}
+
+fn identify_subsystems_from_paths(
+    paths: &[String],
+    mapping: &[sashiko::settings::SubsystemMapping],
+) -> Vec<(String, String)> {
+    let mut subsystems = Vec::new();
+    let compiled_rules: Vec<_> = mapping.iter().filter_map(|rule| {
+        regex::Regex::new(&rule.pattern).ok().map(|re| (re, &rule.name))
+    }).collect();
+
+    for path in paths {
+        let lower_path = path.to_lowercase();
+        for (re, name) in &compiled_rules {
+            if re.is_match(&lower_path)
+            {
+                subsystems.push(((*name).clone(), (*name).clone() + "@forge.local"));
             }
         }
     }
@@ -1259,7 +1332,7 @@ mod tests {
         // Test known subsystem
         let to = "linux-kernel@vger.kernel.org";
         let cc = "netdev@vger.kernel.org";
-        let subsystems = identify_subsystems(to, cc);
+        let subsystems = identify_subsystems(to, cc, &[]);
         assert!(subsystems.contains(&(
             "LKML".to_string(),
             "linux-kernel@vger.kernel.org".to_string()
@@ -1269,7 +1342,7 @@ mod tests {
         // Test fallback
         let to = "unknown-list@vger.kernel.org";
         let cc = "";
-        let subsystems = identify_subsystems(to, cc);
+        let subsystems = identify_subsystems(to, cc, &[]);
         assert!(subsystems.contains(&(
             "unknown-list".to_string(),
             "unknown-list@vger.kernel.org".to_string()
@@ -1278,16 +1351,52 @@ mod tests {
         // Test mixed
         let to = "linux-usb@vger.kernel.org, random-user@example.com";
         let cc = "bpf@vger.kernel.org";
-        let subsystems = identify_subsystems(to, cc);
-        assert!(subsystems.contains(&("usb".to_string(), "linux-usb@vger.kernel.org".to_string())));
+        let subsystems = identify_subsystems(to, cc, &[]);
+        assert!(subsystems.contains(&(
+            "linux-usb".to_string(),
+            "linux-usb@vger.kernel.org".to_string()
+        )));
         assert!(subsystems.contains(&("bpf".to_string(), "bpf@vger.kernel.org".to_string())));
         // random-user should be ignored as it doesn't match list patterns
         assert_eq!(subsystems.len(), 2);
 
         // Test linux-mm
         let to = "linux-mm@kvack.org";
-        let subsystems = identify_subsystems(to, "");
+        let subsystems = identify_subsystems(to, "", &[]);
         assert!(subsystems.contains(&("linux-mm".to_string(), "linux-mm@kvack.org".to_string())));
+    }
+
+    #[test]
+    fn test_identify_subsystems_custom_and_fallback() {
+        let custom_mapping = vec![sashiko::settings::SubsystemMapping {
+            pattern: ".*custom-list@example.com.*".to_string(),
+            name: "Custom".to_string(),
+        }];
+
+        // Test that a known default list is still identified even with custom mappings present.
+        let to = "netdev@vger.kernel.org";
+        let cc = "custom-list@example.com";
+        let subsystems = identify_subsystems(to, cc, &custom_mapping);
+
+        assert_eq!(subsystems.len(), 2); // Both custom and default should be found
+        assert!(subsystems.contains(&("netdev".to_string(), "netdev@vger.kernel.org".to_string())));
+        assert!(
+            subsystems.contains(&("Custom".to_string(), "custom-list@example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_identify_subsystems_from_paths() {
+        let mapping = vec![sashiko::settings::SubsystemMapping {
+            pattern: "^drivers/usb/.*".to_string(),
+            name: "usb".to_string(),
+        }];
+
+        let paths = vec!["drivers/usb/core/devio.c".to_string(), "README.md".to_string()];
+        let subsystems = identify_subsystems_from_paths(&paths, &mapping);
+
+        assert_eq!(subsystems.len(), 1);
+        assert!(subsystems.contains(&("usb".to_string(), "usb@forge.local".to_string())));
     }
 
     #[test]

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -80,12 +80,14 @@ CREATE TABLE IF NOT EXISTS patchsets (
     target_review_count INTEGER DEFAULT 1,
     provider TEXT,
     embargo_until INTEGER,
+    slug TEXT, -- URL-friendly slug like "reponame-725" (repo-mrnum)
     FOREIGN KEY(thread_id) REFERENCES threads(id),
     FOREIGN KEY(cover_letter_message_id) REFERENCES messages(message_id),
     FOREIGN KEY(baseline_id) REFERENCES baselines(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_patchsets_status ON patchsets(status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_patchsets_slug ON patchsets(slug) WHERE slug IS NOT NULL;
 
 
 CREATE TABLE IF NOT EXISTS patches (

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -87,7 +87,6 @@ CREATE TABLE IF NOT EXISTS patchsets (
 );
 
 CREATE INDEX IF NOT EXISTS idx_patchsets_status ON patchsets(status);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_patchsets_slug ON patchsets(slug) WHERE slug IS NOT NULL;
 
 
 CREATE TABLE IF NOT EXISTS patches (

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,39 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct SubsystemMapping {
+    pub pattern: String,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct SubsystemsSettings {
+    #[serde(default)]
+    pub mapping: Vec<SubsystemMapping>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+#[allow(unused)]
+pub struct ProjectSettings {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct ForgeSettings {
+    #[serde(default)]
+    pub enabled: bool,
+    pub provider: Option<String>,
+    pub webhook_secret: Option<String>,
+    pub api_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct DatabaseSettings {
     pub url: String,
     pub token: String,
@@ -382,6 +415,12 @@ fn default_log_level() -> String {
 pub struct Settings {
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    #[serde(default)]
+    pub project: ProjectSettings,
+    #[serde(default = "default_subsystems")]
+    pub subsystems: SubsystemsSettings,
+    #[serde(default = "default_forge")]
+    pub forge: ForgeSettings,
     pub database: DatabaseSettings,
     pub nntp: NntpSettings,
     pub smtp: Option<SmtpSettings>,
@@ -390,6 +429,19 @@ pub struct Settings {
     pub server: ServerSettings,
     pub git: GitSettings,
     pub review: ReviewSettings,
+}
+
+fn default_subsystems() -> SubsystemsSettings {
+    SubsystemsSettings { mapping: vec![] }
+}
+
+fn default_forge() -> ForgeSettings {
+    ForgeSettings {
+        enabled: false,
+        provider: None,
+        webhook_secret: None,
+        api_token: None,
+    }
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,9 +43,15 @@ pub struct ProjectSettings {
 pub struct ForgeSettings {
     #[serde(default)]
     pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub disable_nntp: bool,
     pub provider: Option<String>,
     pub webhook_secret: Option<String>,
     pub api_token: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -438,6 +444,7 @@ fn default_subsystems() -> SubsystemsSettings {
 fn default_forge() -> ForgeSettings {
     ForgeSettings {
         enabled: false,
+        disable_nntp: true,
         provider: None,
         webhook_secret: None,
         api_token: None,

--- a/static/index.html
+++ b/static/index.html
@@ -1181,7 +1181,7 @@
                 <img src="static/logo.png" style="height: 1.5em; margin-right: 12px;" alt="Sashiko Logo">
                 About Sashiko
             </div>
-            <div class="about-text">
+            <div class="about-text" id="about-text-content">
                 <blockquote>
                     <strong>Sashiko</strong> (刺し子, literally "little stabs") is a form of decorative reinforcement stitching from Japan. Originally used to reinforce points of wear or to repair worn places or tears with patches, here it represents our mission to reinforce the Linux kernel through automated, intelligent patch review.
                 </blockquote>
@@ -1201,15 +1201,8 @@
                 <p>
                     This particular instance of Sashiko is provided as a service and is actively <strong>reviewing all LKML (Linux Kernel Mailing List) submissions</strong>. All compute resources and LLM tokens utilized for these automated reviews are proudly provided and funded by <strong>Google</strong>.
                 </p>
-
-                <p>
-                    <strong>Quality of Reviews:</strong> In our tests using Gemini 3.1 Pro, Sashiko was able to successfully identify <strong>53.6% of bugs</strong> based on an unfiltered selection of the last 1000 upstream commits with <code>Fixed:</code> tags. 100% of these historical bugs had previously made it through human-driven code reviews.
-                </p>
-
-                <div class="disclaimer">
-                    <strong>Note:</strong> As with any Large Language Model-based tool, Sashiko's output is probabilistic. It might find or miss bugs across different runs with the exact same input. It is designed to augment and assist human reviewers, not to replace them.
-                </div>
-
+            </div>
+            <div style="margin-top: 32px; text-align: center;">
                 <div style="margin-top: 32px; text-align: center;">
                     <a href="https://github.com/sashiko-dev/sashiko" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 8px; font-weight: bold; color: var(--text); padding: 8px 16px; border: 1px solid var(--border); border-radius: 6px; background: var(--btn-bg); text-decoration: none; box-shadow: 0 1px 2px rgba(0,0,0,0.05);">
                         <svg height="20" aria-hidden="true" viewBox="0 0 16 16" version="1.1" width="20" data-view-component="true" style="fill: currentColor;">
@@ -1386,6 +1379,25 @@
             }
         }
 
+        
+        let config = {};
+        async function fetchConfig() {
+            try {
+                const res = await fetch('/api/config');
+                if (res.ok) {
+                    config = await res.json();
+                    document.title = config.project_name;
+                    document.getElementById('about-text-content').innerHTML = `
+                        <p>${escapeHtml(config.project_description)}</p>
+                    `;
+                    const els = document.querySelectorAll('.header-title, .about-logo');
+                    els.forEach(el => {
+                        el.innerHTML = `<img src="static/logo.png" style="height: 1.5em; margin-right: 12px;" alt="Logo"> ${escapeHtml(config.project_name)}`;
+                    });
+                }
+            } catch(e) { console.error("Failed to load config", e); }
+        }
+
         async function router() {
             const route = parseHash();
             const oldView = state.view;
@@ -1441,7 +1453,7 @@
 
         window.addEventListener('hashchange', () => {
             hasNavigatedInternally = true;
-            router();
+            fetchConfig().then(router);
         });
 
         // =====================================================================
@@ -1940,7 +1952,7 @@
 
                     const clickHandler = (e) => {
                         if (e.target.closest('.copy-btn')) return;
-                        const target = `#/patchset/${encodeURIComponent(p.message_id || p.id)}`;
+                        const target = `#/patchset/${encodeURIComponent(p.slug || p.message_id || p.id)}`;
                         if (e.button === 1 || e.ctrlKey || e.metaKey) {
                             window.open(target, '_blank');
                         } else if (e.button === 0) {
@@ -2121,9 +2133,7 @@
                 if (!reviews || reviews.length === 0) {
                     const statusToCheck = patchStatus || data.status;
                     if (statusToCheck === 'Embargoed' && data.embargo_until) {
-                        const hours = data.date ? Math.round((data.embargo_until - data.date) / 3600) : null;
-                        const hoursText = hours !== null ? `${hours} hours` : 'some time';
-                        return `<p style="font-style:italic; font-size:1.2em; color:var(--status-embargoed);">Embargoed by mailing list policy to ${hoursText} after posting. Public at ${formatDate(data.embargo_until, true)}</p>`;
+                        return `<p style="font-style:italic; color:var(--status-embargoed);">Embargoed until ${formatDate(data.embargo_until, true)}</p>`;
                     }
                     return `<p class="status-placeholder">No reviews yet.</p>`;
                 }
@@ -2301,8 +2311,8 @@
             let paginationHtml = '';
             if (data.total_patches_in_db > data.limit) {
                 const totalPages = Math.ceil(data.total_patches_in_db / data.limit);
-                const basePath = `#/patchset/${encodeURIComponent(data.id || data.message_id)}`;
-                
+                const basePath = `#/patchset/${encodeURIComponent(data.slug || data.id || data.message_id)}`;
+
                 paginationHtml = `
                     <div class="pagination">
                         <button onclick="navigate('${basePath}?page=1&limit=${data.limit}')" ${data.page <= 1 ? 'disabled' : ''}>First</button>
@@ -2441,6 +2451,15 @@
                     <div class="kv"><div class="label">Sashiko ver.:</div><div>${escapeHtml(promptsHash)}</div></div>
                 </div>
                 
+                ${data.mr_url ? `<div class="section">
+                    <h2>Merge Request</h2>
+                    <div style="padding: 12px; background: var(--card-bg); border-radius: 6px; border: 1px solid var(--border);">
+                        <a href="${escapeHtml(data.mr_url)}" target="_blank" rel="noopener noreferrer" style="color: var(--link); text-decoration: none; font-weight: 500;">
+                            ${escapeHtml(data.mr_url)} ↗
+                        </a>
+                    </div>
+                </div>` : ''}
+
                 ${threadHtml ? `<div class="section">
                     <h2>Thread</h2>
                     ${threadHtml}
@@ -3387,7 +3406,7 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
         }
 
         loadSettings();
-        router();
+        fetchConfig().then(router);
     </script>
 </body>
 

--- a/tests/integration/server_tests.rs
+++ b/tests/integration/server_tests.rs
@@ -11,9 +11,53 @@ use sashiko::api::build_router;
 use sashiko::db::Database;
 use sashiko::events::Event;
 use sashiko::fetcher::FetchRequest;
-use sashiko::settings::DatabaseSettings;
+use sashiko::settings::{DatabaseSettings, Settings};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
+
+/// Build a minimal [`Settings`] for integration tests.
+///
+/// The `read_only` flag on `server` is set from the parameter; all other
+/// fields use harmless defaults that don't require external resources.
+fn test_settings(read_only: bool) -> Settings {
+    let toml = format!(
+        r#"
+[database]
+url = ":memory:"
+token = ""
+
+[nntp]
+server = "localhost"
+port = 119
+
+[mailing_lists]
+track = []
+
+[ai]
+provider = "gemini"
+model = "test"
+
+[server]
+host = "127.0.0.1"
+port = 0
+read_only = {read_only}
+
+[git]
+repository_path = "."
+
+[review]
+concurrency = 1
+worktree_dir = "/tmp/sashiko-test-trees"
+timeout_seconds = 60
+"#
+    );
+    let cfg = config::Config::builder()
+        .add_source(config::File::from_str(&toml, config::FileFormat::Toml))
+        .build()
+        .expect("test settings parse");
+    cfg.try_deserialize::<Settings>()
+        .expect("test settings deserialize")
+}
 
 /// A running test server instance with its base URL and background handles.
 struct TestServer {
@@ -41,11 +85,12 @@ async fn spawn_test_server(read_only: bool) -> TestServer {
     let (event_tx, event_rx) = mpsc::channel::<Event>(100);
     let (fetch_tx, _fetch_rx) = mpsc::channel::<FetchRequest>(100);
 
+    let settings = Arc::new(test_settings(read_only));
     let app = build_router(
+        settings,
         Arc::clone(&db),
         event_tx,
         fetch_tx,
-        read_only,
         /* allow_all_submit */ true,
         /* smtp_enabled */ false,
         /* dry_run */ true,


### PR DESCRIPTION
Multi-Forge Integration via ForgeProvider Trait

Patches are currently ingested exclusively via NNTP (mailing list).
This patch adds a ForgeProvider trait that abstracts webhook-based
ingestion from code forges, with built-in implementations for GitHub and
GitLab:

- ForgeProvider trait: validate_event(), parse_payload() — any forge
- that speaks webhooks can implement this interface.
- ForgeRegistry: runtime registry of providers, pre-loaded with GitHub
- and GitLab. Third-party providers can be registered at startup.
- ForgeMetadata: normalized struct (repo_url, base_sha, head_sha,
- pr_number, pr_title, pr_url) — backend-agnostic representation of
- a PR/MR event.
- ForgeSettings in Settings.toml: enabled, provider, webhook_secret,
- api_token.
- Webhook endpoint (/api/webhook/:provider): receives forge events, validates
- via the registered provider, extracts commit range, and feeds patches into
- the existing review pipeline.
- DB schema additions: mr_url, mr_title, mr_number, slug columns on
- patchsets table for forge metadata tracking.

The forge layer is entirely opt-in. When [forge] enabled = false (default),
no webhook routes are registered and the NNTP pipeline is unchanged.