### PR TITLE
docs: env var examples in README and code comment use wrong separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ gemini skills install ./skills/sashiko-feature.skill --scope workspace
 
 For users of other agent interfaces (e.g., OpenCode, Claude Code), we recommend following your interface's specific settings to symlink or copy the skill configurations (the `SKILL.md` and `references/` files) into your agent's custom instruction path.
 
-You can also configure settings via environment variables using the `SASHIKO` prefix and double underscores for nesting (e.g., `SASHIKO_AI__PROVIDER=gemini`).
+You can also configure settings via environment variables using the `SASHIKO` prefix and `__` (double underscore) as the separator between every segment (e.g., `SASHIKO__AI__PROVIDER=gemini`).
 
 **Important**: You must set the `LLM_API_KEY` environment variable with your provider's API key.
 ```bash

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -366,7 +366,7 @@ impl Settings {
             // Start with default settings
             .add_source(File::with_name("Settings"))
             // Add settings from environment variables (with a prefix of SASHIKO)
-            // e.g. SASHIKO_SERVER__PORT=8081 would set the server port
+            // e.g. SASHIKO__SERVER__PORT=8081 would set the server port
             .add_source(Environment::with_prefix("SASHIKO").separator("__"))
             .build()?;
 


### PR DESCRIPTION
## Bug

README:128 and src/settings.rs:369 show env var examples that don't
work. The form `SASHIKO_AI__PROVIDER=gemini` (single underscore between
prefix and first key) is silently ignored. The form that works is
`SASHIKO__AI__PROVIDER=gemini` (double underscore everywhere).

## Reproduce

```bash
env -i HOME=$HOME PATH=$PATH SASHIKO__SERVER__PORT=9876 \
    ./target/release/sashiko --no-ai
# listens on 9876, override applied

env -i HOME=$HOME PATH=$PATH SASHIKO_SERVER__PORT=9876 \
    ./target/release/sashiko --no-ai
# listens on 8080, override silently ignored
```

`Environment::with_prefix("SASHIKO").separator("__")` at
src/settings.rs:370 makes config-rs use `__` as both the prefix
separator and the nested-key separator.

## Why doc-only

The working format is already in active use across the repo:

- `sashiko.dev/base/app/sashiko-k8s.yaml` defines 14+ env vars, all
  using `SASHIKO__KEY__NESTED`.
- `scripts/docker-entrypoint.sh` uses the same.
- `MAINTAINERS_GUIDE.md:17` instructs contributors to write the
  working format.

The broken format only appears in the two doc strings this PR fixes.
A code-side fix (adding `.prefix_separator("_")` so the README's
format would work as written) would risk breaking those existing
deployments. The doc-only fix has zero deployment risk.