### PR TITLE
Add the openvpn-devel mailing list to the sashiko review pipeline

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -85,7 +85,8 @@ spec:
                 linux-crypto,linux-riscv,intel-gfx,intel-xe,linux-kselftest,
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
-                batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic
+                batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
+                openvpn-devel
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "48"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -79,6 +79,9 @@ lists = ["sched-ext@lists.linux.dev"]
 reply_to_author = true
 cc = ["sched-ext@lists.linux.dev"]
 
+[subsystems.openvpn-devel]
+lists = ["openvpn-devel@lists.sourceforge.net"]
+cc = ["antonio@mandelbit.com", "ralf@mandelbit.com", "sd@queasysnail.net"]
 
 [subsystems.pci]
 lists = ["linux-pci@vger.kernel.org"]


### PR DESCRIPTION
Hi, we would like to have patches for the `ovpn` kernel module reviewed by sashiko before we send them to netdev.
Therefore I first asked to have the mailing list archived at https://lore.kernel.org/openvpn-devel/ and I am now sending this PR to add the related bits to sashiko.

I am configuring sashiko to send reviews only to the maintainers to avoid violating the 24h embargo enforced on public netdev reviews.

I hope I didn't miss anything.

Thanks!