### PR TITLE
Add live-patching mailing list

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -86,7 +86,7 @@ spec:
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
-                openvpn-devel
+                openvpn-devel, live-patching
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "60"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -83,6 +83,10 @@ cc = ["sched-ext@lists.linux.dev"]
 lists = ["openvpn-devel@lists.sourceforge.net"]
 cc = ["antonio@mandelbit.com", "ralf@mandelbit.com", "sd@queasysnail.net"]
 
+[subsystems.live-patching]
+lists = ["live-patching@vger.kernel.org"]
+reply_all = true
+
 [subsystems.pci]
 lists = ["linux-pci@vger.kernel.org"]
 reply_to_author = true


### PR DESCRIPTION
Adds live-patching@vger.kernel.org to tracking and sets reply-all email policy.

See subsystem maintainer conversation on signing up here:
https://lore.kernel.org/live-patching/4f5c20003e064cea830ce1e1b135b66c33538714.camel@suse.com/T/#me5135e23c8459abf9e4db1a724cf5a7bfd5c8262