### PR TITLE
prompts: I3C_OR_I2C is a valid Kconfig symbol.

### DIFF
--- a/third_party/prompts/kernel/subsystem/kconfig.md
+++ b/third_party/prompts/kernel/subsystem/kconfig.md
@@ -91,6 +91,10 @@ approaches:
   depends on SOME_SUBSYSTEM
   ```
 
+## Unusual but valid Kconfig symbols
+
+- `I3C_OR_I2C` is a valid Kconfig symbol.
+
 ## Quick Checks
 
 - **Selected symbol existence**: Verify every `select FOO` references a


### PR DESCRIPTION
Sashiko complained:

> +	depends on I3C_OR_I2C

Is this a valid Kconfig symbol? It looks like it will evaluate as a single config symbol named CONFIG_I3C_OR_I2C instead of a logical OR. Could this cause the driver to be silently unbuildable? Perhaps it should be written as depends on I3C || I2C?

Tell it that it is a valid symbol.