### PR TITLE
Drop crap emails to krzk

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -49,7 +49,7 @@ cc = ["damon@lists.linux.dev"]
 [subsystems.devicetree]
 lists = ["devicetree@vger.kernel.org"]
 reply_to_author = true
-cc = ["robh@kernel.org", "krzk+dt@kernel.org", "conor+dt@kernel.org", "devicetree@vger.kernel.org"]
+cc = ["robh@kernel.org", "conor+dt@kernel.org", "devicetree@vger.kernel.org"]
 
 [subsystems.ext4]
 lists = ["linux-ext4@vger.kernel.org"]


### PR DESCRIPTION
Amount of noise, incorrect comments and misleading statements you produce, plus recently introduced fake reviewer's statement of oversight, is just too much.