### PR TITLE
Response cache stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,36 @@ updating sashiko.dev. See the
 [CLI Reference](docs/sashiko-cli.md#local) for full setup, options, and
 a comparison of all three review modes.
 
-### 4. Web Interface
+### 4. Response Cache
+
+Sashiko can cache AI responses locally so that re-reviewing the same patchset
+(e.g. via `sashiko-cli rerun`) avoids redundant API calls and costs.  Each
+request is keyed by a SHA-256 hash of its content; identical requests return
+the cached response instantly.
+
+Enable in `Settings.toml` (or your user config):
+
+```toml
+[ai]
+response_cache = true
+response_cache_ttl_days = 7   # Expire entries after 7 days (default)
+```
+
+To see how the cache is performing, enable cache statistics:
+
+```toml
+[ai]
+show_cache_stats = true
+```
+
+This adds:
+- **CLI** (`sashiko-cli show`): per-patch `{cache: 7/7 hits, 42.1k tokens saved}`
+  after each review status, plus a patchset-level summary line.
+- **Web UI**: hover over a patch row or the patchset title to see cache
+  hit/miss ratios and token savings in a tooltip.
+- **Daemon logs**: per-patch cache delta lines after each patch review completes.
+
+### 5. Web Interface
 
 Once the daemon is running, you can access the Web UI, the daemon will print the
 URL to access it from localhost.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ cd sashiko
 Copy an example config to get started. For a full reference of every
 setting, see the [Configuration Reference](docs/configuration.md).
 
+#### User-Level Configuration
+
+You can place personal overrides (credentials, paths, custom settings) in a
+separate file that is not tracked by git:
+
+```
+~/.config/sashiko/Settings.toml
+```
+
+Settings are loaded in layers — later sources override earlier ones:
+1. `./Settings.toml` — repository defaults (checked into git)
+2. `~/.config/sashiko/Settings.toml` — user overrides (optional)
+3. `SASHIKO__*` environment variables — runtime overrides
+
+This follows the XDG Base Directory Specification: if `$XDG_CONFIG_HOME` is
+set, Sashiko looks there instead of `~/.config`.  The user config file is
+entirely optional — if it doesn't exist, only the repository defaults and
+environment variables are used.
+
 #### Configuring the LLM Provider
 
 Sashiko supports multiple LLM providers. To get started with the default

--- a/Settings.toml
+++ b/Settings.toml
@@ -30,6 +30,17 @@ max_input_tokens = 900000
 max_interactions = 100
 temperature = 1.0
 
+# Response cache: stores AI responses in a local SQLite database so that
+# re-reviewing the same patchset (e.g. via `rerun`) avoids redundant API
+# calls.  Cached entries are keyed by a SHA-256 hash of the request.
+# response_cache = true
+# response_cache_ttl_days = 7  # Expire cached entries after this many days
+
+# Show per-patch and per-patchset response cache hit/miss statistics in
+# the CLI `show` output, web UI hover tooltips, and daemon log output.
+# Requires response_cache = true to produce meaningful data.
+# show_cache_stats = false
+
 # To use Claude API directly:
 # provider = "claude"
 # model = "claude-sonnet-4-6"

--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -397,6 +397,7 @@ fn translate_response(
         },
         usage,
         truncated: false,
+        cache_key: None,
     })
 }
 

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 
 use super::{AiProvider, AiRequest, AiResponse, CacheStats, ProviderCapabilities};
@@ -20,7 +20,18 @@ pub fn fmt_thousands(n: u64) -> String {
     result
 }
 
-/// Format a token count with abbreviated suffix: 1.2M, 42.1k, or raw number.
+pub fn fmt_bytes(n: u64) -> String {
+    if n >= 1_073_741_824 {
+        format!("{:.1} GB", n as f64 / 1_073_741_824.0)
+    } else if n >= 1_048_576 {
+        format!("{:.1} MB", n as f64 / 1_048_576.0)
+    } else if n >= 1_024 {
+        format!("{:.1} KB", n as f64 / 1_024.0)
+    } else {
+        format!("{} B", n)
+    }
+}
+
 pub fn fmt_tokens(n: u64) -> String {
     if n >= 1_000_000 {
         format!("{:.1}M", n as f64 / 1_000_000.0)
@@ -45,6 +56,13 @@ pub struct CachingAiProvider {
 
 impl CachingAiProvider {
     pub async fn new(inner: Arc<dyn AiProvider>, cache_path: &str, ttl_days: u64) -> Result<Self> {
+        let file_size = std::fs::metadata(cache_path).map(|m| m.len()).unwrap_or(0);
+        info!(
+            "Opening response cache ({}, {}), this may take a moment...",
+            cache_path,
+            fmt_bytes(file_size)
+        );
+        let start = Instant::now();
         let db = libsql::Builder::new_local(cache_path).build().await?;
         let conn = db.connect()?;
 
@@ -92,12 +110,34 @@ impl CachingAiProvider {
             );
         }
 
+        let mut total_entries: u64 = 0;
+        // tokens_stored = SUM(tokens_saved) — total tokens across all unique entries,
+        // i.e. potential savings if each entry is hit once.
+        let mut total_tokens_stored: u64 = 0;
+        if let Ok(Some(row)) = conn
+            .query(
+                "SELECT COUNT(*), COALESCE(SUM(tokens_saved), 0) FROM response_cache",
+                (),
+            )
+            .await?
+            .next()
+            .await
+        {
+            total_entries = row.get::<u64>(0).unwrap_or(0);
+            total_tokens_stored = row.get::<u64>(1).unwrap_or(0);
+        }
+
         let session_start = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs() as i64;
 
-        info!("Response cache enabled ({})", cache_path);
+        info!(
+            "Response cache ready: {} entries, {} tokens stored, {:.2}s to load",
+            fmt_thousands(total_entries),
+            fmt_thousands(total_tokens_stored),
+            start.elapsed().as_secs_f64()
+        );
 
         Ok(Self {
             inner,

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -129,40 +129,74 @@ impl AiProvider for CachingAiProvider {
             let tokens_saved: i64 = row.get(1)?;
             let created_at: i64 = row.get(2)?;
             if let Ok(mut resp) = serde_json::from_str::<AiResponse>(&response_json) {
-                let (origin, total) = if created_at >= self.session_start {
-                    self.hits_this.fetch_add(1, Ordering::Relaxed);
-                    let t = self
-                        .tokens_saved_this
-                        .fetch_add(tokens_saved as u64, Ordering::Relaxed)
-                        + tokens_saved as u64;
-                    ("this session", t)
+                // Evict poisoned entries: empty responses that were cached before
+                // this guard existed.  Without eviction they replay on every retry,
+                // turning a transient AI failure into a permanent one.
+                let has_content = resp.content.as_ref().is_some_and(|c| !c.trim().is_empty());
+                let has_tool_calls = resp.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
+                if !has_content && !has_tool_calls {
+                    debug!(
+                        "Evicting poisoned cache entry [{}]: no content or tool calls",
+                        hash_prefix
+                    );
+                    let _ = self
+                        .conn
+                        .execute(
+                            "DELETE FROM response_cache WHERE request_hash = ?",
+                            libsql::params![hash.clone()],
+                        )
+                        .await;
+                    // Fall through to cache miss path below
                 } else {
-                    self.hits_prev.fetch_add(1, Ordering::Relaxed);
-                    let t = self
-                        .tokens_saved_prev
-                        .fetch_add(tokens_saved as u64, Ordering::Relaxed)
-                        + tokens_saved as u64;
-                    ("previous session", t)
-                };
-                info!(
-                    "Cache hit [{}] ({}) — {} tokens saved (total {}: {})",
-                    hash_prefix,
-                    origin,
-                    fmt_thousands(tokens_saved as u64),
-                    origin,
-                    fmt_thousands(total)
-                );
-                if let Some(ref mut usage) = resp.usage {
-                    usage.cached_tokens =
-                        Some(usage.cached_tokens.unwrap_or(0) + usage.prompt_tokens);
+                    let (origin, total) = if created_at >= self.session_start {
+                        self.hits_this.fetch_add(1, Ordering::Relaxed);
+                        let t = self
+                            .tokens_saved_this
+                            .fetch_add(tokens_saved as u64, Ordering::Relaxed)
+                            + tokens_saved as u64;
+                        ("this session", t)
+                    } else {
+                        self.hits_prev.fetch_add(1, Ordering::Relaxed);
+                        let t = self
+                            .tokens_saved_prev
+                            .fetch_add(tokens_saved as u64, Ordering::Relaxed)
+                            + tokens_saved as u64;
+                        ("previous session", t)
+                    };
+                    info!(
+                        "Cache hit [{}] ({}) — {} tokens saved (total {}: {})",
+                        hash_prefix,
+                        origin,
+                        fmt_thousands(tokens_saved as u64),
+                        origin,
+                        fmt_thousands(total)
+                    );
+                    if let Some(ref mut usage) = resp.usage {
+                        usage.cached_tokens =
+                            Some(usage.cached_tokens.unwrap_or(0) + usage.prompt_tokens);
+                    }
+                    resp.cache_key = Some(hash.clone());
+                    return Ok(resp);
                 }
-                return Ok(resp);
             }
         }
 
         debug!("Cache miss [{}]", hash_prefix);
 
-        let resp = self.inner.generate_content(request.clone()).await?;
+        let mut resp = self.inner.generate_content(request.clone()).await?;
+
+        // Never cache empty responses — they poison retries (same hash →
+        // same empty result on every attempt, turning a transient failure
+        // into a permanent one).
+        let has_content = resp.content.as_ref().is_some_and(|c| !c.trim().is_empty());
+        let has_tool_calls = resp.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
+        if !has_content && !has_tool_calls {
+            debug!(
+                "Skipping cache store [{}]: response has no content or tool calls",
+                hash_prefix
+            );
+            return Ok(resp);
+        }
 
         let response_json = serde_json::to_string(&resp)?;
         let request_json = serde_json::to_string(&request)?;
@@ -182,7 +216,7 @@ impl AiProvider for CachingAiProvider {
             .execute(
                 "INSERT OR REPLACE INTO response_cache (request_hash, provider, model, request_json, response_json, tokens_saved, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 libsql::params![
-                    hash,
+                    hash.clone(),
                     caps.model_name.clone(),
                     caps.model_name,
                     request_json,
@@ -193,7 +227,20 @@ impl AiProvider for CachingAiProvider {
             )
             .await;
 
+        resp.cache_key = Some(hash);
         Ok(resp)
+    }
+
+    async fn invalidate_cache_entry(&self, key: &str) {
+        let prefix = &key[..key.len().min(12)];
+        info!("Invalidating poisoned cache entry [{}]", prefix);
+        let _ = self
+            .conn
+            .execute(
+                "DELETE FROM response_cache WHERE request_hash = ?",
+                libsql::params![key],
+            )
+            .await;
     }
 
     fn estimate_tokens(&self, request: &AiRequest) -> usize {
@@ -211,5 +258,139 @@ impl AiProvider for CachingAiProvider {
             tokens_saved_this_session: self.tokens_saved_this.load(Ordering::Relaxed),
             tokens_saved_prev_session: self.tokens_saved_prev.load(Ordering::Relaxed),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_test_db() -> libsql::Connection {
+        let db = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE response_cache (
+                request_hash TEXT PRIMARY KEY,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                request_json TEXT NOT NULL,
+                response_json TEXT NOT NULL,
+                tokens_saved INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL
+            );",
+        )
+        .await
+        .unwrap();
+        conn
+    }
+
+    #[tokio::test]
+    async fn test_poisoned_empty_response_evicted_on_read() {
+        let conn = setup_test_db().await;
+        // Insert an entry whose response has no content and no tool calls
+        let empty_resp = serde_json::json!({
+            "content": null,
+            "tool_calls": null,
+            "usage": {"prompt_tokens": 100, "completion_tokens": 0, "total_tokens": 100},
+            "truncated": false
+        });
+        conn.execute(
+            "INSERT INTO response_cache (request_hash, provider, model, request_json, response_json, tokens_saved, created_at) VALUES ('poisoned', 'test', 'test', '{}', ?, 100, 1000)",
+            libsql::params![empty_resp.to_string()],
+        ).await.unwrap();
+
+        // Verify the guard logic detects it
+        let resp: AiResponse = serde_json::from_str(&empty_resp.to_string()).unwrap();
+        let has_content = resp.content.as_ref().is_some_and(|c| !c.trim().is_empty());
+        let has_tool_calls = resp.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
+        assert!(
+            !has_content && !has_tool_calls,
+            "empty response should trigger eviction"
+        );
+
+        // Verify a response with content passes
+        let good_resp = serde_json::json!({
+            "content": "{\"concerns\": [], \"dismissed_concerns\": []}",
+            "tool_calls": null,
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+            "truncated": false
+        });
+        let good: AiResponse = serde_json::from_str(&good_resp.to_string()).unwrap();
+        let has_content = good.content.as_ref().is_some_and(|c| !c.trim().is_empty());
+        assert!(has_content, "non-empty response should pass the guard");
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_cache_entry() {
+        let conn = setup_test_db().await;
+        conn.execute(
+            "INSERT INTO response_cache (request_hash, provider, model, request_json, response_json, tokens_saved, created_at) VALUES ('bad_entry', 'test', 'test', '{}', '{}', 100, 1000)",
+            libsql::params![],
+        ).await.unwrap();
+
+        // Verify entry exists
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM response_cache WHERE request_hash = 'bad_entry'",
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+            1
+        );
+
+        // Invalidate it
+        let _ = conn
+            .execute(
+                "DELETE FROM response_cache WHERE request_hash = ?",
+                libsql::params!["bad_entry"],
+            )
+            .await;
+
+        // Verify it's gone
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM response_cache WHERE request_hash = 'bad_entry'",
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_cache_key_not_serialized() {
+        // cache_key must be skipped during serialization so it doesn't
+        // get stored in the DB or alter the cached response_json.
+        let resp = AiResponse {
+            content: Some("test".to_string()),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            usage: None,
+            truncated: false,
+            cache_key: Some("abc123".to_string()),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !json.contains("cache_key"),
+            "cache_key must not appear in serialized JSON"
+        );
+        assert!(
+            !json.contains("abc123"),
+            "cache_key value must not appear in serialized JSON"
+        );
+
+        // Deserializing without cache_key should default to None
+        let parsed: AiResponse = serde_json::from_str(&json).unwrap();
+        assert!(parsed.cache_key.is_none());
     }
 }

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -20,6 +20,17 @@ pub fn fmt_thousands(n: u64) -> String {
     result
 }
 
+/// Format a token count with abbreviated suffix: 1.2M, 42.1k, or raw number.
+pub fn fmt_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 pub struct CachingAiProvider {
     inner: Arc<dyn AiProvider>,
     conn: libsql::Connection,
@@ -28,6 +39,8 @@ pub struct CachingAiProvider {
     hits_prev: AtomicU64,
     tokens_saved_this: AtomicU64,
     tokens_saved_prev: AtomicU64,
+    misses: AtomicU64,
+    tokens_stored: AtomicU64,
 }
 
 impl CachingAiProvider {
@@ -94,6 +107,8 @@ impl CachingAiProvider {
             hits_prev: AtomicU64::new(0),
             tokens_saved_this: AtomicU64::new(0),
             tokens_saved_prev: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            tokens_stored: AtomicU64::new(0),
         })
     }
 
@@ -182,6 +197,7 @@ impl AiProvider for CachingAiProvider {
         }
 
         debug!("Cache miss [{}]", hash_prefix);
+        self.misses.fetch_add(1, Ordering::Relaxed);
 
         let mut resp = self.inner.generate_content(request.clone()).await?;
 
@@ -227,6 +243,9 @@ impl AiProvider for CachingAiProvider {
             )
             .await;
 
+        self.tokens_stored
+            .fetch_add(tokens_saved as u64, Ordering::Relaxed);
+
         resp.cache_key = Some(hash);
         Ok(resp)
     }
@@ -257,6 +276,8 @@ impl AiProvider for CachingAiProvider {
             hits_prev_session: self.hits_prev.load(Ordering::Relaxed),
             tokens_saved_this_session: self.tokens_saved_this.load(Ordering::Relaxed),
             tokens_saved_prev_session: self.tokens_saved_prev.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            tokens_stored: self.tokens_stored.load(Ordering::Relaxed),
         })
     }
 }
@@ -290,7 +311,6 @@ mod tests {
     #[tokio::test]
     async fn test_poisoned_empty_response_evicted_on_read() {
         let conn = setup_test_db().await;
-        // Insert an entry whose response has no content and no tool calls
         let empty_resp = serde_json::json!({
             "content": null,
             "tool_calls": null,
@@ -302,7 +322,6 @@ mod tests {
             libsql::params![empty_resp.to_string()],
         ).await.unwrap();
 
-        // Verify the guard logic detects it
         let resp: AiResponse = serde_json::from_str(&empty_resp.to_string()).unwrap();
         let has_content = resp.content.as_ref().is_some_and(|c| !c.trim().is_empty());
         let has_tool_calls = resp.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
@@ -311,7 +330,6 @@ mod tests {
             "empty response should trigger eviction"
         );
 
-        // Verify a response with content passes
         let good_resp = serde_json::json!({
             "content": "{\"concerns\": [], \"dismissed_concerns\": []}",
             "tool_calls": null,
@@ -331,7 +349,6 @@ mod tests {
             libsql::params![],
         ).await.unwrap();
 
-        // Verify entry exists
         let mut rows = conn
             .query(
                 "SELECT COUNT(*) FROM response_cache WHERE request_hash = 'bad_entry'",
@@ -344,7 +361,6 @@ mod tests {
             1
         );
 
-        // Invalidate it
         let _ = conn
             .execute(
                 "DELETE FROM response_cache WHERE request_hash = ?",
@@ -352,7 +368,6 @@ mod tests {
             )
             .await;
 
-        // Verify it's gone
         let mut rows = conn
             .query(
                 "SELECT COUNT(*) FROM response_cache WHERE request_hash = 'bad_entry'",
@@ -368,8 +383,6 @@ mod tests {
 
     #[test]
     fn test_cache_key_not_serialized() {
-        // cache_key must be skipped during serialization so it doesn't
-        // get stored in the DB or alter the cached response_json.
         let resp = AiResponse {
             content: Some("test".to_string()),
             thought: None,
@@ -389,8 +402,28 @@ mod tests {
             "cache_key value must not appear in serialized JSON"
         );
 
-        // Deserializing without cache_key should default to None
         let parsed: AiResponse = serde_json::from_str(&json).unwrap();
         assert!(parsed.cache_key.is_none());
+    }
+
+    #[test]
+    fn test_fmt_tokens() {
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(500), "500");
+        assert_eq!(fmt_tokens(999), "999");
+        assert_eq!(fmt_tokens(1_000), "1.0k");
+        assert_eq!(fmt_tokens(1_500), "1.5k");
+        assert_eq!(fmt_tokens(42_100), "42.1k");
+        assert_eq!(fmt_tokens(999_999), "1000.0k");
+        assert_eq!(fmt_tokens(1_000_000), "1.0M");
+        assert_eq!(fmt_tokens(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn test_fmt_thousands() {
+        assert_eq!(fmt_thousands(0), "0");
+        assert_eq!(fmt_thousands(999), "999");
+        assert_eq!(fmt_thousands(1_000), "1.000");
+        assert_eq!(fmt_thousands(1_234_567), "1.234.567");
     }
 }

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -587,6 +587,7 @@ pub fn translate_ai_response(resp: &ClaudeResponse) -> Result<AiResponse> {
         },
         usage: Some(usage),
         truncated,
+        cache_key: None,
     })
 }
 

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -318,6 +318,7 @@ pub fn parse_inner_response(text: &str, usage: Option<AiUsage>) -> Result<AiResp
             tool_calls: Some(merged_tool_calls),
             usage,
             truncated: false,
+            cache_key: None,
         });
     }
 
@@ -331,6 +332,7 @@ pub fn parse_inner_response(text: &str, usage: Option<AiUsage>) -> Result<AiResp
             tool_calls: None,
             usage,
             truncated: false,
+            cache_key: None,
         });
     }
 
@@ -343,6 +345,7 @@ pub fn parse_inner_response(text: &str, usage: Option<AiUsage>) -> Result<AiResp
         tool_calls: None,
         usage,
         truncated: false,
+        cache_key: None,
     })
 }
 
@@ -371,6 +374,7 @@ fn parse_single_json(v: &Value, json_str: &str, usage: Option<AiUsage>) -> Resul
                 tool_calls: Some(tool_calls),
                 usage,
                 truncated: false,
+                cache_key: None,
             });
         }
     }
@@ -384,6 +388,7 @@ fn parse_single_json(v: &Value, json_str: &str, usage: Option<AiUsage>) -> Resul
             tool_calls: None,
             usage,
             truncated: false,
+            cache_key: None,
         });
     }
 
@@ -395,6 +400,7 @@ fn parse_single_json(v: &Value, json_str: &str, usage: Option<AiUsage>) -> Resul
         tool_calls: None,
         usage,
         truncated: false,
+        cache_key: None,
     })
 }
 

--- a/src/ai/copilot_cli.rs
+++ b/src/ai/copilot_cli.rs
@@ -204,6 +204,7 @@ pub fn parse_jsonl_events(raw: &str) -> Result<AiResponse> {
         tool_calls: None,
         usage,
         truncated: false,
+        cache_key: None,
     })
 }
 

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -771,6 +771,7 @@ fn translate_ai_response(resp: GenerateContentResponse) -> Result<AiResponse> {
         },
         usage,
         truncated,
+        cache_key: None,
     })
 }
 

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -305,12 +305,15 @@ pub struct ProviderCapabilities {
 }
 
 /// Cache statistics returned by providers that support local response caching.
+/// Counters are cumulative; use snapshot-delta to get per-operation stats.
 #[derive(Debug, Clone, Default)]
 pub struct CacheStats {
     pub hits_this_session: u64,
     pub hits_prev_session: u64,
     pub tokens_saved_this_session: u64,
     pub tokens_saved_prev_session: u64,
+    pub misses: u64,
+    pub tokens_stored: u64,
 }
 
 /// Trait defining the standard interface for all AI providers in Sashiko.

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -146,6 +146,11 @@ pub struct AiResponse {
     /// Whether the response was truncated by the provider (e.g., hit max tokens).
     #[serde(default)]
     pub truncated: bool,
+    /// Cache key identifying this response in the local response cache.
+    /// Set by `CachingAiProvider`; not serialized to the cache DB.
+    #[serde(skip)]
+    #[serde(default)]
+    pub cache_key: Option<String>,
 }
 
 /// Classifies a remote AI error using the typed stdio protocol payload.
@@ -319,6 +324,11 @@ pub trait AiProvider: Send + Sync {
 
     /// Returns the capabilities and constraints of this provider.
     fn get_capabilities(&self) -> ProviderCapabilities;
+
+    /// Removes a cached response by its cache key.  Called by the worker
+    /// when a cached response fails downstream validation, so the next
+    /// attempt gets a fresh AI response instead of replaying the bad one.
+    async fn invalidate_cache_entry(&self, _key: &str) {}
 
     /// Returns cache statistics, if the provider supports local response caching.
     fn cache_stats(&self) -> Option<CacheStats> {

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -497,6 +497,7 @@ fn translate_ai_response(resp: OpenAiResponse) -> Result<AiResponse> {
         tool_calls,
         usage,
         truncated,
+        cache_key: None,
     })
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -993,7 +993,7 @@ async fn cancel_patchset(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    let cancelled = state
+    let result = state
         .db
         .cancel_patchset(query.id, query.force)
         .await
@@ -1002,19 +1002,23 @@ async fn cancel_patchset(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    if cancelled {
-        info!("Patchset {} cancelled (force={})", query.id, query.force);
-        Ok(Json(serde_json::json!({ "status": "cancelled" })))
-    } else {
-        let reason = if query.force {
-            "Patchset is not in a cancellable state (must be Pending, Incomplete, or In Review)"
-        } else {
-            "Patchset is not in a cancellable state (must be Pending or Incomplete; use force=true for In Review)"
-        };
-        Ok(Json(serde_json::json!({
-            "status": "not_modified",
-            "reason": reason
-        })))
+    match result {
+        None => Err(StatusCode::NOT_FOUND),
+        Some(true) => {
+            info!("Patchset {} cancelled (force={})", query.id, query.force);
+            Ok(Json(serde_json::json!({ "status": "cancelled" })))
+        }
+        Some(false) => {
+            let reason = if query.force {
+                "Patchset is not in a cancellable state (must be Pending, Incomplete, or In Review)"
+            } else {
+                "Patchset is not in a cancellable state (must be Pending or Incomplete; use force=true for In Review)"
+            };
+            Ok(Json(serde_json::json!({
+                "status": "not_modified",
+                "reason": reason
+            })))
+        }
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -989,7 +989,7 @@ async fn cancel_patchset(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    if !state.allow_all_submit && !addr.ip().is_loopback() {
+    if !state.allow_all_submit && !addr.ip().to_canonical().is_loopback() {
         return Err(StatusCode::FORBIDDEN);
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -129,6 +129,7 @@ pub struct AppState {
     pub allow_all_submit: bool,
     pub smtp_enabled: bool,
     pub dry_run: bool,
+    pub show_cache_stats: bool,
     stats_timeline_cache: AsyncMapCache<Option<i64>, serde_json::Value>,
     stats_reviews_cache: AsyncCache<serde_json::Value>,
     stats_tools_cache: AsyncCache<serde_json::Value>,
@@ -245,6 +246,7 @@ pub fn build_router(
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
+    show_cache_stats: bool,
 ) -> Router {
     let state = Arc::new(AppState {
         db,
@@ -254,6 +256,7 @@ pub fn build_router(
         allow_all_submit,
         smtp_enabled,
         dry_run,
+        show_cache_stats,
         stats_timeline_cache: AsyncMapCache::new(Duration::from_secs(60)),
         stats_reviews_cache: AsyncCache::new(Duration::from_secs(60)),
         stats_tools_cache: AsyncCache::new(Duration::from_secs(60)),
@@ -293,6 +296,7 @@ pub async fn run_server(
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
+    show_cache_stats: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app = build_router(
         db,
@@ -302,6 +306,7 @@ pub async fn run_server(
         allow_all_submit,
         smtp_enabled,
         dry_run,
+        show_cache_stats,
     );
 
     let bind_addr = format!("{}:{}", settings.host, settings.port);
@@ -695,6 +700,10 @@ async fn get_patchset(
                     "dry_run".to_string(),
                     serde_json::Value::Bool(state.dry_run),
                 );
+                obj.insert(
+                    "show_cache_stats".to_string(),
+                    serde_json::Value::Bool(state.show_cache_stats),
+                );
             }
             Ok(Json(details))
         }
@@ -764,6 +773,10 @@ async fn get_patchset_summary(
                 obj.insert(
                     "dry_run".to_string(),
                     serde_json::Value::Bool(state.dry_run),
+                );
+                obj.insert(
+                    "show_cache_stats".to_string(),
+                    serde_json::Value::Bool(state.show_cache_stats),
                 );
             }
             Ok(Json(details))

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -589,6 +589,16 @@ async fn handle_list(
     Ok(())
 }
 
+fn fmt_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 fn review_has_issues(review: &Value) -> bool {
     review
         .get("inline_review")
@@ -654,7 +664,7 @@ async fn fetch_patchset(client: &Client, base_url: &str, id: &str) -> Result<Val
     }
 }
 
-fn print_patch_line(patch: &Value, review: Option<&Value>, show_inline: bool) {
+fn print_patch_line(patch: &Value, review: Option<&Value>, show_inline: bool, cache_suffix: &str) {
     let idx = patch["part_index"].as_i64().unwrap_or(0);
     let status = patch["status"].as_str().unwrap_or("");
     let apply_err = patch["apply_error"].as_str();
@@ -684,6 +694,9 @@ fn print_patch_line(patch: &Value, review: Option<&Value>, show_inline: bool) {
         };
         print_colored(color, review_result_label(rev));
         print!("]");
+    }
+    if !cache_suffix.is_empty() {
+        print!(" {}", cache_suffix);
     }
     println!();
 
@@ -850,11 +863,83 @@ async fn handle_show(
                         println!("{}", reason);
                     }
 
+                    let show_cache_stats = details
+                        .get("show_cache_stats")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let mut total_cache_hits: u64 = 0;
+                    let mut total_cache_misses: u64 = 0;
+                    let mut total_cache_tokens_saved: u64 = 0;
+                    let mut total_cache_tokens_stored: u64 = 0;
+
                     println!("\nPatches ({}):", patches.len());
                     for patch in &patches {
                         let p_id = patch["id"].as_i64().unwrap_or(0);
                         let review = find_best_review_for_patch(p_id, &reviews);
-                        print_patch_line(patch, review, opts.inline);
+
+                        let cache_suffix = if show_cache_stats {
+                            if let Some(rev) = review {
+                                let hits =
+                                    rev.get("cache_hits").and_then(|v| v.as_u64()).unwrap_or(0);
+                                let misses = rev
+                                    .get("cache_misses")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                let saved = rev
+                                    .get("cache_tokens_saved")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                let stored = rev
+                                    .get("cache_tokens_stored")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+
+                                total_cache_hits += hits;
+                                total_cache_misses += misses;
+                                total_cache_tokens_saved += saved;
+                                total_cache_tokens_stored += stored;
+
+                                let total_requests = hits + misses;
+                                if total_requests > 0 {
+                                    let mut s =
+                                        format!("{{cache: {}/{} hits", hits, total_requests);
+                                    if saved > 0 {
+                                        s.push_str(&format!(
+                                            ", {} tokens saved",
+                                            fmt_tokens(saved)
+                                        ));
+                                    }
+                                    s.push('}');
+                                    s
+                                } else {
+                                    String::new()
+                                }
+                            } else {
+                                String::new()
+                            }
+                        } else {
+                            String::new()
+                        };
+
+                        print_patch_line(patch, review, opts.inline, &cache_suffix);
+                    }
+
+                    if show_cache_stats {
+                        let total_requests = total_cache_hits + total_cache_misses;
+                        if total_requests > 0 {
+                            let hit_rate = total_cache_hits as f64 / total_requests as f64 * 100.0;
+                            print!(
+                                "\nCache: {}/{} hits ({:.1}%)",
+                                total_cache_hits, total_requests, hit_rate
+                            );
+                            if total_cache_tokens_saved > 0 {
+                                print!(", {} tokens saved", fmt_tokens(total_cache_tokens_saved));
+                            }
+                            if total_cache_tokens_stored > 0 {
+                                print!(", {} tokens stored", fmt_tokens(total_cache_tokens_stored));
+                            }
+                            println!();
+                        }
                     }
 
                     if let Some(review) = review_data {
@@ -1033,7 +1118,7 @@ fn show_summary(
                     if let Some(rev) = find_best_review_for_patch_refs(p_id, &all_reviews)
                         && review_has_new_issues(rev)
                     {
-                        print_patch_line(patch, Some(rev), opts.inline);
+                        print_patch_line(patch, Some(rev), opts.inline, "");
                     }
                 }
             }
@@ -1086,7 +1171,7 @@ fn show_single_patch(
             println!("{}", serde_json::to_string_pretty(&out)?);
         }
         OutputFormat::Text => {
-            print_patch_line(patch, review, show_inline);
+            print_patch_line(patch, review, show_inline, "");
 
             if let Some(rev) = review
                 && let Some(output_str) = rev.get("output").and_then(|o| o.as_str())
@@ -1147,7 +1232,7 @@ fn show_issues(
                 return Ok(());
             }
             for (patch, rev) in &issue_patches {
-                print_patch_line(patch, Some(rev), show_inline);
+                print_patch_line(patch, Some(rev), show_inline, "");
 
                 if !show_inline
                     && let Some(output_str) = rev.get("output").and_then(|o| o.as_str())

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -1491,6 +1491,8 @@ async fn handle_cancel(
                 }
             }
         }
+    } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(anyhow::anyhow!("Patchset {} not found", id));
     } else {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -619,14 +619,15 @@ fn find_best_review_for_patch(patch_id: i64, reviews: &[Value]) -> Option<&Value
 
 fn find_best_review_for_patch_refs<'a>(patch_id: i64, reviews: &[&'a Value]) -> Option<&'a Value> {
     let mut best: Option<&Value> = None;
+    let mut best_id: i64 = -1;
     for r in reviews {
         if r.get("patch_id").and_then(|id| id.as_i64()) != Some(patch_id) {
             continue;
         }
-        let status = r.get("status").and_then(|s| s.as_str());
-        let current_status = best.and_then(|pr| pr.get("status").and_then(|s| s.as_str()));
-        if status == Some("Reviewed") || current_status != Some("Reviewed") {
+        let rid = r.get("id").and_then(|id| id.as_i64()).unwrap_or(0);
+        if rid > best_id {
             best = Some(r);
+            best_id = rid;
         }
     }
     best

--- a/src/db.rs
+++ b/src/db.rs
@@ -2635,6 +2635,67 @@ impl Database {
         }
     }
 
+    async fn fetch_reviews_json(
+        &self,
+        patchset_id: i64,
+        patch_ids: &[i64],
+        model_name: &Option<String>,
+        provider: &Option<String>,
+        prompts_git_hash: &Option<String>,
+        baseline: &Option<serde_json::Value>,
+    ) -> Result<Vec<serde_json::Value>> {
+        let mut reviews = Vec::new();
+        let mut in_clause = patch_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        if in_clause.is_empty() {
+            in_clause = "-1".to_string();
+        }
+        let query_str = format!(
+            "SELECT r.summary, r.created_at, ai.output_raw, \
+                    r.result_description, r.status, r.inline_review, r.logs, \
+                    ai.tokens_in, ai.tokens_out, r.patch_id, r.id, ai.tokens_cached, \
+                    r.cache_hits, r.cache_misses, r.cache_tokens_saved, r.cache_tokens_stored \
+             FROM reviews r \
+             LEFT JOIN ai_interactions ai ON r.interaction_id = ai.id \
+             WHERE r.patchset_id = ? AND (r.patch_id IS NULL OR r.patch_id IN ({})) \
+             ORDER BY r.created_at ASC",
+            in_clause
+        );
+
+        let mut params = vec![libsql::Value::Integer(patchset_id)];
+        for &pid_val in patch_ids {
+            params.push(libsql::Value::Integer(pid_val));
+        }
+
+        let mut rev_rows = self.conn.query(&query_str, params).await?;
+
+        while let Ok(Some(r)) = rev_rows.next().await {
+            reviews.push(serde_json::json!({
+                "summary": r.get::<Option<String>>(0).ok(),
+                "created_at": r.get::<Option<i64>>(1).ok(),
+                "output": r.get::<Option<String>>(2).ok(),
+                "result": r.get::<Option<String>>(3).ok(),
+                "status": r.get::<Option<String>>(4).ok(),
+                "inline_review": r.get::<Option<String>>(5).ok(),
+                "logs": r.get::<Option<String>>(6).ok(),
+                "tokens_in": r.get::<Option<u32>>(7).ok(),
+                "tokens_out": r.get::<Option<u32>>(8).ok(),
+                "patch_id": r.get::<Option<i64>>(9).ok(),
+                "id": r.get::<i64>(10).ok(),
+                "tokens_cached": r.get::<Option<u32>>(11).ok(),
+                "cache_hits": r.get::<Option<i64>>(12).ok(),
+                "cache_misses": r.get::<Option<i64>>(13).ok(),
+                "cache_tokens_saved": r.get::<Option<i64>>(14).ok(),
+                "cache_tokens_stored": r.get::<Option<i64>>(15).ok(),
+                "model": model_name.clone(),
+                "provider": provider.clone(),
+                "prompts_hash": prompts_git_hash.clone(),
+                "baseline": baseline.clone()
+            }));
+        }
+
+        Ok(reviews)
+    }
+
     pub async fn get_patchset_details(
         &self,
         id: i64,
@@ -2778,46 +2839,16 @@ impl Database {
             }
 
             // Fetch reviews
-            let mut reviews = Vec::new();
-            let mut in_clause = patch_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            if in_clause.is_empty() {
-                in_clause = "-1".to_string(); // Fallback so SQL doesn't error
-            }
-            let query_str = format!(
-                "SELECT r.summary, r.created_at, ai.input_context, ai.output_raw, 
-                        r.result_description, r.status, r.inline_review, r.logs, ai.tokens_in, ai.tokens_out, r.patch_id, r.id, ai.tokens_cached
-                 FROM reviews r
-                 LEFT JOIN ai_interactions ai ON r.interaction_id = ai.id
-                 WHERE r.patchset_id = ? AND (r.patch_id IS NULL OR r.patch_id IN ({}))
-                 ORDER BY r.created_at ASC", in_clause);
-
-            let mut params = vec![libsql::Value::Integer(pid)];
-            for &pid_val in &patch_ids {
-                params.push(libsql::Value::Integer(pid_val));
-            }
-
-            let mut rev_rows = self.conn.query(&query_str, params).await?;
-
-            while let Ok(Some(r)) = rev_rows.next().await {
-                reviews.push(serde_json::json!({
-                    "summary": r.get::<Option<String>>(0).ok(),
-                    "created_at": r.get::<Option<i64>>(1).ok(),
-                    "output": r.get::<Option<String>>(3).ok(),
-                    "result": r.get::<Option<String>>(4).ok(),
-                    "status": r.get::<Option<String>>(5).ok(),
-                    "inline_review": r.get::<Option<String>>(6).ok(),
-                    "logs": r.get::<Option<String>>(7).ok(),
-                    "tokens_in": r.get::<Option<u32>>(8).ok(),
-                    "tokens_out": r.get::<Option<u32>>(9).ok(),
-                    "patch_id": r.get::<Option<i64>>(10).ok(),
-                    "id": r.get::<i64>(11).ok(),
-                    "tokens_cached": r.get::<Option<u32>>(12).ok(),
-                    "model": model_name.clone(),
-                    "provider": provider.clone(),
-                    "prompts_hash": prompts_git_hash.clone(),
-                    "baseline": baseline.clone()
-                }));
-            }
+            let reviews = self
+                .fetch_reviews_json(
+                    pid,
+                    &patch_ids,
+                    &model_name,
+                    &provider,
+                    &prompts_git_hash,
+                    &baseline,
+                )
+                .await?;
 
             // Fetch thread messages
             let mut messages = Vec::new();
@@ -3015,45 +3046,16 @@ impl Database {
                 }));
             }
 
-            let mut reviews = Vec::new();
-            let mut in_clause = patch_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            if in_clause.is_empty() {
-                in_clause = "-1".to_string();
-            }
-            let query_str = format!(
-                "SELECT r.summary, r.created_at, ai.output_raw, 
-                        r.result_description, r.status, r.inline_review, ai.tokens_in, ai.tokens_out, r.patch_id, r.id, ai.tokens_cached
-                 FROM reviews r
-                 LEFT JOIN ai_interactions ai ON r.interaction_id = ai.id
-                 WHERE r.patchset_id = ? AND (r.patch_id IS NULL OR r.patch_id IN ({}))
-                 ORDER BY r.created_at ASC", in_clause);
-
-            let mut params = vec![libsql::Value::Integer(pid)];
-            for &pid_val in &patch_ids {
-                params.push(libsql::Value::Integer(pid_val));
-            }
-
-            let mut rev_rows = self.conn.query(&query_str, params).await?;
-
-            while let Ok(Some(r)) = rev_rows.next().await {
-                reviews.push(serde_json::json!({
-                    "summary": r.get::<Option<String>>(0).ok(),
-                    "created_at": r.get::<Option<i64>>(1).ok(),
-                    "output": r.get::<Option<String>>(2).ok(),
-                    "result": r.get::<Option<String>>(3).ok(),
-                    "status": r.get::<Option<String>>(4).ok(),
-                    "inline_review": r.get::<Option<String>>(5).ok(),
-                    "tokens_in": r.get::<Option<u32>>(6).ok(),
-                    "tokens_out": r.get::<Option<u32>>(7).ok(),
-                    "patch_id": r.get::<Option<i64>>(8).ok(),
-                    "id": r.get::<i64>(9).ok(),
-                    "tokens_cached": r.get::<Option<u32>>(10).ok(),
-                    "model": model_name.clone(),
-                    "provider": provider.clone(),
-                    "prompts_hash": prompts_git_hash.clone(),
-                    "baseline": baseline.clone()
-                }));
-            }
+            let reviews = self
+                .fetch_reviews_json(
+                    pid,
+                    &patch_ids,
+                    &model_name,
+                    &provider,
+                    &prompts_git_hash,
+                    &baseline,
+                )
+                .await?;
 
             let mut messages = Vec::new();
             if let Some(tid) = thread_id {

--- a/src/db.rs
+++ b/src/db.rs
@@ -3455,14 +3455,24 @@ impl Database {
         }
     }
 
-    pub async fn cancel_patchset(&self, id: i64, force: bool) -> Result<bool> {
+    pub async fn cancel_patchset(&self, id: i64, force: bool) -> Result<Option<bool>> {
+        let exists = self
+            .conn
+            .query("SELECT 1 FROM patchsets WHERE id = ?", libsql::params![id])
+            .await?
+            .next()
+            .await?
+            .is_some();
+        if !exists {
+            return Ok(None);
+        }
         let query = if force {
             "UPDATE patchsets SET status = 'Cancelled' WHERE id = ? AND status IN ('Pending', 'Incomplete', 'In Review')"
         } else {
             "UPDATE patchsets SET status = 'Cancelled' WHERE id = ? AND status IN ('Pending', 'Incomplete')"
         };
         let count = self.conn.execute(query, libsql::params![id]).await?;
-        Ok(count > 0)
+        Ok(Some(count > 0))
     }
 
     pub async fn restart_failed_reviews(&self) -> Result<u64> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -159,6 +159,13 @@ pub struct EmailOutboxRow {
     pub created_at: i64,
 }
 
+pub struct ReviewCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub tokens_saved: u64,
+    pub tokens_stored: u64,
+}
+
 impl Database {
     pub async fn get_oldest_message_timestamp(&self) -> Result<Option<i64>> {
         let mut rows = self
@@ -449,6 +456,18 @@ impl Database {
         let _ = self.try_add_column("reviews", "patch_id", "INTEGER").await;
         let _ = self
             .try_add_column("reviews", "inline_review", "TEXT")
+            .await;
+        let _ = self
+            .try_add_column("reviews", "cache_hits", "INTEGER")
+            .await;
+        let _ = self
+            .try_add_column("reviews", "cache_misses", "INTEGER")
+            .await;
+        let _ = self
+            .try_add_column("reviews", "cache_tokens_saved", "INTEGER")
+            .await;
+        let _ = self
+            .try_add_column("reviews", "cache_tokens_stored", "INTEGER")
             .await;
         let _ = self
             .try_add_column("patchsets", "baseline_id", "INTEGER")
@@ -776,11 +795,36 @@ impl Database {
         interaction_id: Option<&str>,
         inline_review: Option<&str>,
         logs: Option<&str>,
+        cache_stats: Option<&ReviewCacheStats>,
     ) -> Result<()> {
+        let (c_hits, c_misses, c_saved, c_stored) = match cache_stats {
+            Some(cs) => (
+                Some(cs.hits as i64),
+                Some(cs.misses as i64),
+                Some(cs.tokens_saved as i64),
+                Some(cs.tokens_stored as i64),
+            ),
+            None => (None, None, None, None),
+        };
         self.conn
             .execute(
-                "UPDATE reviews SET status = ?, result_description = ?, summary = ?, interaction_id = ?, inline_review = ?, logs = ? WHERE id = ?",
-                libsql::params![status, result, summary, interaction_id, inline_review, logs, review_id],
+                "UPDATE reviews SET status = ?, result_description = ?, summary = ?, \
+                 interaction_id = ?, inline_review = ?, logs = ?, \
+                 cache_hits = ?, cache_misses = ?, cache_tokens_saved = ?, cache_tokens_stored = ? \
+                 WHERE id = ?",
+                libsql::params![
+                    status,
+                    result,
+                    summary,
+                    interaction_id,
+                    inline_review,
+                    logs,
+                    c_hits,
+                    c_misses,
+                    c_saved,
+                    c_stored,
+                    review_id
+                ],
             )
             .await?;
         Ok(())
@@ -5213,6 +5257,7 @@ mod tests {
             "desc",
             None,
             Some("int_id"),
+            None,
             None,
             None,
         )

--- a/src/db.rs
+++ b/src/db.rs
@@ -3453,7 +3453,15 @@ impl Database {
             )
             .await?;
 
-        // 3. Increment target_review_count only if it was previously Reviewed
+        // 3. Reset per-patch statuses so stale failure states don't persist
+        self.conn
+            .execute(
+                "UPDATE patches SET status = 'Pending', apply_error = NULL WHERE patchset_id = ?",
+                libsql::params![id],
+            )
+            .await?;
+
+        // 4. Increment target_review_count only if it was previously Reviewed
         if should_increment {
             self.conn
                 .execute(
@@ -3463,7 +3471,7 @@ impl Database {
                 .await?;
         }
 
-        // 4. Delete associated tool usages and findings for failed reviews that block retrying
+        // 5. Delete associated tool usages and findings for failed reviews that block retrying
         self.conn
             .execute(
                 "DELETE FROM tool_usages WHERE review_id IN (

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,26 +548,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         error!("Failed to prune stale worktrees: {}", e);
     }
 
-    if let Some(custom_remotes) = &settings.git.custom_remotes {
-        for remote in custom_remotes {
-            info!(
-                "Ensuring custom remote {} -> {}",
-                remote.name,
-                sashiko::utils::redact_secret(&remote.url)
-            );
-            if let Err(e) =
-                sashiko::git_ops::ensure_remote(&repo_path, &remote.name, &remote.url, false).await
-            {
-                error!("Failed to ensure custom remote {}: {}", remote.name, e);
-            }
-        }
-    }
-
-    // Start Reviewer Service
+    // Start Reviewer Service before custom remote fetches — fetching repos
+    // from git.kernel.org over IPv6 can be sluggish, and blocking here would
+    // delay the reviewer from picking up pending patchsets.  The reviewer
+    // calls ensure_remote() itself when it needs a baseline from a custom
+    // remote, so patchsets targeting those repos will wait for the fetch at
+    // that point while other patchsets proceed without delay.
     let reviewer = Reviewer::new(db.clone(), settings.clone()).await;
     tokio::spawn(async move {
         reviewer.start().await;
     });
+
+    // Warm up custom remotes in a background task so slow fetches
+    // (e.g. pahole from git.kernel.org via IPv6) don't block startup.
+    let repo_path = std::path::PathBuf::from(&settings.git.repository_path);
+    if let Some(custom_remotes) = settings.git.custom_remotes.clone() {
+        tokio::spawn(async move {
+            for remote in custom_remotes {
+                info!("Ensuring custom remote {} -> {}", remote.name, remote.url);
+                if let Err(e) =
+                    sashiko::git_ops::ensure_remote(&repo_path, &remote.name, &remote.url, false)
+                        .await
+                {
+                    error!("Failed to ensure custom remote {}: {}", remote.name, e);
+                }
+            }
+        });
+    }
 
     let metrics_db = db.clone();
     tokio::spawn(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,6 +508,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let allow_all_submit = cli.enable_unsafe_all_submit;
     let smtp_enabled = settings.smtp.is_some();
     let dry_run = settings.smtp.as_ref().map(|s| s.dry_run).unwrap_or(false);
+    let show_cache_stats = settings.ai.show_cache_stats;
     tokio::spawn(async move {
         if let Err(e) = sashiko::api::run_server(
             api_settings,
@@ -517,6 +518,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             allow_all_submit,
             smtp_enabled,
             dry_run,
+            show_cache_stats,
         )
         .await
         {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -589,6 +589,19 @@ impl Reviewer {
                     let handle = tokio::spawn(async move {
                         let mut failed = 0;
                         loop {
+                            if ctx_clone
+                                .db
+                                .get_patchset_status(patchset_id)
+                                .await
+                                .ok()
+                                .flatten()
+                                .as_deref()
+                                == Some(ReviewStatus::Cancelled.as_str())
+                            {
+                                info!("Patchset {} cancelled, stopping review", patchset_id);
+                                queue.lock().await.clear();
+                                break;
+                            }
                             let job = {
                                 let mut q = queue.lock().await;
                                 q.pop()
@@ -636,6 +649,19 @@ impl Reviewer {
             // Main worker loop uses the existing worktree
             let mut main_failed = 0;
             loop {
+                if ctx
+                    .db
+                    .get_patchset_status(patchset_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .as_deref()
+                    == Some(ReviewStatus::Cancelled.as_str())
+                {
+                    info!("Patchset {} cancelled, stopping review", patchset_id);
+                    valid_jobs_queue.lock().await.clear();
+                    break;
+                }
                 let job = {
                     let mut q = valid_jobs_queue.lock().await;
                     q.pop()

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -2444,6 +2444,7 @@ mod tests {
                 tool_calls: None,
                 usage: None,
                 truncated: false,
+                cache_key: None,
             })
         }
         fn estimate_tokens(&self, _request: &AiRequest) -> usize {
@@ -2498,6 +2499,7 @@ mod tests {
                 tool_calls: None,
                 usage: None,
                 truncated: false,
+                cache_key: None,
             })
         }
 
@@ -2954,6 +2956,7 @@ fi
                     cached_tokens: Some(self.cached_tokens),
                 }),
                 truncated: false,
+                cache_key: None,
             })
         }
         fn estimate_tokens(&self, _request: &AiRequest) -> usize {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -19,7 +19,9 @@ use crate::ai::{
     create_provider_cached,
 };
 use crate::baseline::{BaselineRegistry, BaselineResolution, extract_files_from_diff};
-use crate::db::{AiInteractionParams, Database, Finding, PatchsetRow, Severity, ToolUsage};
+use crate::db::{
+    AiInteractionParams, Database, Finding, PatchsetRow, ReviewCacheStats, Severity, ToolUsage,
+};
 use crate::email_policy::EmailPolicyConfig;
 use crate::email_router::{Action as EmailAction, EmailRouter};
 use crate::git_ops::{GitWorktree, ensure_remote, get_commit_hash};
@@ -716,7 +718,9 @@ impl Reviewer {
                 .await;
         }
 
-        if let Some(stats) = ctx.provider.cache_stats() {
+        if ctx.settings.ai.show_cache_stats
+            && let Some(stats) = ctx.provider.cache_stats()
+        {
             use crate::ai::cache::fmt_thousands;
             let total_hits = stats.hits_this_session + stats.hits_prev_session;
             let total_tokens = stats.tokens_saved_this_session + stats.tokens_saved_prev_session;
@@ -1099,6 +1103,7 @@ impl Reviewer {
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await;
 
@@ -1134,6 +1139,8 @@ impl Reviewer {
                 .update_review_status(review_id, ReviewStatus::InReview.as_str(), None)
                 .await;
 
+            let cache_before = ctx.provider.cache_stats();
+
             let result = run_review_tool(
                 patchset_id,
                 input_payload,
@@ -1149,6 +1156,32 @@ impl Reviewer {
                 ctx.llm_semaphore.clone(),
             )
             .await;
+
+            let patch_cache_stats = cache_before.and_then(|before| {
+                ctx.provider.cache_stats().map(|after| ReviewCacheStats {
+                    hits: (after.hits_this_session + after.hits_prev_session)
+                        - (before.hits_this_session + before.hits_prev_session),
+                    misses: after.misses - before.misses,
+                    tokens_saved: (after.tokens_saved_this_session
+                        + after.tokens_saved_prev_session)
+                        - (before.tokens_saved_this_session + before.tokens_saved_prev_session),
+                    tokens_stored: after.tokens_stored - before.tokens_stored,
+                })
+            });
+
+            if ctx.settings.ai.show_cache_stats
+                && let Some(ref cs) = patch_cache_stats
+            {
+                use crate::ai::cache::fmt_tokens;
+                info!(
+                    "Patch {}/{} cache: {} hits, {} misses, {} tokens saved",
+                    patchset_id,
+                    index,
+                    cs.hits,
+                    cs.misses,
+                    fmt_tokens(cs.tokens_saved)
+                );
+            }
 
             match result {
                 Ok(json_output) => {
@@ -1243,6 +1276,7 @@ impl Reviewer {
                                     interaction_id.as_deref(),
                                     None,
                                     logs_str.as_deref(),
+                                    patch_cache_stats.as_ref(),
                                 )
                                 .await;
 
@@ -1302,6 +1336,7 @@ impl Reviewer {
                                         interaction_id.as_deref(),
                                         inline_review,
                                         logs_str.as_deref(),
+                                        patch_cache_stats.as_ref(),
                                     )
                                     .await
                                 {
@@ -1379,6 +1414,7 @@ impl Reviewer {
                                         interaction_id.as_deref(),
                                         None,
                                         logs_str.as_deref(),
+                                        patch_cache_stats.as_ref(),
                                     )
                                     .await;
                                 let _ = ctx.db.update_patch_status(patch_id, "Skipped").await;
@@ -1394,6 +1430,7 @@ impl Reviewer {
                                         interaction_id.as_deref(),
                                         None,
                                         logs_str.as_deref(),
+                                        patch_cache_stats.as_ref(),
                                     )
                                     .await;
                                 if retries < max_retries {
@@ -1418,6 +1455,7 @@ impl Reviewer {
                                     interaction_id.as_deref(),
                                     None,
                                     logs_str.as_deref(),
+                                    patch_cache_stats.as_ref(),
                                 )
                                 .await;
                             let _ = ctx.db.update_patch_status(patch_id, "Failed").await;
@@ -1438,6 +1476,7 @@ impl Reviewer {
                                 interaction_id.as_deref(),
                                 None,
                                 logs_str.as_deref(),
+                                patch_cache_stats.as_ref(),
                             )
                             .await;
                         if retries < max_retries {
@@ -1460,6 +1499,7 @@ impl Reviewer {
                             None,
                             None,
                             None,
+                            patch_cache_stats.as_ref(),
                         )
                         .await;
                     if retries < max_retries {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,7 @@
 
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
@@ -393,12 +394,36 @@ pub struct Settings {
 }
 
 impl Settings {
+    /// Build the user-level config path: ~/.config/sashiko/Settings.toml
+    ///
+    /// Follows the XDG Base Directory Specification: uses $XDG_CONFIG_HOME if
+    /// set, otherwise falls back to $HOME/.config.
+    fn user_config_path() -> Option<PathBuf> {
+        if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+            Some(PathBuf::from(xdg).join("sashiko").join("Settings"))
+        } else {
+            std::env::var("HOME").ok().map(|h| {
+                PathBuf::from(h)
+                    .join(".config")
+                    .join("sashiko")
+                    .join("Settings")
+            })
+        }
+    }
+
+    /// Load settings from a layered set of sources (last wins):
+    ///
+    ///   1. ./Settings.toml        — repo-level defaults (checked into git)
+    ///   2. ~/.config/sashiko/Settings.toml — user overrides (credentials, paths)
+    ///   3. SASHIKO__* env vars    — per-invocation overrides
     pub fn new() -> Result<Self, ConfigError> {
-        let s = Config::builder()
-            // Start with default settings
-            .add_source(File::with_name("Settings"))
-            // Add settings from environment variables (with a prefix of SASHIKO)
-            // e.g. SASHIKO__SERVER__PORT=8081 would set the server port
+        let mut builder = Config::builder().add_source(File::with_name("Settings"));
+
+        if let Some(user_path) = Self::user_config_path() {
+            builder = builder.add_source(File::from(user_path).required(false));
+        }
+
+        let s = builder
             .add_source(Environment::with_prefix("SASHIKO").separator("__"))
             .build()?;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -256,6 +256,10 @@ pub struct AiSettings {
     pub response_cache: bool,
     #[serde(default = "default_response_cache_ttl_days")]
     pub response_cache_ttl_days: u64,
+    /// Show per-patch and per-patchset response cache hit/miss statistics
+    /// in the CLI, web UI hover tooltips, and daemon log output.
+    #[serde(default)]
+    pub show_cache_stats: bool,
     // Provider-specific settings
     pub claude: Option<ClaudeSettings>,
     pub gemini: Option<GeminiSettings>,

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -1000,7 +1000,7 @@ Example Output:
                 )
                 .await
             {
-                Ok((result_json, t_in, t_out, t_cached, stage_history)) => {
+                Ok((result_json, t_in, t_out, t_cached, stage_history, cache_key)) => {
                     total_tokens_in += t_in;
                     total_tokens_out += t_out;
                     total_tokens_cached += t_cached;
@@ -1010,11 +1010,17 @@ Example Output:
                         if c.is_array() {
                             deduplicated_concerns = c.clone();
                         } else {
+                            if let Some(ref key) = cache_key {
+                                self.provider.invalidate_cache_entry(key).await;
+                            }
                             return Err(anyhow::anyhow!(
                                 "Stage 8 output 'concerns' is not an array"
                             ));
                         }
                     } else {
+                        if let Some(ref key) = cache_key {
+                            self.provider.invalidate_cache_entry(key).await;
+                        }
                         return Err(anyhow::anyhow!(
                             "Stage 8 failed to produce a valid 'concerns' array in output."
                         ));
@@ -1024,11 +1030,17 @@ Example Output:
                         if c.is_array() {
                             deduplicated_dismissed_concerns = c.clone();
                         } else {
+                            if let Some(ref key) = cache_key {
+                                self.provider.invalidate_cache_entry(key).await;
+                            }
                             return Err(anyhow::anyhow!(
                                 "Stage 8 output 'dismissed_concerns' is not an array"
                             ));
                         }
                     } else {
+                        if let Some(ref key) = cache_key {
+                            self.provider.invalidate_cache_entry(key).await;
+                        }
                         return Err(anyhow::anyhow!(
                             "Stage 8 failed to produce a valid 'dismissed_concerns' array in output."
                         ));
@@ -1168,7 +1180,7 @@ Example Output:
                 )
                 .await
             {
-                Ok((result_json, t_in, t_out, t_cached, stage_history)) => {
+                Ok((result_json, t_in, t_out, t_cached, stage_history, cache_key)) => {
                     total_tokens_in += t_in;
                     total_tokens_out += t_out;
                     total_tokens_cached += t_cached;
@@ -1178,11 +1190,17 @@ Example Output:
                         if c.is_array() {
                             conflict_resolved_concerns = c.clone();
                         } else {
+                            if let Some(ref key) = cache_key {
+                                self.provider.invalidate_cache_entry(key).await;
+                            }
                             return Err(anyhow::anyhow!(
                                 "Stage 9 output 'concerns' is not an array"
                             ));
                         }
                     } else {
+                        if let Some(ref key) = cache_key {
+                            self.provider.invalidate_cache_entry(key).await;
+                        }
                         return Err(anyhow::anyhow!(
                             "Stage 9 failed to produce a valid 'concerns' array in output."
                         ));
@@ -1283,7 +1301,7 @@ Example Output:
                 )
                 .await
             {
-                Ok((result_json, t_in, t_out, t_cached, stage_history)) => {
+                Ok((result_json, t_in, t_out, t_cached, stage_history, cache_key)) => {
                     total_tokens_in += t_in;
                     total_tokens_out += t_out;
                     total_tokens_cached += t_cached;
@@ -1293,11 +1311,17 @@ Example Output:
                         if f.is_array() {
                             findings_json = f.clone();
                         } else {
+                            if let Some(ref key) = cache_key {
+                                self.provider.invalidate_cache_entry(key).await;
+                            }
                             return Err(anyhow::anyhow!(
                                 "Stage 10 output 'findings' is not an array"
                             ));
                         }
                     } else {
+                        if let Some(ref key) = cache_key {
+                            self.provider.invalidate_cache_entry(key).await;
+                        }
                         return Err(anyhow::anyhow!(
                             "Stage 10 failed to produce a valid 'findings' array in output."
                         ));
@@ -1371,7 +1395,7 @@ Example Output:
                     )
                     .await
                 {
-                    Ok((result_text, t_in, t_out, t_cached, stage_history)) => {
+                    Ok((result_text, t_in, t_out, t_cached, stage_history, cache_key)) => {
                         total_tokens_in += t_in;
                         total_tokens_out += t_out;
                         total_tokens_cached += t_cached;
@@ -1386,6 +1410,9 @@ Example Output:
                                     break;
                                 }
                                 Err(violation) => {
+                                    if let Some(ref key) = cache_key {
+                                        self.provider.invalidate_cache_entry(key).await;
+                                    }
                                     tracing::warn!(
                                         "Stage 11 format validation failed (attempt {}/{}): {}. Retrying with augmented prompt.",
                                         retries + 1,
@@ -1471,8 +1498,8 @@ Example Output:
         clean_system_prompt: String,
         user_prompt: String,
         clean_user_prompt: String,
-    ) -> Result<(Value, u32, u32, u32, Vec<AiMessage>)> {
-        let (raw_text, t_in, t_out, t_cached, stage_history) = self
+    ) -> Result<(Value, u32, u32, u32, Vec<AiMessage>, Option<String>)> {
+        let (raw_text, t_in, t_out, t_cached, stage_history, cache_key) = self
             .run_ai_stage_raw(
                 stage,
                 system_prompt,
@@ -1486,7 +1513,7 @@ Example Output:
             let cands = find_json_candidates(&raw_text);
             cands.into_iter().last().unwrap_or(json!({}))
         });
-        Ok((parsed, t_in, t_out, t_cached, stage_history))
+        Ok((parsed, t_in, t_out, t_cached, stage_history, cache_key))
     }
 
     async fn run_ai_stage_raw(
@@ -1496,10 +1523,11 @@ Example Output:
         _clean_system_prompt: String,
         user_prompt: String,
         clean_user_prompt: String,
-    ) -> Result<(String, u32, u32, u32, Vec<AiMessage>)> {
+    ) -> Result<(String, u32, u32, u32, Vec<AiMessage>, Option<String>)> {
         let mut stage_action_history = Vec::new();
         let mut stage_history = Vec::new();
         let mut local_history = Vec::new();
+        let mut first_turn_cache_key: Option<String> = None;
 
         let user_msg = AiMessage {
             role: AiRole::User,
@@ -1576,6 +1604,10 @@ Example Output:
                     }
                 }
             };
+
+            if first_turn_cache_key.is_none() {
+                first_turn_cache_key = resp.cache_key.clone();
+            }
 
             if resp.truncated {
                 return Err(ReviewError::OutputTruncated.into());
@@ -1676,6 +1708,7 @@ Example Output:
                     t_out,
                     t_cached,
                     stage_history,
+                    first_turn_cache_key,
                 ));
             } else {
                 return Err(anyhow::anyhow!("No content or tool calls from AI"));
@@ -1884,7 +1917,7 @@ Example:
                     )
                     .await
                 {
-                    Ok((result_json, t_in, t_out, t_cached, stage_history)) => {
+                    Ok((result_json, t_in, t_out, t_cached, stage_history, cache_key)) => {
                         total_tokens_in += t_in;
                         total_tokens_out += t_out;
                         total_tokens_cached += t_cached;
@@ -1897,6 +1930,9 @@ Example:
                                 success = true;
                             }
                             Err(violation) => {
+                                if let Some(ref key) = cache_key {
+                                    self.provider.invalidate_cache_entry(key).await;
+                                }
                                 tracing::warn!(
                                     "Stage {} format validation failed (inner attempt {}/{}): {}. Retrying with augmented prompt.",
                                     stage,
@@ -2460,6 +2496,7 @@ mod tests {
                     }]),
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             } else if turn == 1 {
                 Ok(crate::ai::AiResponse {
@@ -2474,6 +2511,7 @@ mod tests {
                     }]),
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             } else {
                 Ok(crate::ai::AiResponse {
@@ -2483,6 +2521,7 @@ mod tests {
                     tool_calls: None,
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             }
         }
@@ -2521,6 +2560,7 @@ mod tests {
                     }]),
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             } else if turn == 1 {
                 Ok(crate::ai::AiResponse {
@@ -2535,6 +2575,7 @@ mod tests {
                     }]),
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             } else if turn == 2 {
                 Ok(crate::ai::AiResponse {
@@ -2549,6 +2590,7 @@ mod tests {
                     }]),
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             } else {
                 Ok(crate::ai::AiResponse {
@@ -2558,6 +2600,7 @@ mod tests {
                     tool_calls: None,
                     usage: None,
                     truncated: false,
+                    cache_key: None,
                 })
             }
         }
@@ -2601,7 +2644,7 @@ mod tests {
             .await;
 
         assert!(res.is_ok());
-        let (_, _, _, _, stage_history) = res.unwrap();
+        let (_, _, _, _, stage_history, _) = res.unwrap();
         assert_eq!(stage_history.len(), 6);
 
         let blocked_msg = &stage_history[4];
@@ -2639,7 +2682,7 @@ mod tests {
             .await;
 
         assert!(res.is_ok());
-        let (_, _, _, _, stage_history) = res.unwrap();
+        let (_, _, _, _, stage_history, _) = res.unwrap();
         assert_eq!(stage_history.len(), 8);
 
         let response_msg = &stage_history[6];
@@ -2679,6 +2722,7 @@ mod tests {
                         tool_calls: None,
                         usage: None,
                         truncated: false,
+                        cache_key: None,
                     });
                 }
                 anyhow::bail!(

--- a/static/index.html
+++ b/static/index.html
@@ -490,6 +490,132 @@
             display: block;
         }
 
+        /* Cache stats expandable rows in summary table */
+        .cache-detail-row td {
+            padding: 0;
+            border-bottom: none;
+        }
+
+        .cache-detail-row:hover {
+            background: none;
+        }
+
+        .cache-detail-row .cache-panel {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                        opacity 0.2s ease;
+            opacity: 0;
+        }
+
+        .cache-detail-row.open .cache-panel {
+            max-height: 200px;
+            opacity: 1;
+        }
+
+        .cache-stats-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1px;
+            background: var(--border-light);
+            margin: 4px 8px 8px;
+            border: 1px solid var(--border-light);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .cache-stat-cell {
+            background: var(--code-bg);
+            padding: 6px 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .cache-stat-label {
+            font-size: 0.75em;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .cache-stat-val {
+            font-size: 0.9em;
+            font-weight: 600;
+        }
+
+        .cache-bar-row {
+            margin: 0 8px 8px;
+        }
+
+        .cache-bar-label {
+            font-size: 0.75em;
+            color: var(--text-dim);
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 2px;
+        }
+
+        .cache-bar-track {
+            height: 3px;
+            background: var(--border-light);
+            border-radius: 2px;
+            overflow: hidden;
+        }
+
+        .cache-bar-fill {
+            height: 100%;
+            border-radius: 2px;
+            background: var(--status-reviewed);
+            width: 0;
+            transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1) 0.1s;
+        }
+
+        .cache-detail-row.open .cache-bar-fill {
+            width: var(--pct);
+        }
+
+        /* Expandable model/cache detail in metadata section */
+        .model-expandable {
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        .model-expandable .toggle-indicator {
+            font-size: 0.8em;
+            color: var(--text-dim);
+            margin-right: 4px;
+            display: inline-block;
+            transition: transform 0.2s ease;
+        }
+
+        .model-expandable.open .toggle-indicator {
+            transform: rotate(90deg);
+        }
+
+        .model-detail {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                        opacity 0.2s ease;
+            opacity: 0;
+            margin-top: 4px;
+        }
+
+        .model-detail.open {
+            max-height: 300px;
+            opacity: 1;
+        }
+
+        .model-detail .cache-bar-fill {
+            width: 0;
+            transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1) 0.1s;
+        }
+
+        .model-detail.open .cache-bar-fill {
+            width: var(--pct);
+        }
+
         /* Code/Log blocks */
         .log-block {
             background: var(--code-bg);
@@ -1292,6 +1418,27 @@
             return full ? d.toLocaleString() : d.toISOString().split('T')[0];
         }
 
+        function fmtTokens(n) {
+            if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+            if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
+            return String(n);
+        }
+
+        function toggleCacheRow(pid, event) {
+            event.stopPropagation();
+            const row = document.getElementById('cache-' + pid);
+            if (row) row.classList.toggle('open');
+        }
+
+        function toggleModelDetail() {
+            const wrapper = document.getElementById('model-wrapper');
+            const detail = document.getElementById('model-detail');
+            if (wrapper && detail) {
+                wrapper.classList.toggle('open');
+                detail.classList.toggle('open');
+            }
+        }
+
         function copyToClipboard(text) {
             navigator.clipboard.writeText(text).then(() => {
                 console.log('Copied:', text);
@@ -1724,6 +1871,8 @@
                 summaryHtml = '<table style="margin-bottom: 20px;"><thead><tr><th>Patch</th><th>Potential Regressions</th></tr></thead><tbody>';
             }
 
+            let psTotalHits = 0, psTotalMisses = 0, psTotalSaved = 0, psTotalStored = 0;
+
             sortedPatchIds.forEach((pid, index) => {
                 const patch = patchMap.get(pid);
                 const reviews = reviewsByPatch.get(pid);
@@ -1864,7 +2013,42 @@
                     }
                     const patchLabel = patch ? `Patch ${patch.part_index}` : `Patch ${pid}`;
                     const patchSubject = patch ? escapeHtml(patch.subject || '(no subject)') : '';
-                    summaryHtml += `<tr onclick="document.getElementById('patch-${pid}').scrollIntoView({behavior: 'smooth'})" style="cursor:pointer"><td><strong>${patchLabel}</strong>: ${patchSubject}</td><td>${summaryStatus}</td></tr>`;
+
+                    let cacheIndicator = '';
+                    let cacheDetailHtml = '';
+                    if (data.show_cache_stats && reviews && reviews.length > 0) {
+                        const latest = reviews.reduce((best, r) => (!best || (r.id || 0) > (best.id || 0)) ? r : best, null);
+                        if (latest) {
+                            const h = latest.cache_hits || 0;
+                            const m = latest.cache_misses || 0;
+                            const sv = latest.cache_tokens_saved || 0;
+                            const st = latest.cache_tokens_stored || 0;
+                            psTotalHits += h; psTotalMisses += m;
+                            psTotalSaved += sv; psTotalStored += st;
+                            const t = h + m;
+                            if (t > 0) {
+                                const rate = (h / t * 100).toFixed(1);
+                                cacheIndicator = ` <span onclick="toggleCacheRow(${pid}, event)" style="cursor:pointer;color:var(--text-dim);font-size:0.85em" title="Cache stats">▶</span>`;
+                                cacheDetailHtml = `<tr class="cache-detail-row" id="cache-${pid}"><td colspan="2"><div class="cache-panel">
+                                    <div class="cache-stats-grid">
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Hits</span><span class="cache-stat-val" style="color:var(--status-reviewed)">${h}</span></div>
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Misses</span><span class="cache-stat-val" style="color:${m > 0 ? 'var(--error-text)' : 'var(--text)'}">${m}</span></div>
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Hit Rate</span><span class="cache-stat-val">${rate}%</span></div>
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Saved</span><span class="cache-stat-val" style="color:var(--status-reviewed)">${fmtTokens(sv)}</span></div>
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Stored</span><span class="cache-stat-val">${fmtTokens(st)}</span></div>
+                                        <div class="cache-stat-cell"><span class="cache-stat-label">Calls</span><span class="cache-stat-val">${t}</span></div>
+                                    </div>
+                                    <div class="cache-bar-row">
+                                        <div class="cache-bar-label"><span>hit rate</span><span>${rate}%</span></div>
+                                        <div class="cache-bar-track"><div class="cache-bar-fill" style="--pct:${rate}%"></div></div>
+                                    </div>
+                                </div></td></tr>`;
+                            }
+                        }
+                    }
+
+                    summaryHtml += `<tr onclick="document.getElementById('patch-${pid}').scrollIntoView({behavior: 'smooth'})" style="cursor:pointer"><td><strong>${patchLabel}</strong>: ${patchSubject}${cacheIndicator}</td><td>${summaryStatus}</td></tr>`;
+                    summaryHtml += cacheDetailHtml;
                 }
             });
 
@@ -1996,6 +2180,30 @@
 
             let currentStatus = data.status || 'Pending';
 
+            let modelDetailHtml = '';
+            let modelClickable = false;
+            if (data.show_cache_stats) {
+                const psTotal = psTotalHits + psTotalMisses;
+                if (psTotal > 0) {
+                    modelClickable = true;
+                    const rate = (psTotalHits / psTotal * 100).toFixed(1);
+                    modelDetailHtml = `<div class="model-detail" id="model-detail">
+                        <div class="cache-stats-grid">
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Hits</span><span class="cache-stat-val" style="color:var(--status-reviewed)">${psTotalHits}</span></div>
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Misses</span><span class="cache-stat-val" style="color:${psTotalMisses > 0 ? 'var(--error-text)' : 'var(--text)'}">${psTotalMisses}</span></div>
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Hit Rate</span><span class="cache-stat-val">${rate}%</span></div>
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Saved</span><span class="cache-stat-val" style="color:var(--status-reviewed)">${fmtTokens(psTotalSaved)}</span></div>
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Stored</span><span class="cache-stat-val">${fmtTokens(psTotalStored)}</span></div>
+                            <div class="cache-stat-cell"><span class="cache-stat-label">Calls</span><span class="cache-stat-val">${psTotal}</span></div>
+                        </div>
+                        <div class="cache-bar-row">
+                            <div class="cache-bar-label"><span>hit rate</span><span>${rate}%</span></div>
+                            <div class="cache-bar-track"><div class="cache-bar-fill" style="--pct:${rate}%"></div></div>
+                        </div>
+                    </div>`;
+                }
+            }
+
             document.getElementById('app').innerHTML = `
                 <div class="nav"><a href="#/" onclick="event.preventDefault(); goBack();">← Back</a></div>
                 <h1>
@@ -2013,7 +2221,11 @@
                     <div class="kv"><div class="label">Date:</div><div>${date}</div></div>
                     <div class="kv"><div class="label">Subsystems:</div><div>${subsystemsHtml}</div></div>
                     <div class="kv"><div class="label">Patches:</div><div>${data.received_parts || 0} / ${data.total_parts || 0}</div></div>
-                    <div class="kv"><div class="label">Model:</div><div>${escapeHtml(providerModel)}</div></div>
+                    <div class="kv${modelClickable ? ' model-expandable' : ''}" id="model-wrapper" ${modelClickable ? 'onclick="toggleModelDetail()"' : ''}>
+                        <div class="label">Model:</div>
+                        <div>${modelClickable ? '<span class="toggle-indicator">▶</span>' : ''}${escapeHtml(providerModel)}</div>
+                    </div>
+                    ${modelDetailHtml}
                     <div class="kv"><div class="label">Sashiko ver.:</div><div>${escapeHtml(promptsHash)}</div></div>
                 </div>
                 

--- a/tests/integration/server_tests.rs
+++ b/tests/integration/server_tests.rs
@@ -49,6 +49,7 @@ async fn spawn_test_server(read_only: bool) -> TestServer {
         /* allow_all_submit */ true,
         /* smtp_enabled */ false,
         /* dry_run */ true,
+        /* show_cache_stats */ false,
     );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/tests/integration/test_cache_stats.rs
+++ b/tests/integration/test_cache_stats.rs
@@ -141,3 +141,78 @@ async fn test_complete_review_without_cache_stats() {
         "cache_misses should be NULL when no stats provided"
     );
 }
+
+#[tokio::test]
+async fn test_cache_stats_in_patchset_summary() {
+    let settings = DatabaseSettings {
+        url: ":memory:".to_string(),
+        token: "".to_string(),
+    };
+    let db = Database::new(&settings).await.unwrap();
+    db.migrate().await.unwrap();
+
+    db.conn
+        .execute(
+            "INSERT INTO patchsets (id, status, subject, date) VALUES (1, 'Reviewed', 'test', 1000)",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO messages (message_id) VALUES ('<msg1>')", ())
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO patches (id, patchset_id, message_id, part_index) VALUES (1, 1, '<msg1>', 1)",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO reviews (id, patchset_id, patch_id, status) VALUES (1, 1, 1, 'In Review')",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let cache_stats = ReviewCacheStats {
+        hits: 42,
+        misses: 7,
+        tokens_saved: 50_000,
+        tokens_stored: 8_000,
+    };
+
+    db.complete_review(
+        1,
+        "Reviewed",
+        "Review completed",
+        Some("Test summary"),
+        None,
+        None,
+        None,
+        Some(&cache_stats),
+    )
+    .await
+    .unwrap();
+
+    let result = db.get_patchset_summary(1, None, None).await.unwrap();
+    assert!(result.is_some(), "patchset summary should exist");
+    let data = result.unwrap();
+
+    let reviews = data["reviews"].as_array().expect("reviews should be array");
+    assert!(!reviews.is_empty(), "should have at least one review");
+
+    let review = &reviews[0];
+    assert_eq!(review["cache_hits"], 42, "cache_hits mismatch");
+    assert_eq!(review["cache_misses"], 7, "cache_misses mismatch");
+    assert_eq!(
+        review["cache_tokens_saved"], 50_000,
+        "cache_tokens_saved mismatch"
+    );
+    assert_eq!(
+        review["cache_tokens_stored"], 8_000,
+        "cache_tokens_stored mismatch"
+    );
+}

--- a/tests/integration/test_cache_stats.rs
+++ b/tests/integration/test_cache_stats.rs
@@ -1,0 +1,143 @@
+use sashiko::db::{Database, ReviewCacheStats};
+use sashiko::settings::DatabaseSettings;
+
+#[tokio::test]
+async fn test_complete_review_with_cache_stats() {
+    let settings = DatabaseSettings {
+        url: ":memory:".to_string(),
+        token: "".to_string(),
+    };
+    let db = Database::new(&settings).await.unwrap();
+    db.migrate().await.unwrap();
+
+    db.conn
+        .execute(
+            "INSERT INTO patchsets (id, status) VALUES (1, 'Reviewing')",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO messages (message_id) VALUES ('<msg1>')", ())
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO patches (id, patchset_id, message_id, part_index) VALUES (1, 1, '<msg1>', 1)",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO reviews (id, patchset_id, patch_id, status) VALUES (1, 1, 1, 'In Review')",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let cache_stats = ReviewCacheStats {
+        hits: 5,
+        misses: 2,
+        tokens_saved: 10_000,
+        tokens_stored: 3_000,
+    };
+
+    db.complete_review(
+        1,
+        "Reviewed",
+        "Review completed",
+        Some("Test summary"),
+        None,
+        None,
+        None,
+        Some(&cache_stats),
+    )
+    .await
+    .unwrap();
+
+    let mut rows = db
+        .conn
+        .query(
+            "SELECT cache_hits, cache_misses, cache_tokens_saved, cache_tokens_stored FROM reviews WHERE id = 1",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 5);
+    assert_eq!(row.get::<i64>(1).unwrap(), 2);
+    assert_eq!(row.get::<i64>(2).unwrap(), 10_000);
+    assert_eq!(row.get::<i64>(3).unwrap(), 3_000);
+}
+
+#[tokio::test]
+async fn test_complete_review_without_cache_stats() {
+    let settings = DatabaseSettings {
+        url: ":memory:".to_string(),
+        token: "".to_string(),
+    };
+    let db = Database::new(&settings).await.unwrap();
+    db.migrate().await.unwrap();
+
+    db.conn
+        .execute(
+            "INSERT INTO patchsets (id, status) VALUES (1, 'Reviewing')",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO messages (message_id) VALUES ('<msg1>')", ())
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO patches (id, patchset_id, message_id, part_index) VALUES (1, 1, '<msg1>', 1)",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO reviews (id, patchset_id, patch_id, status) VALUES (1, 1, 1, 'In Review')",
+            (),
+        )
+        .await
+        .unwrap();
+
+    db.complete_review(
+        1,
+        "Reviewed",
+        "Review completed",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let mut rows = db
+        .conn
+        .query(
+            "SELECT cache_hits, cache_misses FROM reviews WHERE id = 1",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    let hits: Option<i64> = row.get(0).ok();
+    let misses: Option<i64> = row.get(1).ok();
+    assert!(
+        hits.is_none(),
+        "cache_hits should be NULL when no stats provided"
+    );
+    assert!(
+        misses.is_none(),
+        "cache_misses should be NULL when no stats provided"
+    );
+}

--- a/tests/integration/test_rerun_resets.rs
+++ b/tests/integration/test_rerun_resets.rs
@@ -1,0 +1,76 @@
+use sashiko::db::Database;
+use sashiko::settings::DatabaseSettings;
+
+#[tokio::test]
+async fn test_rerun_resets_patch_statuses() {
+    let settings = DatabaseSettings {
+        url: ":memory:".to_string(),
+        token: "".to_string(),
+    };
+    let db = Database::new(&settings).await.unwrap();
+    db.migrate().await.unwrap();
+
+    db.conn
+        .execute(
+            "INSERT INTO patchsets (id, status) VALUES (1, 'Reviewed')",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO messages (message_id) VALUES ('<msg1>')", ())
+        .await
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO messages (message_id) VALUES ('<msg2>')", ())
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO patches (id, patchset_id, message_id, part_index, status, apply_error) \
+             VALUES (1, 1, '<msg1>', 1, 'Failed', 'could not apply')",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO patches (id, patchset_id, message_id, part_index, status, apply_error) \
+             VALUES (2, 1, '<msg2>', 2, 'Reviewed', NULL)",
+            (),
+        )
+        .await
+        .unwrap();
+
+    db.rerun_patchset(1).await.unwrap();
+
+    // Verify patchset status is reset
+    let mut rows = db
+        .conn
+        .query("SELECT status FROM patchsets WHERE id = 1", ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    let status: String = row.get(0).unwrap();
+    assert_eq!(status, "Pending");
+
+    // Verify all patch statuses are reset and apply_error cleared
+    let mut rows = db
+        .conn
+        .query(
+            "SELECT status, apply_error FROM patches WHERE patchset_id = 1 ORDER BY id",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    let status: String = row.get(0).unwrap();
+    let apply_error: Option<String> = row.get(1).ok();
+    assert_eq!(status, "Pending");
+    assert!(apply_error.is_none(), "apply_error should be cleared");
+
+    let row = rows.next().await.unwrap().unwrap();
+    let status: String = row.get(0).unwrap();
+    assert_eq!(status, "Pending");
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,4 +13,5 @@ mod integration {
     mod singleton_root_overwrite;
     mod test_nested;
     mod test_pending;
+    mod test_rerun_resets;
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,6 +11,7 @@ mod integration {
     mod server_tests;
     mod singleton_cover_merge_test;
     mod singleton_root_overwrite;
+    mod test_cache_stats;
     mod test_nested;
     mod test_pending;
     mod test_rerun_resets;


### PR DESCRIPTION
● Response cache statistics, startup improvements, and bug fixes

  This series adds observability into the response cache, fixes several
  bugs found during testing, and improves daemon startup behavior.

  Response cache statistics (patches 3-6)

  Track per-review cache hit/miss/token counts in the database and expose
  them through the API, CLI (sashiko show), and web UI.  The web UI uses
  tap-to-expand panels with hit-rate progress bars — available per-patch
  and aggregated at the patchset level.  All cache stats display is gated
  behind the show_cache_stats setting (default off).

  Example sashiko-cli show output with cache stats enabled:

  Patchset Details:
    ID:        61
    Subject:   perf session: Add minimum event size and alignment validation
    Author:    Arnaldo Carvalho de Melo <acme@redhat.com>
    Status:    Failed
    Date:      2026-05-19 14:48:09

  Patches (28):
    [1] perf session: Add minimum event size and alignment validation (Failed) [Failed] {cache: 502/543 hits, 23.1M tokens saved}
    [2] perf tools: Fix event_contains() macro to verify full field extent (Reviewed) [Issues Found] {cache: 413/807 hits, 15.7M tokens saved}
    ...
    [27] perf kwork: Bounds check work->cpu before indexing cpus_runtime[] (Reviewed) [Reviewed] {cache: 3667/4155 hits, 163.0M tokens saved}
    [28] perf test: Add truncated perf.data robustness test (Reviewed) [Issues Found] {cache: 3080/3334 hits, 134.8M tokens saved}

  Cache: 64296/78526 hits (81.9%), 2841.6M tokens saved, 647.2M tokens stored
    Model:   gemini-3.1-pro-preview

  In the web interface, these stats are available by tapping the ▶ indicator
  next to each patch row for per-patch details, and on the Model: line in
  the patchset header for aggregate stats across all patches.

  Startup and operational improvements (patches 2, 11, 12)

  - Support user-level config in ~/.config/sashiko/Settings.toml so
  personal credentials and overrides don't live in the repo checkout
  - Move custom remote fetches to a background task so the reviewer starts
  immediately instead of blocking on slow git.kernel.org IPv6 fetches
  - Log response cache open timing, file size, and entry count at startup

  Bug fixes (patches 1, 7-10)

  - Fix sashiko show picking a stale "Reviewed" result over a newer
  "Failed" retry after patchset resubmission
  - Fix cancel endpoint rejecting localhost connections on dual-stack
  servers (missing to_canonical() call)
  - Return proper 404 when cancelling a non-existent patchset
  - Stop submitting LLM requests for remaining patches after a patchset
  is cancelled

  Docs (patch 0)

  - Extract LLM provider configurations into examples/ directory

I'll work now on adding limits to the cache and hopefully some sort of LRU to keep LLM requests that have tons of hits while making space for new entries by purging seldom used ones and then make the request cache a default feature with a given reasonable size based on the experience we gather by exposing the stats using this patch series publicly, which is something I encourage the admin for https:://sashiko.dev to do when upgrading to the next release.

Saving "I know that this is not something introduced by your patch, but there is this pre-existing problem that I analysed and found problematic, can you postpone submitting this series and fixing just this one more issue, pretty please?" cases in some sort of database that gets exposed in the https://sashiko.dev site in one special session of "please help picking up from this cache of query/response tokens cache of problems" is another idea I plan to work on Real Soon Now. :-)

     @@@@@Cheers,

Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>