### PR TITLE
k8s: track linux-arm-msm mailing list

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -86,7 +86,7 @@ spec:
                 kexec,linux-iio,netfilter-devel,linux-renesas-soc,linux-omap,linux-xfs,
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
-                live-patching, openvpn-devel, platform-driver-x86
+                live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "60"
             - name: SASHIKO__SMTP__SENDER_ADDRESS


### PR DESCRIPTION
Sashiko already reviews Qualcomm SoC patches when they overlap with other tracked lists, but linux-arm-msm is not configured as an explicit source. That makes those patches harder to find in the UI and misses patches that are only sent to linux-arm-msm.

Add linux-arm-msm to the tracked review mailing lists.