### PR TITLE
policy: Enable email reviews for kvm@vger.kernel.org

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -143,3 +143,8 @@ lists = ["linux-nfs@vger.kernel.org"]
 reply_to_author = false
 cc_individuals = false
 cc = ["Chuck Lever <cel@kernel.org>", "Jeff Layton <jlayton@kernel.org>", "Anna Schumaker <anna@kernel.org>"]
+
+[subsystems.kvm]
+lists = ["kvm@vger.kernel.org"]
+reply_to_author = true
+cc = ["kvm@vger.kernel.org"]


### PR DESCRIPTION
Add a "kvm" subsystem entry in the email policy to enable reviews for all patches sent to kvm@vger.kernel.org.  While kvm@ is used for a large number of subsystems (it's much more of a "virtualization" list at this point), there's general consensus across all affected maintainers that the benefits of automated email outweigh any potential downsides.

Send emails only to the author and kvm@, not to any individual maintainers, due to kvm@ covering so many subsystems (and subsystems of subsystems).