### PR TITLE
worker: fix stale LLM-facing tool names in design docs

### DIFF
--- a/designs/DESIGN_CONTENT_TRUNCATION.md
+++ b/designs/DESIGN_CONTENT_TRUNCATION.md
@@ -26,7 +26,7 @@ We view the context window (e.g., 32k, 1M, 2M tokens) as a **strict budget** tha
 ## 2. Truncation Algorithms
 
 ### A. The "Key-Hole" View (For Source Files)
-When the agent requests `read_file`, we rarely want the *entire* file if it's 10k lines long.
+When the agent requests `read_files`, we rarely want the *entire* file if it's 10k lines long.
 *   **Default**: Return +/- 50 lines around the requested area (if line numbers specified).
 *   **Symbol-Aware Pruning**:
     *   Parse the AST (or use regex/`tree-sitter` for C/Rust).
@@ -94,8 +94,8 @@ impl ContextWindow {
 ```
 
 ### Smart File Reader (Tool Enhancement)
-Update the `read_file` tool to support "smart mode":
-*   `read_file(path, focus_lines=[10..20], mode="smart")`
+Update the `read_files` tool to support "smart mode":
+*   `read_files(files=[{path, start_line, end_line}], mode="smart")`
 *   If `mode="smart"`, it parses the file and collapses irrelevant sections before returning.
 
 ## 4. Integration Plan

--- a/designs/DESIGN_LLM_REVIEW_STRATEGY.md
+++ b/designs/DESIGN_LLM_REVIEW_STRATEGY.md
@@ -18,7 +18,7 @@ Instead of asking for a review directly, we force a multi-step reasoning process
 > "You are reviewing a patch. Do not output the review yet. First, perform the following analysis steps:
 > 1.  **Summary**: Briefly summarize what the patch claims to do.
 > 2.  **Safety Check**: List potential security implications (buffer overflows, UAF).
-> 3.  **Context Verification**: Identify external functions/structs modified. Do you need to see their definitions? (Use `read_file` if so).
+> 3.  **Context Verification**: Identify external functions/structs modified. Do you need to see their definitions? (Use `read_files` if so).
 > 4.  **Style Check**: Does it match kernel coding style?
 > 5.  **Plan**: What specific files or lines do you need to inspect to verify correctness?"
 
@@ -38,7 +38,7 @@ The System Prompt must strictly define the persona to avoid "helpful assistant" 
 ### A. The "Needle in a Haystack" Problem
 The Linux kernel is too large for the context window. The worker must *retrieval-augment* itself.
 -   **Initial Context**: Cover letter + Patch diffs (limited to N lines).
--   **Active Retrieval**: The Worker *must* use tools (`git_grep`, `read_file`) to fetch definitions of modified functions.
+-   **Active Retrieval**: The Worker *must* use tools (`search_file_content`, `read_files`) to fetch definitions of modified functions.
     -   *Rule*: "If a patch modifies `foo()`, you must read the definition of `foo()` unless it's trivial."
 -   **Diff Context Expansion**: Allow the worker to request `git_diff -U20` if the default context is insufficient.
 
@@ -51,7 +51,7 @@ The Linux kernel is too large for the context window. The worker must *retrieval
 ### A. Tool Use Enforcement
 -   **Problem**: LLMs might hallucinate file content or API existence.
 -   **Solution**:
-    -   **Mandatory Verification**: Before claiming "function X does not exist", the worker must execute `git_grep X`.
+    -   **Mandatory Verification**: Before claiming "function X does not exist", the worker must execute `search_file_content` for `X`.
     -   **Loop Prevention**: If the worker asks for the same file twice, interrupt and prompt: "You already have this. Proceed to analysis."
 
 ### B. Structured Output (JSON Mode)
@@ -96,6 +96,6 @@ If the patch uses a deprecated API (e.g., `simple_strtol`), the worker should su
 ## 7. Implementation Roadmap (Features)
 
 1.  **Phase 1**: Basic Review (Text output, diff-only context).
-2.  **Phase 2**: Tool-Assisted (Worker can `read_file`, `grep`).
+2.  **Phase 2**: Tool-Assisted (Worker can `read_files`, `search_file_content`).
 3.  **Phase 3**: Structured JSON Output & Database Integration.
 4.  **Phase 4**: Multi-turn "Critic" Loop.

--- a/designs/DESIGN_LOOP_PREVENTION.md
+++ b/designs/DESIGN_LOOP_PREVENTION.md
@@ -54,10 +54,10 @@ When a potential stall or loop is detected, instead of killing the process, the 
 ### 2.4. Smart Tools to Reduce Steps
 One major cause of high step counts is inefficient tools. We will add "Macro-Tools" that combine operations.
 
-1.  **`search_code` (ripgrep)**: Instead of `list_dir` + `read_file` loops to find a symbol, the worker can grep the entire tree in 1 step.
+1.  **`search_file_content`**: Instead of `list_dir` + `read_files` loops to find a symbol, the worker can search the entire tree in 1 step.
     *   *Constraint*: Must return strictly limited output (e.g., top 20 matches) to prevent context flooding.
-2.  **`glob_find`**: To locate files without walking the tree manually.
-3.  **`batch_read`**: Allow `read_file` to accept a list of paths, returning a JSON map of contents. This allows reading 5 relevant files in 1 turn instead of 5 turns.
+2.  **`find_files`**: To locate files without walking the tree manually.
+3.  **`read_files`**: Accept a list of file requests, allowing the worker to read 5 relevant files in 1 turn instead of 5 turns.
 
 ## 3. Implementation Plan
 
@@ -97,13 +97,13 @@ Add to `src/worker/tools.rs`:
 ### Scenario A: The "Grep" Loop
 *Bad Worker*:
 1. `list_dir src/`
-2. `read_file src/main.rs` (No match)
-3. `read_file src/lib.rs` (No match)
+2. `read_files files=[{path:"src/main.rs"}]` (No match)
+3. `read_files files=[{path:"src/lib.rs"}]` (No match)
 ... (20 steps) ...
 
 *Smart Worker*:
 1. `search_file_content "loops"` -> Returns matches in `src/worker/mod.rs` and `DESIGN_LOOP_PREVENTION.md`.
-2. `read_file src/worker/mod.rs`
+2. `read_files files=[{path:"src/worker/mod.rs"}]`
 3. Done. (3 steps)
 
 ### Scenario B: The "Stuck" Worker

--- a/designs/DESIGN_REVIEW_WORKER.md
+++ b/designs/DESIGN_REVIEW_WORKER.md
@@ -40,9 +40,9 @@ Provides a safe, read-only interface to the system.
     - `git_show(ref, path)`: Read file content at specific revision.
     - `git_diff(range)`: Get patch/diff content.
     - `git_blame(path, start_line, end_line)`: Check authorship context.
-    - `git_grep(pattern, path_glob)`: Search for symbols or patterns.
+    - `search_file_content(pattern, path, context_lines)`: Search for symbols or patterns.
 - **Analysis Tools**:
-    - `read_file_lines(path, start, end)`: Read specific line range.
+    - `read_files(files, mode)`: Read one or more files or line ranges.
     - `list_dir(path)`: Explore directory structure.
 - **Worker Tools**:
     - `todo_write(task, status)`: Help worker track progress as required by prompts.
@@ -74,7 +74,7 @@ Provides a safe, read-only interface to the system.
 3.  **Analysis Loop**:
     -   Worker constructs prompt: "Review patchset: [Subject]..."
     -   **Gemini**: "I need to see `net/core/dev.c` lines 100-150 to check locking."
-    -   **Worker**: Runs `read_file` -> Returns content.
+    -   **Worker**: Runs `read_files` -> Returns content.
     -   **Gemini**: "Checks out. But who touched this last? `git blame` please."
     -   **Worker**: Runs `git blame` -> Returns result.
     -   **Gemini**: "Sashiko has reviewed this patch and found no issues. It looks great!"

--- a/designs/DESIGN_SECURITY_REVIEW_WORKER.md
+++ b/designs/DESIGN_SECURITY_REVIEW_WORKER.md
@@ -25,7 +25,7 @@ This document outlines the security architecture for the `sashiko-review` worker
 ### 4.1. Directory Traversal / Path Injection
 *   **Threat**: The LLM (potentially hallucinating or manipulated via prompt injection) attempts to access files outside the repository (e.g., `/etc/passwd`, `~/.ssh`).
 *   **Mitigation**:
-    *   **Path Validation**: All file path arguments passed to tools (e.g., `read_file`, `git_blame`) must be canonicalized and verified to be descendants of the authorized root (repo or prompts dir).
+    *   **Path Validation**: All file path arguments passed to tools (e.g., `read_files`, `git_blame`) must be canonicalized and verified to be descendants of the authorized root (repo or prompts dir).
     *   **Blocklist**: Explicitly reject paths containing `..` or absolute paths starting with `/` (unless resolved to within the root).
 
 ### 4.2. Command Injection
@@ -51,12 +51,12 @@ Implemented via `git` CLI, strictly parameterized.
 *   `git_diff(range)`: Safe.
 *   `git_blame(path, lines)`: Safe.
 *   `git_log(path, limit)`: Safe.
-*   `git_grep(pattern, path)`: **Caution**. Must prevent ReDoS (Regex Denial of Service) if possible, but standard git grep is generally robust. Enforce `max_count`.
+*   `search_file_content(pattern, path, context_lines)`: **Caution**. Must prevent ReDoS (Regex Denial of Service) if possible, and enforce output limits.
 
 **Banned**: `apply`, `commit`, `push`, `config`, `rm`, `add`.
 
 ### 5.2. File System Operations
-*   `read_file(path, range)`: Restricted to repo root.
+*   `read_files(files, mode)`: Restricted to repo root.
 *   `list_dir(path)`: Restricted to repo root.
 *   `write_file(path, content)`: Restricted to repo root (specifically intended for `review-inline.txt`).
 


### PR DESCRIPTION
These design documents are used as LLM-facing guidance for the review worker. They still referenced obsolete tool names such as git_grep and read_file, which can make the model call tools that do not exist and fail with Unknown tool errors.

Update the documented tool names to match the actual worker tool API, including search_file_content, read_files, and find_files.