### PR TITLE
Enable sashiko for nova-gpu@lists.linux.dev

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -87,7 +87,7 @@ spec:
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
                 live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm,
-                linux-modules,nouveau
+                linux-modules,nouveau,nova-gpu
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "32"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -153,3 +153,8 @@ cc = ["kvm@vger.kernel.org"]
 lists = ["linux-modules@vger.kernel.org"]
 reply_to_author = true
 cc = ["linux-modules@vger.kernel.org"]
+
+[subsystems.nova-gpu]
+lists = ["nova-gpu@lists.linux.dev"]
+reply_all = true
+cc = ["Danilo Krummrich <dakr@kernel.org>", "Alexandre Courbot <acourbot@nvidia.com>"]


### PR DESCRIPTION
Add nova-gpu to the tracked mailing lists in the k8s deployment, also add an email policy with reply_all enabled, sending reviews to the author, all original recipients, and Cc to Alexandre and Danilo.