### PR TITLE
Add clone discipline to review-pr skill

### DIFF
--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -20,6 +20,8 @@ Perform a deep, scrutinizing code review of the target code against the gathered
 - **Safety:** Are there any risky operations (e.g., unchecked unwraps, poor error handling, thread safety issues, SQL injection risks)?
 - **Idiomatic Conventions:** Does the code use the language idiomatic patterns and the project-specific coding standards defined in `GEMINI.md`?
 - **SOLID/DRY Principles:** Reference [references/principles.md](references/principles.md) and evaluate the code for adherence to SOLID and DRY principles within the Rust context.
+- **Clone Discipline:** If the code calls `.clone()` on expensive-to-clone structures, reference
+[references/clone-discipline.md](references/clone-discipline.md) and evaluate the code for adherence to clone discipline.
 - **Test Coverage:** Are unit or integration tests missing for new logic?
 
 ### 3. Reporting

--- a/skills/review-pr/references/clone-discipline.md
+++ b/skills/review-pr/references/clone-discipline.md
@@ -1,0 +1,140 @@
+# Clone Discipline
+
+## Directive
+
+Detect and challenge redundant and/or excessive uses of `.clone()`.
+
+## Definition
+
+The "Attack of the Clones" anti-pattern in Rust refers to the excessive and often unnecessary use of the
+`.clone()` method to bypass ownership and lifetime challenges. It occurs when developers choose to create
+deep copies of data as a "path of least resistance" to satisfy the borrow checker, rather than
+addressing the underlying structural or ownership issues in the code.
+
+## Anti Pattern Examples
+
+### BAD: Cloning a `Struct` when a `&Struct` will do
+
+```rs
+// BAD: prefer using `line: &str` which eliminates the .clone() below
+fn make_lipographic(banned: char, line: String) -> String {
+    line.as_str().chars().filter(|&c| c != banned).collect()
+}
+
+fn main() {
+    let passage = String::from("If Youth, throughout all history, had had a champion to stand up for it");
+    assert_eq!(make_lipographic('e', passage.clone()), passage);
+}
+```
+
+### BAD: Cloning a `Vec` when iterating
+
+```rs
+fn main() {
+    let mut bad_letters = vec!['e', 't', 'o', 'i'];
+    // BAD: prefer `for l in &bad_letters {`
+    for l in bad_letters.clone() {
+        // do something here
+    }
+    bad_letters.push('s');
+}
+```
+
+### BAD: Cloning when handling an `Option` or `Result`
+
+```rs
+pub struct LipogramCorpora {
+    selections: Vec<(char, Option<String>)>,
+}
+
+impl LipogramCorpora {
+    pub fn validate_all(&mut self) -> Result<(), char> {
+        for selection in &self.selections {
+            if selection.1.is_some() {
+                // BAD. prefer `if let Some(s) = selection.1.as_deref()` or pattern matching
+                if selection.1.clone().unwrap().contains(selection.0) {
+                    return Err(selection.0);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+### BAD: Cloning when passing immutable Struct into a closure
+
+If a `move` or `async move` closure needs immutable access to a Struct
+that is expensive to clone, it's good practice to share it via `Arc<_>`
+instead of `.clone()`.
+
+```rs
+// BAD
+let big_chunk = BigChunk::new();
+
+for _ in 1..10 {
+    let big_chunk = big_chunk.clone();
+    tokio::spawn(async move {
+        do_something_immutable(&big_chunk);
+    });
+}
+```
+
+```rs
+// GOOD
+let big_chunk = Arc::new(BigChunk::new());
+
+for _ in 1..10 {
+    let big_chunk = Arc::clone(&big_chunk);
+    tokio::spawn(async move {
+        do_something_immutable(&big_chunk);
+    });
+}
+```
+
+## Limitation
+
+Ignore redundant clones if their elimination would require adding explicit lifetime
+annotations (`'a`).
+
+<example>
+Using `.clone()` (Simple)
+The Config struct is "self-contained" and easy to pass around.
+
+```rs
+struct Config {
+    path: String,
+}
+fn load_config(path: &str) -> Config {
+    // Cloning ensures the Config owns its data
+    // and doesn't depend on the 'path' reference.
+    Config {
+        path: path.to_string(),
+    }
+}
+```
+
+Eliminating `.clone()` (Complex)
+To remove the clone, we must introduce a lifetime. This is "complex" because the 'a now must be
+propagated to every single place Config is used, potentially requiring dozens of changes across
+the codebase.
+
+```rs
+// Now the struct is bound to a lifetime
+struct Config<'a> {
+    path: &'a str,
+}
+// Every function returning or holding Config must now
+// manage these annotations.
+fn load_config<'a>(path: &'a str) -> Config<'a> {
+    Config {
+           path,
+    }
+}
+
+// Any struct containing Config also becomes complex:
+struct App<'a> {
+    config: Config<'a>,
+}
+```
+</example>


### PR DESCRIPTION
Integrate clone discipline guidelines and examples into the review-pr skill.

Establishing these checks directly in the review directives helps scrutinize future commits for redundant or excessive uses of clone. This is particularly useful in preventing unnecessary deep copies and cloning anti-patterns from being introduced into the codebase.