### PR TITLE
email: Add email policy for selinux

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -87,7 +87,7 @@ spec:
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
                 live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm,
-                linux-modules,nouveau,nova-gpu,ntb
+                linux-modules,nouveau,nova-gpu,ntb,selinux
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "32"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -177,3 +177,10 @@ cc = ["linux-media@vger.kernel.org"]
 lists = ["ntb@lists.linux.dev"]
 reply_to_author = true
 cc = ["ntb@lists.linux.dev"]
+
+[subsystems.selinux]
+lists = ["selinux@vger.kernel.org"]
+reply_all = false
+reply_to_author = false
+cc_individuals = false
+cc = ["paul@paul-moore.com"]


### PR DESCRIPTION
Initial enablement of the SELinux mailing list.  Until we have a better idea of how Sashiko and Chris Mason's review prompts works on the SELinux list keep things rather conservative with the automated email only being sent to myself.  Once things are working reasonably well we can open this up to others who are interested.