### PR TITLE
fix: fix patch application

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -257,6 +257,11 @@ impl BaselineRegistry {
                     .is_ok()
                 {
                     candidates.push(BaselineResolution::LocalRef(tag_ref));
+                } else {
+                    info!(
+                        "Skipping version tag candidate {} (not found locally)",
+                        tag_ref
+                    );
                 }
             } else {
                 let tag_ref = format!("v{}", version);
@@ -265,6 +270,11 @@ impl BaselineRegistry {
                     .is_ok()
                 {
                     candidates.push(BaselineResolution::LocalRef(tag_ref));
+                } else {
+                    info!(
+                        "Skipping version tag candidate {} (not found locally)",
+                        tag_ref
+                    );
                 }
             }
         }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -238,6 +238,10 @@ impl BaselineRegistry {
         }
 
         // 1.5 Version Tag from Subject
+        // Only add version-tag candidates if the tag actually exists
+        // locally. Subjects often contain version-like strings (e.g.,
+        // "for-7.2" or "Fixes for 7.1") that produce tags like v7.1
+        // which may not exist yet during release candidate phases.
         if let Some(version) = extract_version_tag(subject) {
             if version.ends_with(".y") {
                 candidates.push(BaselineResolution::RemoteTarget {
@@ -247,9 +251,21 @@ impl BaselineRegistry {
                     branch: Some(format!("linux-{}", version)),
                 });
                 let base_version = version.strip_suffix(".y").unwrap();
-                candidates.push(BaselineResolution::LocalRef(format!("v{}", base_version)));
+                let tag_ref = format!("v{}", base_version);
+                if crate::git_ops::get_commit_hash(&self.repo_path, &tag_ref)
+                    .await
+                    .is_ok()
+                {
+                    candidates.push(BaselineResolution::LocalRef(tag_ref));
+                }
             } else {
-                candidates.push(BaselineResolution::LocalRef(format!("v{}", version)));
+                let tag_ref = format!("v{}", version);
+                if crate::git_ops::get_commit_hash(&self.repo_path, &tag_ref)
+                    .await
+                    .is_ok()
+                {
+                    candidates.push(BaselineResolution::LocalRef(tag_ref));
+                }
             }
         }
 

--- a/src/bin/review.rs
+++ b/src/bin/review.rs
@@ -535,6 +535,10 @@ async fn apply_single_patch(
         }
     }
 
+    let mut applied_via_am = false;
+    let mut am_error = String::new();
+    let mut success = false;
+
     if let (Some(author), Some(subject)) = (&p.author, &p.subject) {
         // Try to construct mbox
         let date_str = if let Some(ts) = p.date {
@@ -561,6 +565,8 @@ async fn apply_single_patch(
 
         match worktree.apply_patch(&mbox).await {
             Ok(_) => {
+                applied_via_am = true;
+                success = true;
                 if let Ok(sha) = sashiko::git_ops::get_commit_hash(&worktree.path, "HEAD").await {
                     patch_shas.insert(p.index, sha.clone());
                     if let Ok(show) = worktree.get_commit_show(&sha).await {
@@ -575,28 +581,98 @@ async fn apply_single_patch(
                     "status": "applied",
                     "method": "git-am"
                 }));
-                return true;
             }
             Err(e) => {
-                error!("git am failed: {}", e);
-                patch_results.push(json!({
-                    "index": p.index,
-                    "status": "error",
-                    "method": "git-am",
-                    "error": e.to_string()
-                }));
-                return false;
+                info!("git am failed, falling back to git apply: {}", e);
+                am_error = e.to_string();
             }
         }
     }
 
-    patch_results.push(json!({
-        "index": p.index,
-        "status": "error",
-        "method": "unknown",
-        "error": "Missing author or subject for am apply"
-    }));
-    false
+    if !applied_via_am {
+        match worktree.apply_raw_diff(&p.diff).await {
+            Ok(output) => {
+                let status = if output.status.success() {
+                    success = true;
+                    "applied"
+                } else {
+                    "failed"
+                };
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+                if status == "failed" {
+                    info!(
+                        "Failed to apply patch {}. stdout: {}\nstderr: {}",
+                        p.index, stdout, stderr
+                    );
+                }
+
+                patch_results.push(json!({
+                    "index": p.index,
+                    "status": status,
+                    "method": "git-apply",
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "exit_code": output.status.code(),
+                    "am_error": if !am_error.is_empty() { Some(am_error.clone()) } else { None }
+                }));
+            }
+            Err(e) => {
+                info!("Error applying patch {}: {}", p.index, e);
+                patch_results.push(json!({
+                    "index": p.index,
+                    "status": "error",
+                    "method": "git-apply",
+                    "error": e.to_string(),
+                    "am_error": if !am_error.is_empty() { Some(am_error.clone()) } else { None }
+                }));
+            }
+        }
+    }
+
+    // Reduced-context fallback: git apply -C2
+    if !applied_via_am && !success {
+        match worktree.apply_raw_diff_relaxed(&p.diff, 2).await {
+            Ok(output) => {
+                let status = if output.status.success() {
+                    success = true;
+                    "applied"
+                } else {
+                    "failed"
+                };
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+                if status == "applied" {
+                    // Replace the last failed result with the successful one
+                    patch_results.pop();
+                }
+
+                patch_results.push(json!({
+                    "index": p.index,
+                    "status": status,
+                    "method": "git-apply-C2",
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "exit_code": output.status.code(),
+                    "am_error": if !am_error.is_empty() { Some(am_error.clone()) } else { None }
+                }));
+            }
+            Err(e) => {
+                info!("Error applying patch {} with -C2: {}", p.index, e);
+                patch_results.push(json!({
+                    "index": p.index,
+                    "status": "error",
+                    "method": "git-apply-C2",
+                    "error": e.to_string(),
+                    "am_error": if !am_error.is_empty() { Some(am_error) } else { None }
+                }));
+            }
+        }
+    }
+
+    success
 }
 
 #[cfg(test)]

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -89,17 +89,30 @@ impl GitWorktree {
         let output = {
             let lock = get_worktree_lock();
             let _guard = lock.lock().await;
-            Command::new("git")
+            let out = Command::new("git")
                 .current_dir(repo_path)
                 .args(["-c", "safe.bareRepository=all"])
-                .arg("worktree")
-                .arg("add")
-                .arg("--detach")
-                .arg("--no-checkout")
+                .args(["worktree", "add", "--detach", "--no-checkout"])
                 .arg(&path)
                 .arg(commit_hash)
                 .output()
-                .await?
+                .await?;
+
+            if !out.status.success() {
+                // commit_hash may be a valid object not reachable from any
+                // named ref. git worktree add rejects such loose SHAs.
+                // Retry at HEAD; phase 2 reset --hard will reposition.
+                Command::new("git")
+                    .current_dir(repo_path)
+                    .args(["-c", "safe.bareRepository=all"])
+                    .args(["worktree", "add", "--detach", "--no-checkout"])
+                    .arg(&path)
+                    .arg("HEAD")
+                    .output()
+                    .await?
+            } else {
+                out
+            }
         };
 
         if !output.status.success() {

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -102,6 +102,11 @@ impl GitWorktree {
                 // commit_hash may be a valid object not reachable from any
                 // named ref. git worktree add rejects such loose SHAs.
                 // Retry at HEAD; phase 2 reset --hard will reposition.
+                warn!(
+                    "Worktree add failed for ref {}: {}. Retrying with HEAD.",
+                    commit_hash,
+                    String::from_utf8_lossy(&out.stderr).trim()
+                );
                 Command::new("git")
                     .current_dir(repo_path)
                     .args(["-c", "safe.bareRepository=all"])
@@ -116,10 +121,9 @@ impl GitWorktree {
         };
 
         if !output.status.success() {
-            return Err(anyhow!(
-                "Failed to create worktree: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            error!("Failed to create worktree for {}: {}", commit_hash, stderr);
+            return Err(anyhow!("Failed to create worktree: {}", stderr));
         }
 
         let output = Command::new("git")

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -188,6 +188,67 @@ impl GitWorktree {
         Ok(())
     }
 
+    #[allow(dead_code)]
+    pub async fn apply_raw_diff(&self, diff_content: &str) -> Result<std::process::Output> {
+        info!("Applying raw diff in {:?}", self.path);
+
+        let mut child = Command::new("git")
+            .current_dir(&self.path)
+            .args(["-c", "safe.bareRepository=all"])
+            .arg("apply")
+            .arg("-") // Read from stdin
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(diff_content.as_bytes()).await?;
+        }
+
+        let output = child.wait_with_output().await?;
+
+        Ok(output)
+    }
+
+    /// Apply a raw diff with reduced context matching (-C<n>).
+    /// Useful as a fallback when strict context matching fails due
+    /// to minor tree divergence from the patch's original baseline.
+    #[allow(dead_code)]
+    pub async fn apply_raw_diff_relaxed(
+        &self,
+        diff_content: &str,
+        context_lines: u32,
+    ) -> Result<std::process::Output> {
+        info!(
+            "Applying raw diff with -C{} in {:?}",
+            context_lines, self.path
+        );
+
+        let context_arg = format!("-C{}", context_lines);
+        let mut child = Command::new("git")
+            .current_dir(&self.path)
+            .args(["-c", "safe.bareRepository=all"])
+            .arg("apply")
+            .arg(&context_arg)
+            .arg("-")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(diff_content.as_bytes()).await?;
+        }
+
+        let output = child.wait_with_output().await?;
+        Ok(output)
+    }
+
     pub async fn get_commit_show(&self, hash: &str) -> Result<String> {
         let output = Command::new("git")
             .current_dir(&self.path)

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -213,14 +213,21 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
         || subject_lower.contains("(was:");
     let has_patch_tag = subject_clean.contains("patch") || subject_clean.contains("rfc");
     let has_diff = !diff.is_empty();
+    // GIT PULL requests are maintainer pull requests containing a git
+    // URL and branch, not applicable diffs. They often include inline
+    // diffstats that trigger has_diff, but should not be treated as
+    // patchsets since they cannot be applied via git am or git apply.
+    let is_git_pull = subject_clean.contains("[git pull]");
 
     // A message is part of a series if it's a cover letter (index 0) or has multiple parts (total > 1)
     let is_series_metadata = total > 1 || index == 0;
 
     // It is a patch or cover letter if:
     // 1. It is NOT a reply (Re: ...)
-    // 2. AND (It has [PATCH]/[RFC] tag OR it has a diff OR it looks like a series cover letter/part)
-    let is_patch_or_cover = !is_reply && (has_patch_tag || has_diff || is_series_metadata);
+    // 2. It is NOT a GIT PULL request
+    // 3. AND (It has [PATCH]/[RFC] tag OR it has a diff OR it looks like a series cover letter/part)
+    let is_patch_or_cover =
+        !is_reply && !is_git_pull && (has_patch_tag || has_diff || is_series_metadata);
 
     let metadata = PatchsetMetadata {
         message_id: message_id.clone(),
@@ -568,6 +575,14 @@ Body";
     #[test]
     fn test_pure_reply() {
         let raw = b"Message-ID: <abc>\r\nSubject: Re: [PATCH] fix bug\r\n\r\nLGTM";
+        let (meta, _) = parse_email(raw).unwrap();
+        assert!(!meta.is_patch_or_cover);
+    }
+
+    #[test]
+    fn test_git_pull_ignored() {
+        // GIT PULL with inline diffstat should not be treated as a patch
+        let raw = b"Message-ID: <pull-1>\r\nSubject: [GIT PULL] tracing: Fixes for 7.1\r\n\r\nPlease pull.\n\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new";
         let (meta, _) = parse_email(raw).unwrap();
         assert!(!meta.is_patch_or_cover);
     }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -16,6 +16,7 @@ use anyhow::{Result, anyhow};
 use mail_parser::{HeaderValue, MessageParser};
 use regex::Regex;
 use std::sync::OnceLock;
+use tracing::info;
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -218,6 +219,9 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
     // diffstats that trigger has_diff, but should not be treated as
     // patchsets since they cannot be applied via git am or git apply.
     let is_git_pull = subject_clean.contains("[git pull]");
+    if is_git_pull {
+        info!("Skipping [GIT PULL] message: {}", message_id);
+    }
 
     // A message is part of a series if it's a cover letter (index 0) or has multiple parts (total > 1)
     let is_series_metadata = total > 1 || index == 0;

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -912,6 +912,27 @@ impl Reviewer {
                     }
                 }
 
+                // Reduced-context fallback: git apply -C2
+                if !applied
+                    && let Ok(output) = worktree.apply_raw_diff_relaxed(diff, 2).await
+                    && output.status.success()
+                {
+                    applied = true;
+                    let _ = Command::new("git")
+                        .current_dir(&worktree.path)
+                        .args(["add", "."])
+                        .output()
+                        .await;
+                    let commit_msg = format!("{}\n\n(Applied via git apply -C2)", subject);
+                    let _ = Command::new("git")
+                        .current_dir(&worktree.path)
+                        .env("GIT_AUTHOR_NAME", author)
+                        .env("GIT_AUTHOR_EMAIL", "sashiko@localhost")
+                        .args(["commit", "-m", &commit_msg])
+                        .output()
+                        .await;
+                }
+
                 if applied {
                     if fast_path_taken {
                         patch_commits.insert(*index, msg_id.clone());

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -907,8 +907,37 @@ impl Reviewer {
                     );
 
                     // Try git am
-                    if (worktree.apply_patch(&mbox).await).is_ok() {
-                        applied = true;
+                    match worktree.apply_patch(&mbox).await {
+                        Ok(_) => applied = true,
+                        Err(e) => {
+                            warn!(
+                                "git am failed for patch {}/{} (ID: {}): {}",
+                                patchset_id, index, patch_id, e
+                            );
+                        }
+                    }
+
+                    if !applied {
+                        // Fallback raw diff
+                        if let Ok(output) = worktree.apply_raw_diff(diff).await
+                            && output.status.success()
+                        {
+                            applied = true;
+                            // Commit raw diff
+                            let _ = Command::new("git")
+                                .current_dir(&worktree.path)
+                                .args(["add", "."])
+                                .output()
+                                .await;
+                            let commit_msg = format!("{}\n\n(Applied via git apply)", subject);
+                            let _ = Command::new("git")
+                                .current_dir(&worktree.path)
+                                .env("GIT_AUTHOR_NAME", author)
+                                .env("GIT_AUTHOR_EMAIL", "sashiko@localhost")
+                                .args(["commit", "-m", &commit_msg])
+                                .output()
+                                .await;
+                        }
                     }
                 }
 
@@ -942,6 +971,10 @@ impl Reviewer {
                 } else {
                     let msg = format!(
                         "Patch {}/{} (ID: {}) failed to apply.\n",
+                        patchset_id, index, patch_id
+                    );
+                    warn!(
+                        "All apply methods failed for patch {}/{} (ID: {})",
                         patchset_id, index, patch_id
                     );
                     apply_logs.push_str(&msg);


### PR DESCRIPTION
Fix patch application failures and add diagnostics

Investigation of patchsets stuck in Failed To Apply status revealed four distinct root causes in the reviewer pipeline:

1. Patchsets with base-commit: trailers referencing subsystem tree SHAs that exist in the local object store but are not reachable from any named ref. git worktree add rejects these even though git rev-parse resolves them, causing the highest-priority baseline candidate to fail silently before any patch application is attempted.
2. Patches targeting trees that have diverged slightly from all available baselines. Both git am and git apply reject these due to strict context matching, even when the actual patch hunks are unambiguous.
3. 40 [GIT PULL] maintainer pull requests being ingested as patchsets. These contain git URLs and branches, not diffs, and always fail application. 29 were still pending review.
4. Version references like 7.1 and 7.2 extracted from subjects (e.g., "Fixes for 7.1", "sched_ext/for-7.2") producing baseline candidates for tags that don't exist yet during release candidate phases. Harmless but noisy in attempt logs.

To fix this, we employ the following:

- Worktree creation now retries at HEAD when the target SHA is unreachable from any named ref
- Added git apply -C2 as a third fallback after git am and git apply for context drift, tagged as git-apply-C2 in review metadata.
- [GIT PULL] messages are excluded from patchset classification at parse time
- Version tag baseline candidates (e.g., v7.1) are verified locally before being added, eliminating spurious resolution failures during RC phases

along with more logging on failure failure/success paths.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: derekbarbosa <derekasobrab@gmail.com>
