### PR TITLE
email: Add email policy for i3c

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -184,3 +184,8 @@ reply_all = false
 reply_to_author = false
 cc_individuals = false
 cc = ["paul@paul-moore.com"]
+
+[subsystems.i3c]
+lists = ["linux-i3c@lists.infradead.org"]
+reply_to_author = true
+cc = ["linux-i3c@lists.infradead.org", "Frank.Li@kernel.org"]


### PR DESCRIPTION
Add email policy for i3c. Alex and I think it is good to send review result to i3c list.