### PR TITLE
tests: work-around race condition in run_review_tool

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -2981,6 +2981,7 @@ echo '{"type": "ai_request", "payload": {"messages": [{"role": "user", "content"
 read -r ai_response
 echo '{"type": "ai_request", "payload": {"messages": [{"role": "user", "content": "second"}], "temperature": 0.5}}'
 read -r ai_response
+sleep 1  # make less sensitive to race condition
 echo '{"patchset_id": 1, "patches": [{"index": 1, "status": "applied"}]}'
 "#;
         std::fs::write(&bin_path, mock_script)?;


### PR DESCRIPTION
Add a small sleep to the mock review script in run_two_request_mock. This makes the tests less sensitive to the race condition described in https://github.com/sashiko-dev/sashiko/issues/245

Note that this is a hacky work-around which aims to make the tests deterministic. It's not a root-cause fix.