### PR TITLE
email: add email policy for linux-can

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -89,7 +89,8 @@ spec:
                 linux-cxl,nvdimm,linux-ide,linux-btrfs,rcu,sched-ext,oe-linux-nfc,
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
                 live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm,
-                linux-modules,nouveau,nova-gpu,ntb,selinux,linux-raid,linux-rt
+                linux-modules,nouveau,nova-gpu,ntb,selinux,linux-raid,linux-rt,
+                linux-can
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "24"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -200,3 +200,12 @@ cc = ["linux-raid@vger.kernel.org", "yukuai@fygo.io"]
 lists = ["linux-rt-devel@lists.linux.dev"]
 reply_to_author = true
 cc = ["linux-rt-devel@lists.linux.dev", "linux-kernel@vger.kernel.org"]
+
+[subsystems.linux-can]
+lists = ["linux-can@vger.kernel.org"]
+reply_to_author = true
+cc = ["Marc Kleine-Budde <mkl@pengutronix.de>",
+      "Oliver Hartkopp <socketcan@hartkopp.net>",
+      "Vincent Mailhol <mailhol@kernel.org>",
+      "Oleksij Rempel <o.rempel@pengutronix.de>",
+      "linux-can@vger.kernel.org"]


### PR DESCRIPTION
With agreement of all currently active SocketCAN maintainers, we would like to get direct sashiko feedback.