### PR TITLE
email: Add email configuration for kvmarm

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -225,3 +225,7 @@ lists = ["linux-s390@vger.kernel.org"]
 reply_to_author = true
 cc = ["linux-s390@vger.kernel.org", "Heiko Carstens <hca@linux.ibm.com>", "Vasily Gorbik <gor@linux.ibm.com>", "Alexander Gordeev <agordeev@linux.ibm.com>"]
 
+[subsystems.kvmarm]
+lists = ["kvmarm@lists.linux.dev"]
+reply_to_author = true
+cc = ["kvmarm@lists.linux.dev", "Oliver Upton <oupton@kernel.org>", "Marc Zyngier <maz@kernel.org>"]


### PR DESCRIPTION
Enable email replies for patches sent to the kvmarm mailing list. Cc the list and kvmarm maintainers.

cc:  @mzyngier