### PR TITLE
email: enable sending positive review feedback for the PCI subsystem

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -95,6 +95,7 @@ reply_all = true
 
 [subsystems.pci]
 lists = ["linux-pci@vger.kernel.org"]
+send_positive_review = true
 reply_to_author = true
 cc = ["linux-pci@vger.kernel.org"]
 


### PR DESCRIPTION
Also send a positive feedback to the users to let them know that there weren't any issues with their review.

Related:

- https://github.com/sashiko-dev/sashiko/pull/143