### PR TITLE
docker: Build with persistent cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,17 @@ COPY . .
 ## This makes the image large but ensures fast startup in Cloud Run
 #RUN wget -c https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/clone.bundle -O /usr/src/sashiko/linux-kernel.bundle
 
-# Build for release
-RUN cargo build --release
+# Build for release with persistent cache
+# Note: some Docker versions could run into bugs when a later stage accesses a
+# cached directory from previous stages, so copy the binaries into a separate
+# directory first.
+RUN --mount=type=cache,target=/usr/src/sashiko/target/ \
+    --mount=type=cache,target=/usr/local/cargo/git/db/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    cargo build --release && \
+    mkdir -p /app && \
+    cd /usr/src/sashiko/target/release/ && \
+    cp -a sashiko review sashiko-cli /app
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim
@@ -36,9 +45,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy binaries from builder
-COPY --from=builder /usr/src/sashiko/target/release/sashiko /usr/local/bin/sashiko
-COPY --from=builder /usr/src/sashiko/target/release/review /usr/local/bin/review
-COPY --from=builder /usr/src/sashiko/target/release/sashiko-cli /usr/local/bin/sashiko-cli
+COPY --from=builder /app /usr/local/bin
 
 ## Copy the pre-downloaded kernel bundle
 #COPY --from=builder /usr/src/sashiko/linux-kernel.bundle /opt/linux-kernel.bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build
 FROM rust:1.90-bookworm AS builder
 
+# Install clippy and rustfmt first to allow the persistent cache to cover them
+RUN rustup component add clippy rustfmt
+
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
     clang \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.88-bookworm AS builder
+FROM rust:1.90-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Cache downloaded and generated files with `RUN --mount=type=cache`, so that later builds don't need to download and build everything from scratch.

Some Docker versions could run into bugs when a later stage accesses a cached directory from previous stages, so copy the binaries into a separate directory first. Doing so also allows Stage 2 to merge multiple `COPY --from=builder` steps into a single one.

This series also bumps rust image version to 1.90, otherwise it keeps downloading 1.90 according to `rust-toolchain.toml`.

Link: https://docs.docker.com/build/cache/optimize/#use-cache-mounts