### PR TITLE
email: Add the LSM mailing list

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -90,7 +90,7 @@ spec:
                 batman,linux-s390,linux-devicetree,imx,linux-sunxi,linux-amlogic,
                 live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm,
                 linux-modules,nouveau,nova-gpu,ntb,selinux,linux-raid,linux-rt,
-                linux-can,linux-target,linux-hardening
+                linux-can,linux-target,linux-hardening,linux-security-module
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "24"
             - name: SASHIKO__SMTP__SENDER_ADDRESS

--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -230,3 +230,9 @@ cc = ["linux-s390@vger.kernel.org", "Heiko Carstens <hca@linux.ibm.com>", "Vasil
 lists = ["kvmarm@lists.linux.dev"]
 reply_to_author = true
 cc = ["kvmarm@lists.linux.dev", "Oliver Upton <oupton@kernel.org>", "Marc Zyngier <maz@kernel.org>"]
+
+[subsystems.linux-security-module]
+lists = ["linux-security-module@vger.kernel.org"]
+send_positive_review = true
+reply_to_author = true
+cc = ["linux-security-module@vger.kernel.org"]


### PR DESCRIPTION
Enable emails replies for patches sent to the Linux Security Module mailing list.

See https://lore.kernel.org/linux-security-module/20260615.zeinurej8oZ9@digikod.net/