### PR TITLE
terminate Sashiko early when HEAD commit hash not found

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -913,11 +913,16 @@ impl Reviewer {
                 }
 
                 if applied {
-                    if fast_path_taken {
-                        patch_commits.insert(*index, msg_id.clone());
-                    } else if let Ok(sha) = get_commit_hash(&worktree.path, "HEAD").await {
-                        patch_commits.insert(*index, sha);
-                    }
+                    let sha = if fast_path_taken {
+                        msg_id.clone()
+                    } else {
+                        get_commit_hash(&worktree.path, "HEAD")
+                            .await
+                            .unwrap_or_else(|e| {
+                                panic!("No commit hash for HEAD in {:?}: {:?}", worktree.path, e)
+                            })
+                    };
+                    patch_commits.insert(*index, sha);
                 } else {
                     let msg = format!(
                         "Patch {}/{} (ID: {}) failed to apply.\n",


### PR DESCRIPTION
We expect to be always able to retrieve the HEAD commit hash. Reports from the field suggest that this is not always the case. We do not yet understand the root cause.

Failure to retrieve the commit hash results in deadlocks, which prevent patches from completing review.

Take a leaf out of The Pragmatic Programmer's "Dead Software tells no lies" and terminate early when the unexpected happens.

Pros:
- failing reviews are retried after Sashiko restarts (instead of deadlocked)
- the termination log allows us to learn why the unexpected happened

Cons:
- if not intermittent, failing reviews may be retried forever

See #248