### PR TITLE
email: Update policy for SELinux

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -191,10 +191,11 @@ cc = ["ntb@lists.linux.dev"]
 
 [subsystems.selinux]
 lists = ["selinux@vger.kernel.org"]
+send_positive_review = true
 reply_all = false
 reply_to_author = false
 cc_individuals = false
-cc = ["paul@paul-moore.com"]
+cc = ["selinux@vger.kernel.org"]
 
 [subsystems.i3c]
 lists = ["linux-i3c@lists.infradead.org"]


### PR DESCRIPTION
Now that we have some experience with Sashiko, enable positive reports as well as sending all reports to the mailing list for easier review by a wider audience.