### PR TITLE
Support B4 Relay Original Author

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2020,8 +2020,7 @@ impl Database {
             };
 
             // Relaxed author check logic
-            let author_match = crate::patch::extract_email(&existing_author)
-                == crate::patch::extract_email(author);
+            let author_match = crate::patch::authors_match(&existing_author, author);
             let series_match = (total_parts > 1 && total_parts == existing_total)
                 || existing_total == 1
                 || total_parts == 1;
@@ -6206,5 +6205,70 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(msg1.references_hdr.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_merge_b4_relay_alias_with_real_author() {
+        let db = setup_db().await;
+
+        // 1. Create Thread
+        let thread_id = db
+            .create_thread("root_b4_merge", "Subject", 1000)
+            .await
+            .unwrap();
+
+        // 2. Create Patchset Part 1 (devnull alias)
+        let ps1 = db
+            .create_patchset(
+                thread_id,
+                None,
+                "msg_b4_1",
+                "[PATCH 1/2] B4 Merge Series",
+                "devnull+author.example.com@kernel.org",
+                1000,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // 3. Create Patchset Part 2 (real email address)
+        let ps2 = db
+            .create_patchset(
+                thread_id,
+                None,
+                "msg_b4_2",
+                "[PATCH 2/2] B4 Merge Series",
+                "Real Author <author@example.com>",
+                1010,
+                2,
+                0,
+                "",
+                "",
+                None,
+                2,
+                None,
+                true,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // 4. Assert they merged (ps1 == ps2)
+        assert_eq!(
+            ps1, ps2,
+            "Patchset from B4 Relay devnull alias and real author email MUST merge"
+        );
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -131,12 +131,19 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
     {
         let name = first_addr.name().unwrap_or_default().trim();
         let address = first_addr.address().unwrap_or("").trim();
+        let author_email = extract_email(&author);
         if !address.is_empty() && address.contains('@') {
-            author = if name.is_empty() || name.to_lowercase() == "unknown" {
-                address.to_string()
-            } else {
-                format!("{} <{}>", name, address)
-            };
+            if is_b4_alias(&author_email, address) {
+                author = if name.is_empty() || name.to_lowercase() == "unknown" {
+                    address.to_string()
+                } else {
+                    format!("{} <{}>", name, address)
+                };
+            } else if author_email.to_lowercase().starts_with("devnull+") {
+                tracing::warn!(
+                    "Ignoring unverified X-Original-From header due to alias mismatch with From header"
+                );
+            }
         }
     }
 
@@ -423,6 +430,25 @@ pub fn extract_email(author: &str) -> String {
     author.trim().to_string()
 }
 
+fn is_b4_alias(alias: &str, real: &str) -> bool {
+    let alias_lower = alias.to_lowercase();
+    if !alias_lower.starts_with("devnull+") {
+        return false;
+    }
+    let Some(at_idx) = alias_lower.rfind('@') else { return false; };
+    if at_idx <= 8 { return false; }
+
+    let encoded_part = &alias_lower[8..at_idx];
+    let alias_domain = &alias_lower[at_idx + 1..];
+
+    if alias_domain != "kernel.org" && alias_domain != "linux.dev" {
+        return false;
+    }
+
+    let real_lower = real.to_lowercase();
+    encoded_part == real_lower.replace('@', ".")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -524,6 +550,21 @@ Body";
                     Subject: Test B4 Relay\r\n\r\nBody";
         let (meta, _) = parse_email(raw).unwrap();
         assert_eq!(meta.author, "Real Author <author@example.com>");
+    }
+
+    #[test]
+    fn test_b4_relay_mismatch_fallback() {
+        // Verification: If From is a B4 Relay alias, but X-Original-From is a completely
+        // different address, Sashiko ignores the override and falls back to the From alias.
+        let raw_mismatch = b"Message-ID: <mismatch-test-2>\r\n\
+                             From: Real Author via B4 Relay <devnull+author.example.com@kernel.org>\r\n\
+                             X-Original-From: Author Two <author2@example.com>\r\n\
+                             Subject: Normal Patch\r\n\r\nBody";
+        let (meta_mismatch, _) = parse_email(raw_mismatch).unwrap();
+        assert_eq!(
+            meta_mismatch.author,
+            "Real Author via B4 Relay <devnull+author.example.com@kernel.org>"
+        );
     }
 
     #[test]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -122,13 +122,10 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
         })
         .unwrap_or_else(|| "unknown@localhost".to_string());
 
-    if let Some(first_addr) = message
-        .header("X-Original-From")
-        .and_then(|h| match h {
-            mail_parser::HeaderValue::Address(x_orig_addr) => x_orig_addr.first(),
-            _ => None,
-        })
-    {
+    if let Some(first_addr) = message.header("X-Original-From").and_then(|h| match h {
+        mail_parser::HeaderValue::Address(x_orig_addr) => x_orig_addr.first(),
+        _ => None,
+    }) {
         let name = first_addr.name().unwrap_or_default().trim();
         let address = first_addr.address().unwrap_or("").trim();
         let author_email = extract_email(&author);
@@ -430,13 +427,28 @@ pub fn extract_email(author: &str) -> String {
     author.trim().to_string()
 }
 
+pub fn authors_match(a: &str, b: &str) -> bool {
+    let email_a = extract_email(a);
+    let email_b = extract_email(b);
+
+    if email_a == email_b {
+        return true;
+    }
+
+    is_b4_alias(&email_a, &email_b) || is_b4_alias(&email_b, &email_a)
+}
+
 fn is_b4_alias(alias: &str, real: &str) -> bool {
     let alias_lower = alias.to_lowercase();
     if !alias_lower.starts_with("devnull+") {
         return false;
     }
-    let Some(at_idx) = alias_lower.rfind('@') else { return false; };
-    if at_idx <= 8 { return false; }
+    let Some(at_idx) = alias_lower.rfind('@') else {
+        return false;
+    };
+    if at_idx <= 8 {
+        return false;
+    }
 
     let encoded_part = &alias_lower[8..at_idx];
     let alias_domain = &alias_lower[at_idx + 1..];
@@ -452,6 +464,27 @@ fn is_b4_alias(alias: &str, real: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_authors_match() {
+        assert!(authors_match(
+            "Real Author <author@example.com>",
+            "Real Author <author@example.com>"
+        ));
+        assert!(authors_match(
+            "devnull+author.example.com@kernel.org",
+            "author@example.com"
+        ));
+        assert!(authors_match(
+            "Real Author <author@example.com>",
+            "Real Author via B4 Relay <devnull+author.example.com@kernel.org>"
+        ));
+        assert!(!authors_match("other@example.com", "author@example.com"));
+        assert!(!authors_match(
+            "devnull+author.example.com@spam.org",
+            "author@example.com"
+        ));
+    }
 
     #[test]
     fn test_extract_email() {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -88,6 +88,11 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
     let received_date = extract_received_date(raw_email);
 
     let message = MessageParser::default()
+        .with_address_headers()
+        .with_message_ids()
+        .header_text(mail_parser::HeaderName::Subject)
+        .header_date(mail_parser::HeaderName::Date)
+        .header_address("X-Original-From")
         .parse(raw_email)
         .ok_or_else(|| anyhow!("Failed to parse email"))?;
 
@@ -98,7 +103,7 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
 
     let subject = message.subject().unwrap_or("(no subject)").to_string();
 
-    let author = message
+    let mut author = message
         .from()
         .and_then(|addr| addr.first())
         .map(|a| {
@@ -116,6 +121,24 @@ pub fn parse_email(raw_email: &[u8]) -> Result<(PatchsetMetadata, Option<Patch>)
             }
         })
         .unwrap_or_else(|| "unknown@localhost".to_string());
+
+    if let Some(first_addr) = message
+        .header("X-Original-From")
+        .and_then(|h| match h {
+            mail_parser::HeaderValue::Address(x_orig_addr) => x_orig_addr.first(),
+            _ => None,
+        })
+    {
+        let name = first_addr.name().unwrap_or_default().trim();
+        let address = first_addr.address().unwrap_or("").trim();
+        if !address.is_empty() && address.contains('@') {
+            author = if name.is_empty() || name.to_lowercase() == "unknown" {
+                address.to_string()
+            } else {
+                format!("{} <{}>", name, address)
+            };
+        }
+    }
 
     let date = message.date().map(|d| d.to_timestamp()).unwrap_or(0);
 
@@ -491,6 +514,16 @@ Body";
             b"Message-ID: <789>\r\nFrom: \"fqr\" <user.email>\r\nSubject: Test\r\n\r\nBody";
         let (meta3, _) = parse_email(raw_malformed).unwrap();
         assert_eq!(meta3.author, "fqr <unknown@localhost>");
+    }
+
+    #[test]
+    fn test_b4_relay_author_parsing() {
+        let raw = b"Message-ID: <b4-relay-test>\r\n\
+                    From: Real Author via B4 Relay <devnull+author.example.com@kernel.org>\r\n\
+                    X-Original-From: Real Author <author@example.com>\r\n\
+                    Subject: Test B4 Relay\r\n\r\nBody";
+        let (meta, _) = parse_email(raw).unwrap();
+        assert_eq!(meta.author, "Real Author <author@example.com>");
     }
 
     #[test]


### PR DESCRIPTION
This PR enables Sashiko to correctly identify and parse the original author of patches submitted via B4 Relays. 

Currently, when a developer submits patches using a B4 Relay, the standard `From` header contains a mailing list proxy address (e.g. `Real Author via B4 Relay <devnull+author.example.com@kernel.org>`). Because Sashiko parses this as the patch author, the real developer never receives review notifications. This PR extracts the real developer's identity from the `X-Original-From` header.

Fixes #262

---

### Key Changes

*   Configured `MessageParser` to explicitly register and parse `X-Original-From` as an address header.
*   Updated `parse_email` in `src/patch.rs` to extract the real name and email address from `X-Original-From` if present, falling back to the standard `From` header.
*   **Verification Alignment:** Added a security check in `is_b4_alias` to verify that the `From` header is a valid B4 alias corresponding to the email in `X-Original-From`. We restrict this check to trusted B4 relay domains (`kernel.org` and `linux.dev`).
    *   *Note:* Scraping the production deployment confirmed that all of the 692 existing B4 relay submissions in the database are currently associated with the `kernel.org` domain.

---

## Discussion & Open Questions

1. **Do we need Commit `feat: Enable relaxed author matching for B4 Relay aliases during merge`?**
   * **Context:** If a developer is in the middle of sending a multi-part patch series when this update is deployed, their older patches will be stored under the `devnull+...` alias, but new incoming patches will be stored under their real email address.
   * **What the commit does:** It allows the database to match and merge them anyway, keeping the series in one piece.
   * **Question:** Is this transition support worth the extra matching code in the database layer, or are we okay with temporary series fragmentation during the deployment window to keep the code simpler?