### PR TITLE
Revert "email: add policy for the RTC subsystem"

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -256,8 +256,3 @@ reply_to_author = true
 send_positive_review = true
 cc = ["linux-leds@vger.kernel.org", "lee@kernel.org"]
 
-[subsystems.rtc]
-lists = ["linux-rtc@vger.kernel.org"]
-reply_to_author = true
-send_positive_review = true
-cc = ["linux-rtc@vger.kernel.org", "Alexandre Belloni <alexandre.belloni@bootlin.com>"]


### PR DESCRIPTION
Reverts sashiko-dev/sashiko#297 because of the missing SOB line