### PR TITLE
fix(review): Fix passing --repo from `sashiko local` command

### DIFF
--- a/src/bin/review.rs
+++ b/src/bin/review.rs
@@ -40,6 +40,10 @@ struct Args {
     #[arg(long)]
     baseline: Option<String>,
 
+    /// Path to the git repository. Overrides settings.
+    #[arg(long)]
+    repo: Option<PathBuf>,
+
     /// Parent directory for creating worktrees.
     #[arg(long)]
     worktree_dir: Option<PathBuf>,
@@ -123,7 +127,10 @@ async fn main() -> Result<()> {
     );
     let (patchset_id, subject, patches) = (input.id, input.subject, input.patches);
     let baseline_arg = args.baseline.clone().unwrap_or_else(|| "HEAD".to_string());
-    let repo_path = PathBuf::from(&settings.git.repository_path);
+    let repo_path = args
+        .repo
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(&settings.git.repository_path));
 
     let run_logic = async {
         info!("Resolving baseline: {}", baseline_arg);

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -1551,7 +1551,12 @@ async fn handle_local(
             format!("{}^", first_sha)
         };
 
-        let mut args = vec!["--baseline".to_string(), baseline_ref];
+        let mut args = vec![
+            "--baseline".to_string(),
+            baseline_ref,
+            "--repo".to_string(),
+            repo_path.to_string_lossy().to_string(),
+        ];
 
         if no_ai {
             args.push("--no-ai".to_string());


### PR DESCRIPTION
The `sashiko local` command uses the passed repo in its own code, e.g. to resolve commits, but then doesn't pass the repo through to the review subprocess. This means if the repo in your Settings.toml doesn't match the --repo arg you will get confusing errors as it fails to identify your commit messages.