### PR TITLE
skills: enhance review-pr skill with regression and security checks

### DIFF
--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -17,16 +17,16 @@ When asked to perform a code review, follow these steps strictly:
 ### 2. Analysis
 Perform a deep, scrutinizing code review of the target code against the gathered context. Evaluate for:
 - **Design Alignment:** Does the implementation match the intent described in the design documents?
-- **Safety:** Are there any risky operations (e.g., unchecked unwraps, poor error handling, thread safety issues, SQL injection risks)?
+- **Safety & Security:** Are there any risky operations (e.g., unchecked unwraps, poor error handling, thread safety issues, SQL injection risks, insecure dependency usage, or credential leakage)?
+- **Regression Analysis:** Assess if the changes could break existing functionality. Check for impacts on related modules, performance regressions, or unintended side effects in shared components.
 - **Idiomatic Conventions:** Does the code use the language idiomatic patterns and the project-specific coding standards defined in `GEMINI.md`?
 - **SOLID/DRY Principles:** Reference [references/principles.md](references/principles.md) and evaluate the code for adherence to SOLID and DRY principles within the Rust context.
-- **Clone Discipline:** If the code calls `.clone()` on expensive-to-clone structures, reference
-[references/clone-discipline.md](references/clone-discipline.md) and evaluate the code for adherence to clone discipline.
 - **Test Coverage:** Are unit or integration tests missing for new logic?
 
 ### 3. Reporting
 Output your findings in a structured, categorized markdown format. Use the following emoji prefixes for each finding to indicate severity/type:
-- 🔴 **Safety / Bugs:** Broken behavior, potential crashes, security risks, or unhandled errors.
+- 🔴 **Safety / Bugs / Security:** Broken behavior, potential crashes, security risks, or unhandled errors.
+- 🟠 **Regressions:** Potential to break existing functionality or introduce performance bottlenecks.
 - 🟡 **Complexity / Logic / SOLID:** High cyclomatic complexity, functions that are too long, risky architectural choices, or violations of SOLID principles.
 - 🔵 **Style / Nits / DRY:** Style violations, naming issues, duplicated code (DRY violations), or minor optimizations.
 - 🟢 **Design Alignment:** Noting where the code successfully or unsuccessfully aligns with the mapped design documents.


### PR DESCRIPTION
Update the review-pr skill to evaluate potential regressions in existing functionality and identify security concerns like SQL injection and credential leakage. Introduce a new severity category for regressions to improve code review granularity as per https://github.com/sashiko-dev/sashiko/pull/310#issuecomment-4918855064

Suggested-by: Roman Gushchin <roman.gushchin@linux.dev>