### PR TITLE
baseline: use mainline remote-tracking ref instead of HEAD

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -132,6 +132,16 @@ impl BaselineRegistry {
         })
     }
 
+    /// Name of the identified mainline remote (Linus tree or origin), for
+    /// use as a git fetch target. Falls back to "origin" when none was
+    /// identified.
+    pub fn mainline_remote_name(&self) -> &str {
+        self.mainline_remote
+            .as_ref()
+            .map(|(_, name)| name.as_str())
+            .unwrap_or("origin")
+    }
+
     fn read_file_from_git(repo_path: &Path, rev: &str, file_path: &str) -> Result<String> {
         use std::process::Command;
         let output = Command::new("git")

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -58,6 +58,7 @@ pub struct BaselineRegistry {
     remote_map: HashMap<String, String>, // URL -> Local Remote Name
     pub custom_remotes: Option<Vec<CustomRemoteSettings>>,
     pub repo_path: std::path::PathBuf,
+    mainline_remote: Option<(String, String)>, // (URL, local remote name)
 }
 
 impl BaselineRegistry {
@@ -67,14 +68,29 @@ impl BaselineRegistry {
     ) -> Result<Self> {
         let remote_map = Self::load_git_remotes(repo_path).unwrap_or_default();
 
-        // Identify Linus's tree
-        let linus_remote = remote_map
+        // Identify Linus's tree by URL, falling back to whatever is named "origin".
+        let mainline_remote = remote_map
             .iter()
             .find(|(url, _)| url.contains("torvalds/linux.git"))
+            .or_else(|| {
+                remote_map
+                    .iter()
+                    .filter(|(_, name)| name.as_str() == "origin")
+                    .find(|(url, _)| url.ends_with(".git"))
+                    .or_else(|| {
+                        remote_map
+                            .iter()
+                            .find(|(_, name)| name.as_str() == "origin")
+                    })
+            })
+            .map(|(url, name)| (url.clone(), name.clone()));
+
+        let mainline_name = mainline_remote
+            .as_ref()
             .map(|(_, name)| name.as_str())
             .unwrap_or("origin");
 
-        let ref_name = format!("{}/master", linus_remote);
+        let ref_name = format!("{}/master", mainline_name);
         info!(
             "Attempting to load MAINTAINERS from {}:MAINTAINERS",
             ref_name
@@ -112,6 +128,7 @@ impl BaselineRegistry {
             remote_map,
             custom_remotes,
             repo_path: repo_path.to_path_buf(),
+            mainline_remote,
         })
     }
 
@@ -262,11 +279,20 @@ impl BaselineRegistry {
         let linux_next_url = "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git";
         candidates.push(self.resolve_url(linux_next_url, None));
 
-        // 4. Mainline (Local Origin/Master or HEAD)
-        // We assume 'origin' is mainline if available, or just HEAD.
-        // Or if we can find 'torvalds/linux.git' in remote map.
-        // For simplicity: HEAD.
-        candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
+        // 4. Mainline
+        // Use the identified mainline remote (Linus tree or origin) as a
+        // RemoteTarget so that ensure_remote fetches it before use. A bare
+        // LocalRef("HEAD") would resolve to the local checkout, which nothing
+        // in Sashiko ever advances after fetching.
+        if let Some((url, name)) = &self.mainline_remote {
+            candidates.push(BaselineResolution::RemoteTarget {
+                url: url.clone(),
+                name: name.clone(),
+                branch: Some("master".to_string()),
+            });
+        } else {
+            candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
+        }
 
         // 5. Custom Remotes
         if let Some(custom_remotes) = &self.custom_remotes {
@@ -574,6 +600,7 @@ mod tests {
             remote_map,
             custom_remotes: None,
             repo_path: std::path::PathBuf::from("."),
+            mainline_remote: None,
         }
     }
 
@@ -598,6 +625,64 @@ mod tests {
             BaselineResolution::RemoteTarget { name, .. } => assert_eq!(name, "net-next"),
             _ => panic!("Expected RemoteTarget net-next"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_mainline_remote_used_instead_of_head() {
+        let mut remote_map = HashMap::new();
+        remote_map.insert(
+            "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git".to_string(),
+            "origin".to_string(),
+        );
+        let registry = BaselineRegistry {
+            entries: Vec::new(),
+            remote_map,
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
+            mainline_remote: Some((
+                "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git".to_string(),
+                "origin".to_string(),
+            )),
+        };
+
+        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+
+        // The last candidate before custom remotes should be a RemoteTarget
+        // for origin/master, not a LocalRef("HEAD").
+        let mainline = candidates.iter().find(|c| match c {
+            BaselineResolution::RemoteTarget { name, branch, .. } => {
+                name == "origin" && branch.as_deref() == Some("master")
+            }
+            _ => false,
+        });
+        assert!(mainline.is_some(), "Expected RemoteTarget origin/master");
+
+        // No LocalRef("HEAD") should be present.
+        let has_head = candidates
+            .iter()
+            .any(|c| matches!(c, BaselineResolution::LocalRef(r) if r == "HEAD"));
+        assert!(
+            !has_head,
+            "LocalRef(HEAD) should not be emitted when mainline_remote is set"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_head_fallback_without_mainline_remote() {
+        let registry = BaselineRegistry {
+            entries: Vec::new(),
+            remote_map: HashMap::new(),
+            custom_remotes: None,
+            repo_path: std::path::PathBuf::from("."),
+            mainline_remote: None,
+        };
+
+        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+
+        let has_head = candidates
+            .iter()
+            .any(|c| matches!(c, BaselineResolution::LocalRef(r) if r == "HEAD"));
+        assert!(has_head, "LocalRef(HEAD) should be present as fallback");
     }
 
     #[test]
@@ -638,6 +723,7 @@ F: patterns/
             remote_map,
             custom_remotes: None,
             repo_path: std::path::PathBuf::from("."),
+            mainline_remote: None,
         };
 
         let files = vec!["mm/memory.c".to_string()];
@@ -705,6 +791,7 @@ F: patterns/
             remote_map,
             custom_remotes: None,
             repo_path: std::path::PathBuf::from("."),
+            mainline_remote: None,
         };
 
         let files = vec!["tools/perf/builtin-report.c".to_string()];
@@ -750,6 +837,7 @@ F: patterns/
             remote_map,
             custom_remotes: None,
             repo_path: std::path::PathBuf::from("."),
+            mainline_remote: None,
         };
 
         let files = vec!["net/core.c".to_string()];
@@ -816,6 +904,7 @@ F: patterns/
                 only_branches: Some(vec!["master".to_string()]),
             }]),
             repo_path: repo_path.to_path_buf(),
+            mainline_remote: None,
         };
 
         let candidates = registry.resolve_candidates(&[], "Subject", None).await;

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -775,10 +775,11 @@ impl Reviewer {
                 Ok(sha) => sha,
                 Err(e) => {
                     if let BaselineResolution::Commit(sha_str) = candidate {
-                        // Attempt to fetch the missing commit from origin
+                        // Attempt to fetch the missing commit from the
+                        // mainline remote.
                         let _ = Command::new("git")
                             .current_dir(&repo_path)
-                            .args(["fetch", "origin", sha_str])
+                            .args(["fetch", mainline_remote, sha_str])
                             .output()
                             .await;
                         // Retry resolving

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -747,6 +747,7 @@ impl Reviewer {
     ) {
         let mut attempts: Vec<BaselineAttempt> = Vec::new();
         let repo_path = PathBuf::from(&ctx.settings.git.repository_path);
+        let mainline_remote = ctx.baseline_registry.mainline_remote_name();
         let mut tested_shas = std::collections::HashSet::new();
 
         for candidate in candidates {
@@ -783,18 +784,33 @@ impl Reviewer {
                         // Retry resolving
                         match get_commit_hash(&repo_path, &baseline_ref).await {
                             Ok(sha) => sha,
-                            Err(e2) => {
-                                let msg = format!(
-                                    "Failed to resolve baseline ref {}: {}\n",
-                                    baseline_ref, e2
-                                );
-                                current_log.push_str(&msg);
-                                attempts.push(BaselineAttempt {
-                                    baseline: baseline_ref.clone(),
-                                    status: current_status,
-                                    log: current_log,
-                                });
-                                continue;
+                            Err(_) => {
+                                // b4 can emit annotated tag object SHAs as
+                                // base-commit (e.g. the tag object for
+                                // v7.2-rc2). Those aren't fetchable by SHA,
+                                // so pull tags from the mainline remote and
+                                // retry.
+                                let _ = Command::new("git")
+                                    .current_dir(&repo_path)
+                                    .args(["fetch", mainline_remote, "--tags"])
+                                    .output()
+                                    .await;
+                                match get_commit_hash(&repo_path, &baseline_ref).await {
+                                    Ok(sha) => sha,
+                                    Err(e2) => {
+                                        let msg = format!(
+                                            "Failed to resolve baseline ref {}: {}\n",
+                                            baseline_ref, e2
+                                        );
+                                        current_log.push_str(&msg);
+                                        attempts.push(BaselineAttempt {
+                                            baseline: baseline_ref.clone(),
+                                            status: current_status,
+                                            log: current_log,
+                                        });
+                                        continue;
+                                    }
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
The mainline fallback candidate in baseline resolution was `LocalRef("HEAD")`, which resolves to whatever the local repo has checked out. Nothing in Sashiko advances the local `HEAD` after fetching: `GitSyncWorker` updates remote-tracking refs (`origin/master`) but never the local checkout. So `HEAD` drifts behind `origin/master` indefinitely.

Additionally, `ensure_remote` fetches with `--no-tags`, so annotated tag objects are never available locally. b4 can emit annotated tag object SHAs as the `base-commit` header (the tag object rather than the commit it points to), and these are not fetchable by SHA either.

**Trigger:** Mark Brown's [KVM/arm64 SME v11 series](https://lore.kernel.org/all/20260709-kvm-arm64-sme-v11-0-32799f66db9d@kernel.org/) included `base-commit: 4c45e14df2f4e77982ad70d6d8e3fe750edd4c37`, which is the annotated tag object for `v7.2-rc2`. Sashiko could not resolve it for two reasons: the tag object was never fetched (`--no-tags`), and the fallback to `HEAD` resolved to a stale commit well behind `origin/master`. The series applies cleanly to v7.2-rc2, but Sashiko [failed to apply it](https://sashiko.dev/#/log/baseline/42725/7) and [did not produce a review](https://sashiko.dev/#/patchset/20260709-kvm-arm64-sme-v11-0-32799f66db9d%40kernel.org).

**Fixes:**

1. **Use mainline remote-tracking ref instead of HEAD.** Store the identified mainline remote (Linus tree or `origin`) in `BaselineRegistry` and emit it as a `RemoteTarget` instead of `LocalRef("HEAD")`. This causes `ensure_remote` to fetch the remote if stale, and resolves the ref to the remote-tracking branch (e.g. `origin/master`) rather than the local checkout. Falls back to `LocalRef("HEAD")` when no mainline remote can be identified.

2. **Fetch tags when base-commit SHA is unresolvable.** When the direct `git fetch <sha>` recovery fails to resolve a `Commit` baseline, fetch tags from the mainline remote (`git fetch <remote> --tags`) and retry. This handles the b4 case where `base-commit` is a tag object SHA. Tags are fetched from the mainline remote that `BaselineRegistry` already identifies, so it does not assume the remote is named `origin`, and it keeps the tag namespace clean rather than pulling every subsystem tree's tags. Only fires in the already-failing recovery path.

3. **Fetch the missing base commit from the mainline remote.** The pre-existing direct base-commit recovery fetched from a hardcoded `origin`. The mainline remote is not always named `origin` (it may be Linus's tree under a different name), in which case the fetch targeted the wrong remote and silently failed. Use the identified mainline remote, matching the tag-fetch recovery.
