### PR TITLE
git_ops: make git_status independent of user config

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -899,9 +899,11 @@ pub async fn get_git_log(params: GitLogParams) -> Result<String> {
 }
 
 pub async fn git_status(repo_path: &Path) -> Result<String> {
+    // Force --untracked-files=normal so the output does not depend on a
+    // user's global status.showUntrackedFiles setting.
     let output = Command::new("git")
         .current_dir(repo_path)
-        .args(["status"])
+        .args(["status", "--untracked-files=normal"])
         .output()
         .await?;
 


### PR DESCRIPTION
`git_status` shells out to a bare `git status`, whose output wording
depends on the ambient `status.showUntrackedFiles` setting. On a host
where a user has set `status.showUntrackedFiles = no` in their global
config, a clean tree reports:

```
nothing to commit (use -u to show untracked files)
```

instead of:

```
nothing to commit, working tree clean
```

This makes `test_git_ops_extensions` fail on such hosts, since it
asserts on the "working tree clean" wording.

Pass `--untracked-files=normal` so the command's output is deterministic
regardless of the user's global git configuration.