### PR TITLE
prompts: add fuse subsystem guide

### DIFF
--- a/third_party/prompts/kernel/subsystem/fuse.md
+++ b/third_party/prompts/kernel/subsystem/fuse.md
@@ -1,0 +1,24 @@
+# FUSE Subsystem Details
+
+## io-uring ring pointer access
+
+`fch->ring` is published with `smp_store_release()` after the ring's fields
+have been initialized. `smp_load_acquire()` is not necessary since readers
+only dereference through the pointer, so READ_ONCE() is sufficient for any
+lockless reads that can concurrently race with the publish.
+
+**Not a bug**: a lockless reader of `fch->ring` using `READ_ONCE()` instead of
+`smp_load_acquire()`.
+
+## io-uring SQE data stability
+
+fuse reads the submission queue entry through the ->uring_cmd handler.
+`fuse_uring_cmd()` uses `io_uring_sqe128_cmd(cmd->sqe, ...)` and
+`READ_ONCE(cmd->sqe->...)` to access the sqe fields. This is correct and how
+uring_cmd handlers should be accessing the sqe fields.
+
+**Not a bug**: reading `cmd->sqe` fields at issue time instead of caching the
+sqe's fields at prep time. `uring_cmd` has no `->prep()` and does not need
+one, since the SQE is stable at issue time (the first issue runs while the
+ring slot is valid and io_uring copies the whole SQE before any async
+retries).

--- a/third_party/prompts/kernel/subsystem/subsystem.md
+++ b/third_party/prompts/kernel/subsystem/subsystem.md
@@ -47,6 +47,7 @@ and symbols regexes.
 | NFSD | fs/nfsd/*, fs/lockd/* | nfsd.md |
 | SunRPC | net/sunrpc/* | sunrpc.md |
 | io_uring | io_uring/, io_uring_, io_ring_, io_sq_, io_cq_, io_wq_, IORING_ | io_uring.md |
+| FUSE | fs/fuse/, fuse_uring_, fuse_chan_, fuse_dev_, FUSE_IO_URING, FUSE_OVER_IO_URING | fuse.md |
 | Cleanup API | `__free`, `guard(`, `scoped_guard`, `DEFINE_FREE`, `DEFINE_GUARD`, `no_free_ptr`, `return_ptr` | cleanup.md |
 | RCU lifecycle | `call_rcu(`, `kfree_rcu(`, `synchronize_rcu(`, `rhashtable_*` + `call_rcu`, `hlist_del_rcu` + `call_rcu`, `list_del_rcu` + `call_rcu` | rcu.md |
 | Power Domains | drivers/pmdomain/, pm_genpd_, of_genpd_, exynos_pd_ | pmdomain.md |


### PR DESCRIPTION
Add a new guide for the fuse subsystem. Document two patterns in the fuse io-uring code that are correct but getting flagged as bugs by Sashiko. Also register the fuse guide in the subsystem index.

Signed-off-by: Joanne Koong <joannelkoong@gmail.com>