### PR TITLE
docs: clarify [subsystems] configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ setting, see the [Configuration Reference](docs/configuration.md). The default `
 *   **Server**: API server host and port.
 *   **Git**: Path to the reference kernel repository.
 *   **Review**: Concurrency and worktree settings.
-    *   **Forge** *(Experimental)*: GitHub/GitLab webhook integration (optional, unsupported). See forge setup guides below.
+*   **Forge** *(Experimental)*: GitHub/GitLab webhook integration (optional, unsupported). See forge setup guides below.
         *   When enabling `[forge]`, the NNTP (mailing list) ingestor is disabled by default. If you need to monitor both, set `disable_nntp = false` in the `[forge]` section of your config.
-    *   **Subsystems**: Map file patterns to subsystems for targeted reviews (optional).
+*   **Subsystems**: Map file patterns to subsystems for targeted reviews (optional). Works with both mailing lists (recipient matching) and git forges (file path matching).
 
 #### Configuring the LLM Provider
 

--- a/docs/FORGE_SETUP.md
+++ b/docs/FORGE_SETUP.md
@@ -116,7 +116,7 @@ enabled = true
 # Set to 'false' if you need to monitor both mailing lists and forges.
 disable_nntp = true
 
-# Optional: Configure subsystem mapping for targeted reviews
+# Global Config: Map file paths to subsystems for targeted reviews (Optional)
 [subsystems]
 mapping = [
     { pattern = ".*drivers/.*", name = "Drivers" },

--- a/docs/GITLAB_SETUP.md
+++ b/docs/GITLAB_SETUP.md
@@ -68,7 +68,7 @@ Edit `Settings.toml`:
 enabled = true
 
 [subsystems]
-# Optional: Map file paths to subsystems
+# Global Config: Map file paths to subsystems for targeted reviews (Optional)
 mapping = [
     { pattern = ".*drivers/.*", name = "Drivers" },
     { pattern = ".*net/.*", name = "Networking" },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,36 @@ Optional array of additional git remotes to track.
 | `max_total_tokens` | integer | `5000000` | Maximum cumulative uncached tokens (input + output) per review. Cached tokens are excluded. Set to 0 to disable. |
 | `max_total_output_tokens` | integer | `500000` | Maximum cumulative output tokens per review. Set to 0 to disable. |
 
+### `[subsystems]`
+
+Controls how patches and emails are categorized into subsystems for targeted reviews and specific email policies. By default, this section is empty, meaning the system relies on fallback heuristics (like identifying `@vger.kernel.org` addresses) to determine subsystems.
+
+This feature is **globally active** and applies to both mailing list (NNTP) and Forge (Webhook) ingestion.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mapping` | list of objects | `[]` | A list of rules mapping a regular expression pattern to a subsystem name. |
+
+Each mapping object in the list requires two fields:
+* `pattern` (string): A regular expression used for matching.
+* `name` (string): The resulting subsystem name if the pattern matches.
+
+**How it works:**
+- **For Git Forges (Webhooks):** The system applies the `pattern` against the **file paths** modified by a pull request (e.g., matching `^drivers/net/.*`).
+- **For Mailing Lists (NNTP):** The system applies the `pattern` against the **To and Cc email addresses** of the incoming patch email.
+
+When a patch is tagged with a subsystem, it can trigger subsystem-specific AI review rules (context loading) and specific email/embargo policies defined in `email_policy.toml`.
+
+```toml
+[subsystems]
+mapping = [
+    { pattern = ".*drivers/.*", name = "Drivers" },
+    { pattern = ".*net/.*", name = "Networking" },
+    { pattern = ".*fs/.*", name = "Filesystems" },
+    { pattern = ".*mm/.*", name = "Memory Management" },
+]
+```
+
 ## email_policy.toml
 
 Controls how Sashiko sends (or suppresses) review emails. See


### PR DESCRIPTION
The [subsystems] configuration block in Settings.toml applies to both NNTP (mailing lists) and Webhooks (Git forges). However, the documentation previously implied it was specific to the forge integration.

This commit updates the documentation to:
- Detail how the mapping works for both email addresses and file paths.
- Explain the default state (empty array with fallback heuristics).
- Move the subsystems documentation to a top-level section in the README and configuration reference.


Assisted-by: Gemini <noreply@google.com>