### PR TITLE
main.rs: prevent overall bar to crash if completed states is big

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1143,6 +1143,7 @@ fn render_progress(state: &mut ProgressState) {
         } else {
             0
         };
+        let filled = filled.min(width);
 
         let mut tw = TruncatingWriter::new(limit, state.color_choice);
         let _ = tw.write_segment("Overall: [", None, true);


### PR DESCRIPTION
The logic at main.rs may actually have more completed states than its total:

DEBUG: completed_stages=9, total_stages=9, width=20, filled=20
      [Patch 1] media: em28xx: dro... | Execution Flow (turn 1) (+1 stages)
DEBUG: completed_stages=10, total_stages=9, width=20, filled=22
      [Patch 1] media: em28xx: drop 'users'... | Locking & Sync (turn 1)
DEBUG: completed_stages=11, total_stages=9, width=20, filled=24
      [Patch 1] media: em28xx: drop 'users'... | Reviewing...
      [Patch 1] media: em28xx: drop 'users'... | Deduplication
DEBUG: completed_stages=12, total_stages=9, width=20, filled=26
      [Patch 1] media: em28xx: drop 'users'... | Deduplication (turn 1)
DEBUG: completed_stages=12, total_stages=9, width=20, filled=26
Overall: [████████████████████] 133% | 12/9 stages | 24 turns
      [Patch 1] media: em28xx: drop 'users'... | Reviewing...
      [Patch 1] media: em28xx: drop 'users'... | Conflict Resolution
DEBUG: completed_stages=13, total_stages=9, width=20, filled=28
      [Patch 1] media: em28xx: drop 'user... | Conflict Resolution (turn 1)
DEBUG: completed_stages=13, total_stages=9, width=20, filled=28
Overall: [████████████████████] 144% | 13/9 stages | 25 turns
      [Patch 1] media: em28xx: drop 'user... | Conflict Resolution (turn 1)
DEBUG: completed_stages=13, total_stages=9, width=20, filled=28
Overall: [████████████████████] 144% | 13/9 stages | 26 turns
      [Patch 1] media: em28xx: drop 'user... | Conflict Resolution (turn 1)
DEBUG: completed_stages=13, total_stages=9, width=20, filled=28
Overall: [████████████████████] 144% | 13/9 stages | 27 turns

This causes a crash as width-filled becomes a negative number:

    Overall: [████████████████████] 100% | 11/11 stages | 30 turns
          [Patch 1] media: em28xx: dro... | Implementation (turn 1) (+5 stages)
    Overall: [█████████████████████
    thread 'main' (2447762) panicked at library/alloc/src/slice.rs:523:50:
    capacity overflow
    stack backtrace:
      0:     0x55b30561217a - <<std[52ccbc9b4b4e18b4]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[a0a13ccc4397ecab]
    ::fmt::Display>::fmt
      1:     0x55b30562deca - core[a0a13ccc4397ecab]::fmt::write
      2:     0x55b305619f32 - <std[52ccbc9b4b4e18b4]::sys::stdio::unix::Stderr as std[52ccbc9b4b4e18b4]::io::Write>::write_fmt
      3:     0x55b3055edb53 - std[52ccbc9b4b4e18b4]::panicking::default_hook::{closure#0}
      4:     0x55b3056089fc - std[52ccbc9b4b4e18b4]::panicking::default_hook
      5:     0x55b305608bbb - std[52ccbc9b4b4e18b4]::panicking::panic_with_hook
      6:     0x55b3055edc08 - std[52ccbc9b4b4e18b4]::panicking::panic_handler::{closure#0}
      7:     0x55b3055e2ab9 - std[52ccbc9b4b4e18b4]::sys::backtrace::__rust_end_short_backtrace::<std[52ccbc9b4b4e18b4]::panicking::pani
    c_handler::{closure#0}, !>
      8:     0x55b3055eec3d - __rustc[149301a0351973cc]::rust_begin_unwind
      9:     0x55b303ebcd1c - core[a0a13ccc4397ecab]::panicking::panic_fmt
     10:     0x55b303ebca74 - core[a0a13ccc4397ecab]::option::expect_failed
     11:     0x55b3041cd0b6 - alloc::slice::<impl [T]>::repeat::h2076c0dffcce8bdf
     12:     0x55b3040edfaf - sashiko::render_progress::h0541955cd5cf889a
     13:     0x55b30401d514 - sashiko::handle_review_command::{{closure}}::{{closure}}::h165c77097608c979
     14:     0x55b3041eff25 - sashiko::local_review::review_single_patch::{{closure}}::{{closure}}::{{closure}}::hc8facc02e89571c9
     15:     0x55b30409c143 - sashiko::worker::prompts::Worker::execute_stage::{{closure}}::he1ae86600eb08e04
     16:     0x55b30407eeb0 - <futures_util::future::try_maybe_done::TryMaybeDone<Fut> as core::future::future::Future>::poll::h84a15cee
    07a1edc6
     17:     0x55b3041b54dc - <futures_util::future::try_join_all::TryJoinAll<F> as core::future::future::Future>::poll::hd081061f793f89
    f8
     18:     0x55b3041fe54b - sashiko::worker::prompts::Worker::run::{{closure}}::h461674680251a479
     19:     0x55b3041ec8dc - sashiko::local_review::review_single_patch::{{closure}}::h0d3b0cd3d9218508
     20:     0x55b3041ddcdf - <futures_util::stream::futures_unordered::FuturesUnordered<Fut> as futures_core::stream::Stream>::poll_nex
    t::h145d4ece09d10d83
     21:     0x55b304160df5 - <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll::hae7eb5e448e10f26
     22:     0x55b304019aa7 - sashiko::local_review::run_worker_in_worktree::{{closure}}::h8d15c424eb97e326
     23:     0x55b30400edec - sashiko::local_review::run_worker::{{closure}}::hf516081af4ea7f43
     24:     0x55b3040280c4 - sashiko::main::{{closure}}::hea950edadefa9f7a
     25:     0x55b3040088d7 - tokio::runtime::park::CachedParkThread::block_on::he9c7ef757edf9eac
     26:     0x55b3041af8d3 - tokio::runtime::runtime::Runtime::block_on::h8a019604f34765ef
     27:     0x55b3040f2609 - sashiko::main::hb75d07e27cdb81f7
     28:     0x55b3041c5c13 - std::sys::backtrace::__rust_begin_short_backtrace::h8cfefc670e2afde0
     29:     0x55b3041e11c9 - std::rt::lang_start::{{closure}}::h2724112c1b27a7b4
     30:     0x55b305607464 - std[52ccbc9b4b4e18b4]::rt::lang_start_internal
     31:     0x55b3040f7085 - main
     32:     0x7f62e6cd2681 - __libc_start_call_main
     33:     0x7f62e6cd2798 - __libc_start_main@@GLIBC_2.34
     34:     0x55b303ebcfe5 - _start
     35:                0x0 - <unknown>

Prevent the crash by limiting the maximum size for the scrollbar.

I suspect that the root cause is due to retries:

	2026-07-19T23:05:03.356421Z  INFO sashiko: AI review retry (attempt 2/3)
	2026-07-19T23:05:03.356424Z  INFO sashiko::local_review: Restarting AI review for patch 1 (attempt 2/3)...

That have been accounted as completed.