### PR TITLE
feat(email): Add support for email body description prefix

### DIFF
--- a/docs/examples/email_policy.toml
+++ b/docs/examples/email_policy.toml
@@ -11,6 +11,9 @@ reply_all = false
 # Whether to send the review email to the author of the patch.
 reply_to_author = false
 
+# An optional body description prefix to be added on emails.
+body_prefix = ""
+
 # Whether to include individual recipients (non-mailing-list) in the review email.
 cc_individuals = false
 

--- a/src/email_policy.rs
+++ b/src/email_policy.rs
@@ -111,6 +111,8 @@ pub struct SubsystemPolicy {
     #[serde(default)]
     pub subject_prefixes: Vec<String>,
     #[serde(default)]
+    pub body_prefix: Option<String>,
+    #[serde(default)]
     pub patchwork: PatchworkPolicy,
     #[serde(default)]
     pub embargo_hours: Option<u32>,

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -2204,6 +2204,20 @@ impl Reviewer {
             &sender_address,
         );
 
+        let body_desc = policy
+            .defaults
+            .body_prefix
+            .as_ref()
+            .and_then(|p| {
+                let s = p.as_str();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("{}\n", s))
+                }
+            })
+            .unwrap_or_default();
+
         if findings_count == 0 {
             let mut sent_positive_review = false;
             if let EmailAction::Send {
@@ -2270,8 +2284,8 @@ impl Reviewer {
                     };
                     let final_subject = format!("{}{}", subject_prefix, patch_subject);
                     let final_body = format!(
-                        "{}\nSashiko has reviewed this patch and found no issues. It looks great!\n\n-- \nSashiko AI review · {}\n",
-                        body_head, target_url
+                        "{}{}\nSashiko has reviewed this patch and found no issues. It looks great!\n\n-- \nSashiko AI review · {}\n",
+                        body_desc, body_head, target_url
                     );
 
                     ctx.db
@@ -2415,7 +2429,13 @@ impl Reviewer {
 
                 footer.push_str(&format!("\n\n-- \nSashiko AI review · {}", target_url));
 
-                let final_body = format!("{}{}{}", header, inline_review.trim_end(), footer);
+                let final_body = format!(
+                    "{}{}{}{}",
+                    body_desc,
+                    header,
+                    inline_review.trim_end(),
+                    footer
+                );
 
                 let status = match &ctx.settings.smtp {
                     None => "Disabled",


### PR DESCRIPTION
There have been discussions about having custom per-subsystem body prefixes to add instructions about how to use Sashiko's review:
- at the media subsystem, there was a proposition to add a prefix to warn new developers like this:
  ```
    This is an LLM-generated review that can be prone to hallucinations.
    It is fine to ignore this review.
    When in doubt about some of the findings, please consult an experienced developer.
   ```
- recently, at Ksummit ML, about adding a custom per-subsystem note about what it is expected with regards to pre-existing conditions:
  https://lore.kernel.org/all/efdce5c5-13a1-4dec-9823-bb2a37084538@roeck-us.net/

Add an option to optionally set it at the sashiko.dev email policy.

NOTE: compile-tested only.