### PR TITLE
baseline: support per-subsystem branch configuration

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -23,10 +23,11 @@ enabled = false
 # webhook_secret = ""
 
 [subsystems]
-# Regex map: email address pattern -> subsystem name
+# Regex map: email address or changed path pattern -> subsystem name
 # mapping = [
 #     { pattern = ".*linux-kernel@vger.kernel.org.*", name = "LKML" },
 #     { pattern = ".*netdev@vger.kernel.org.*", name = "netdev" },
+#     { pattern = "^fs/smb/server/.*", name = "ksmbd", base_tree = "git://git.samba.org/ksmbd.git", base_branch = "for-next" },
 # ]
 
 [database]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,13 +179,18 @@ This feature is **globally active** and applies to both mailing list (NNTP) and 
 |-----|------|---------|-------------|
 | `mapping` | list of objects | `[]` | A list of rules mapping a regular expression pattern to a subsystem name. |
 
-Each mapping object in the list requires two fields:
+Each mapping object requires two fields:
 * `pattern` (string): A regular expression used for matching.
 * `name` (string): The resulting subsystem name if the pattern matches.
+
+It also accepts two optional baseline fields:
+* `base_tree` (string): Git repository URL to try before MAINTAINERS-derived baselines when the pattern matches a changed file path.
+* `base_branch` (string): Branch in `base_tree` to use. When omitted, the remote's default HEAD is used.
 
 **How it works:**
 - **For Git Forges (Webhooks):** The system applies the `pattern` against the **file paths** modified by a pull request (e.g., matching `^drivers/net/.*`).
 - **For Mailing Lists (NNTP):** The system applies the `pattern` against the **To and Cc email addresses** of the incoming patch email.
+- **For Baseline Selection:** Mappings with `base_tree` are also matched against changed file paths. A matching tree and optional branch are tried before baselines inferred from `MAINTAINERS`, linux-next, and mainline.
 
 When a patch is tagged with a subsystem, it can trigger subsystem-specific AI review rules (context loading) and specific email/embargo policies defined in `email_policy.toml`.
 
@@ -196,6 +201,7 @@ mapping = [
     { pattern = ".*net/.*", name = "Networking" },
     { pattern = ".*fs/.*", name = "Filesystems" },
     { pattern = ".*mm/.*", name = "Memory Management" },
+    { pattern = "^fs/smb/server/.*", name = "ksmbd", base_tree = "git://git.samba.org/ksmbd.git", base_branch = "for-next" },
 ]
 ```
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::settings::CustomRemoteSettings;
+use crate::settings::{CustomRemoteSettings, SubsystemMapping};
 use anyhow::Result;
 use regex::Regex;
 use std::collections::HashMap;
@@ -254,6 +254,7 @@ impl BaselineRegistry {
         files: &[String],
         subject: &str,
         body: Option<&str>,
+        subsystem_mapping: &[SubsystemMapping],
     ) -> Vec<BaselineResolution> {
         let mut candidates = Vec::new();
 
@@ -280,16 +281,19 @@ impl BaselineRegistry {
             }
         }
 
-        // 2. Subsystem Heuristic
+        // 2. Explicit per-subsystem baseline configuration
+        candidates.extend(self.resolve_configured_subsystem_baselines(files, subsystem_mapping));
+
+        // 3. MAINTAINERS subsystem heuristic
         let heuristic_candidates = self.resolve_subsystem_heuristic(files, subject);
         candidates.extend(heuristic_candidates);
 
-        // 3. Linux Next
+        // 4. Linux Next
         // Hardcoded linux-next URL
         let linux_next_url = "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git";
         candidates.push(self.resolve_url(linux_next_url, None));
 
-        // 4. Mainline
+        // 5. Mainline
         // Use the identified mainline remote (Linus tree or origin) as a
         // RemoteTarget so that ensure_remote fetches it before use. A bare
         // LocalRef("HEAD") would resolve to the local checkout, which nothing
@@ -304,7 +308,7 @@ impl BaselineRegistry {
             candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
         }
 
-        // 5. Custom Remotes
+        // 6. Custom Remotes
         if let Some(custom_remotes) = &self.custom_remotes {
             for remote in custom_remotes {
                 // Fetch to ensure we have the latest branches (Issue 1)
@@ -362,6 +366,41 @@ impl BaselineRegistry {
         }
 
         unique_candidates
+    }
+
+    fn resolve_configured_subsystem_baselines(
+        &self,
+        files: &[String],
+        subsystem_mapping: &[SubsystemMapping],
+    ) -> Vec<BaselineResolution> {
+        let lower_files: Vec<String> = files.iter().map(|file| file.to_lowercase()).collect();
+        let mut candidates = Vec::new();
+
+        for mapping in subsystem_mapping {
+            let Some(url) = mapping.base_tree.as_deref() else {
+                continue;
+            };
+
+            let regex = match Regex::new(&mapping.pattern) {
+                Ok(regex) => regex,
+                Err(e) => {
+                    warn!(
+                        "Ignoring invalid subsystem pattern for {}: {}",
+                        mapping.name, e
+                    );
+                    continue;
+                }
+            };
+
+            if lower_files.iter().any(|file| regex.is_match(file)) {
+                let candidate = self.resolve_url(url, mapping.base_branch.clone());
+                if !candidates.contains(&candidate) {
+                    candidates.push(candidate);
+                }
+            }
+        }
+
+        candidates
     }
 
     fn resolve_subsystem_heuristic(
@@ -621,7 +660,7 @@ mod tests {
         let body = "Some text\nbase-commit: 1234567890123456789012345678901234567890\n";
 
         let candidates = registry
-            .resolve_candidates(&files, "Subject", Some(body))
+            .resolve_candidates(&files, "Subject", Some(body), &[])
             .await;
 
         assert_eq!(candidates.len(), 4); // Base, Subsystem, Next, Head
@@ -635,6 +674,59 @@ mod tests {
             BaselineResolution::RemoteTarget { name, .. } => assert_eq!(name, "net-next"),
             _ => panic!("Expected RemoteTarget net-next"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_configured_subsystem_baseline_precedes_maintainers() {
+        let registry = create_registry();
+        let files = vec!["net/core.c".to_string()];
+        let mappings = vec![SubsystemMapping {
+            pattern: "^net/.*".to_string(),
+            name: "networking".to_string(),
+            base_tree: Some("git://example.com/networking.git".to_string()),
+            base_branch: Some("for-next".to_string()),
+        }];
+
+        let candidates = registry
+            .resolve_candidates(&files, "Subject", None, &mappings)
+            .await;
+
+        assert_eq!(
+            candidates[0],
+            BaselineResolution::RemoteTarget {
+                url: "git://example.com/networking.git".to_string(),
+                name: "networking".to_string(),
+                branch: Some("for-next".to_string()),
+            }
+        );
+        assert!(
+            candidates.iter().any(|candidate| matches!(
+                candidate,
+                BaselineResolution::RemoteTarget { name, .. } if name == "net-next"
+            )),
+            "MAINTAINERS-derived candidates should remain as fallbacks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subsystem_mapping_without_base_tree_keeps_existing_order() {
+        let registry = create_registry();
+        let files = vec!["net/core.c".to_string()];
+        let mappings = vec![SubsystemMapping {
+            pattern: "^net/.*".to_string(),
+            name: "networking".to_string(),
+            base_tree: None,
+            base_branch: None,
+        }];
+
+        let candidates = registry
+            .resolve_candidates(&files, "Subject", None, &mappings)
+            .await;
+
+        assert!(matches!(
+            &candidates[0],
+            BaselineResolution::RemoteTarget { name, .. } if name == "net-next"
+        ));
     }
 
     #[tokio::test]
@@ -655,7 +747,7 @@ mod tests {
             )),
         };
 
-        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+        let candidates = registry.resolve_candidates(&[], "Subject", None, &[]).await;
 
         // The last candidate before custom remotes should be a RemoteTarget
         // for origin/master, not a LocalRef("HEAD").
@@ -687,7 +779,7 @@ mod tests {
             mainline_remote: None,
         };
 
-        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+        let candidates = registry.resolve_candidates(&[], "Subject", None, &[]).await;
 
         let has_head = candidates
             .iter()
@@ -737,7 +829,9 @@ F: patterns/
         };
 
         let files = vec!["mm/memory.c".to_string()];
-        let candidates = registry.resolve_candidates(&files, "Subject", None).await;
+        let candidates = registry
+            .resolve_candidates(&files, "Subject", None, &[])
+            .await;
 
         // Expected order:
         // 1. mm-new (Subsystem Heuristic 1)
@@ -805,7 +899,9 @@ F: patterns/
         };
 
         let files = vec!["tools/perf/builtin-report.c".to_string()];
-        let candidates = registry.resolve_candidates(&files, "Subject", None).await;
+        let candidates = registry
+            .resolve_candidates(&files, "Subject", None, &[])
+            .await;
 
         // Current implementation likely only returns ONE of the trees (arbitrarily or first)
         // plus linux-next and HEAD.
@@ -854,7 +950,7 @@ F: patterns/
 
         // With "next" in subject
         let candidates_next = registry
-            .resolve_candidates(&files, "[PATCH net-next] something", None)
+            .resolve_candidates(&files, "[PATCH net-next] something", None, &[])
             .await;
         let names_next: Vec<String> = candidates_next
             .iter()
@@ -871,7 +967,7 @@ F: patterns/
 
         // Without "next" in subject
         let candidates_nonext = registry
-            .resolve_candidates(&files, "[PATCH net] something", None)
+            .resolve_candidates(&files, "[PATCH net] something", None, &[])
             .await;
         let names_nonext: Vec<String> = candidates_nonext
             .iter()
@@ -917,7 +1013,7 @@ F: patterns/
             mainline_remote: None,
         };
 
-        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+        let candidates = registry.resolve_candidates(&[], "Subject", None, &[]).await;
 
         let candidate_names: Vec<String> = candidates
             .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -2494,6 +2494,8 @@ mod tests {
         let custom_mapping = vec![sashiko::settings::SubsystemMapping {
             pattern: ".*custom-list@example.com.*".to_string(),
             name: "Custom".to_string(),
+            base_tree: None,
+            base_branch: None,
         }];
 
         // Test that a known default list is still identified even with custom mappings present.
@@ -2513,6 +2515,8 @@ mod tests {
         let mapping = vec![sashiko::settings::SubsystemMapping {
             pattern: "^drivers/usb/.*".to_string(),
             name: "usb".to_string(),
+            base_tree: None,
+            base_branch: None,
         }];
 
         let paths = vec![

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -390,12 +390,22 @@ impl Reviewer {
                 vec![BaselineResolution::Commit(commit)]
             } else {
                 ctx.baseline_registry
-                    .resolve_candidates(&all_files, &subject, body.as_deref())
+                    .resolve_candidates(
+                        &all_files,
+                        &subject,
+                        body.as_deref(),
+                        &ctx.settings.subsystems.mapping,
+                    )
                     .await
             }
         } else {
             ctx.baseline_registry
-                .resolve_candidates(&all_files, &subject, body.as_deref())
+                .resolve_candidates(
+                    &all_files,
+                    &subject,
+                    body.as_deref(),
+                    &ctx.settings.subsystems.mapping,
+                )
                 .await
         };
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,10 @@ use std::path::{Path, PathBuf};
 pub struct SubsystemMapping {
     pub pattern: String,
     pub name: String,
+    #[serde(default)]
+    pub base_tree: Option<String>,
+    #[serde(default)]
+    pub base_branch: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -555,6 +559,27 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_subsystem_mapping_baseline_fields() {
+        let settings: SubsystemsSettings = toml::from_str(
+            r#"
+            mapping = [
+                { pattern = "^fs/smb/server/.*", name = "ksmbd", base_tree = "git://git.samba.org/ksmbd.git", base_branch = "for-next" },
+                { pattern = "^net/.*", name = "networking" },
+            ]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.mapping[0].base_tree.as_deref(),
+            Some("git://git.samba.org/ksmbd.git")
+        );
+        assert_eq!(settings.mapping[0].base_branch.as_deref(), Some("for-next"));
+        assert!(settings.mapping[1].base_tree.is_none());
+        assert!(settings.mapping[1].base_branch.is_none());
+    }
 
     #[test]
     fn test_local_review_path_prefers_current_directory() {


### PR DESCRIPTION
Fixes #331

## Summary

Allow subsystem mappings to select the Git tree and branch used when Sashiko
tries to apply a patch series.

For example, ksmbd can now be configured to try its `for-next` branch:

```toml
[[subsystems.mapping]]
pattern = "^fs/smb/server/.*"
name = "ksmbd"
base_tree = "git://git.samba.org/ksmbd.git"
base_branch = "for-next"
```

## Root cause

Sashiko inferred subsystem trees from `MAINTAINERS`, but a `T:` entry without
an explicit branch caused it to try the remote's default HEAD. Some subsystem
patches are based on a development branch such as `for-next`, so they could
fail to apply even when the correct tree had been identified.

## Changes

- add optional `base_tree` and `base_branch` fields to subsystem mappings
- match configured baselines against the changed file paths
- try matching configured baselines before MAINTAINERS-derived trees
- retain explicit patch baselines as the highest-priority candidates
- preserve existing behavior for mappings without `base_tree`
- document the new configuration with a ksmbd example

## Validation

- synced with current upstream `main` and resolved baseline-priority changes
- focused settings and baseline-resolution tests pass
- `cargo fmt --all -- --check`
- `cargo clippy --release --lib -- -D warnings`
- GitHub Actions DCO, full lint, and Rust unit-test checks pass
- `git diff --check`