### PR TITLE
prompts: reconcile I2C subsystem guidance

### DIFF
--- a/third_party/prompts/kernel/subsystem/i2c.md
+++ b/third_party/prompts/kernel/subsystem/i2c.md
@@ -1,7 +1,21 @@
 # I2C Subsystem Details
 
 This document provides a knowledge reference for reviewing code in the I2C
-subsystem, focusing on buffer allocation contracts and DMA safety.
+subsystem.
+
+## Client Device Lifecycle and Debugfs
+
+*   **Debugfs Cleanup**: debugfs entries attached to the `debugfs` object in
+    `struct i2c_client` are cleaned up by the I2C subsystem core in the client
+    device removal function after calling the client driver remove function and
+    before releasing client device resources allocated with devres functions,
+    and in the I2C subsystem probe function after a probe failure has been
+    reported by the driver's probe function.
+
+## Initialization and Data Structures
+
+*   **`struct i2c_device_id`**: Initialized arrays of type `struct i2c_device_id`
+    must be declared const and use named initializers.
 
 ## Transfer Buffers and DMA Safety
 


### PR DESCRIPTION
Re-add client debugfs cleanup rules and struct i2c_device_id initialization rules that were overwritten during the prompt sync.