### PR TITLE
Track linux-fscrypt and fsverity mailing lists

### DIFF
--- a/sashiko.dev/base/app/sashiko-k8s.yaml
+++ b/sashiko.dev/base/app/sashiko-k8s.yaml
@@ -91,7 +91,7 @@ spec:
                 live-patching,openvpn-devel,platform-driver-x86,linux-arm-msm,
                 linux-modules,nouveau,nova-gpu,ntb,selinux,linux-raid,linux-rt,linux-rtc,
                 linux-can,linux-target,linux-hardening,linux-security-module,linux-unionfs,mfd,linux-leds,mhi,
-                linux-mtd
+                linux-mtd,linux-fscrypt,fsverity
             - name: SASHIKO__REVIEW__CONCURRENCY
               value: "24"
             - name: SASHIKO__SMTP__SENDER_ADDRESS


### PR DESCRIPTION
Add linux-fscrypt and fsverity to the tracked mailing lists in the Kubernetes deployment configuration to enable monitoring of these lists.