### PR TITLE
email: add borntraeger to s390 cc list

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -236,7 +236,11 @@ cc = ["linux-target@vger.kernel.org"]
 lists = ["linux-s390@vger.kernel.org"]
 reply_to_author = true
 send_positive_review = true
-cc = ["linux-s390@vger.kernel.org", "Heiko Carstens <hca@linux.ibm.com>", "Vasily Gorbik <gor@linux.ibm.com>", "Alexander Gordeev <agordeev@linux.ibm.com>"]
+cc = ["linux-s390@vger.kernel.org",
+      "Heiko Carstens <hca@linux.ibm.com>",
+      "Vasily Gorbik <gor@linux.ibm.com>",
+      "Alexander Gordeev <agordeev@linux.ibm.com>",
+      "Christian Borntraeger <borntraeger@linux.ibm.vom>"]
 
 [subsystems.kvmarm]
 lists = ["kvmarm@lists.linux.dev"]


### PR DESCRIPTION
From borntraeger@linux.ibm.com:

> I am a reviewer for s390 and want to see sashiko review.
>
> Signed-off-by: Christian Borntraeger <borntraeger@linux.ibm.com>

[0] https://lore.kernel.org/sashiko/20260730144458.286663-1-borntraeger@linux.ibm.com/

Signed-off-by: derekbarbosa <derekasobrab@gmail.com>
