### PR TITLE
ai: accept full chat completions URL in openai-compat base_url

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -279,3 +279,30 @@ cp docs/examples/Settings.openai-compat.toml Settings.toml
 ```
 
 Adjust `base_url` to point to your provider's endpoint.
+
+`base_url` may be either:
+
+- a shorthand such as `http://localhost:8080/v1` (the `/chat/completions`
+  suffix is appended automatically), or
+- the full chat completions URL, e.g.
+  `https://api.z.ai/api/coding/paas/v4/chat/completions`. Use this form for
+  providers whose path is not a recognised shorthand.
+
+**z.ai / Zhipu (glm-*) example:**
+
+z.ai exposes two OpenAI-compatible gateways with **separate billing**: a
+direct API (`…/api/paas/v4/…`, billed to the API resource package) and a
+coding-plan gateway (`…/api/coding/paas/v4/…`, billed to the coding-plan
+subscription). To review against the coding-plan quota, point `base_url` at
+the full coding endpoint and set `LLM_API_KEY` (or `OPENAI_API_KEY`):
+
+```toml
+[ai]
+provider = "openai-compatible"
+model = "glm-5.2"
+
+[ai.openai_compat]
+base_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"
+context_window_size = 128000
+max_tokens = 16384
+```

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -203,6 +203,16 @@ impl OpenAiCompatClient {
             None => return Err(anyhow::anyhow!("Invalid url scheme in OpenAI url {}", url)),
         };
 
+        // If the caller supplied a full URL that already targets a chat
+        // completions endpoint, accept it verbatim. This allows any
+        // OpenAI-compatible provider to be configured via `base_url` alone,
+        // including endpoints whose path is not otherwise recognised such as
+        // z.ai's coding-plan gateway
+        // (https://api.z.ai/api/coding/paas/v4/chat/completions).
+        if path.ends_with("/chat/completions") {
+            return Ok(format!("{base}{path}"));
+        }
+
         let path = match path.as_str() {
             "" => "/chat/completions",
             "/v1" | "/v1/chat/completions" => "/v1/chat/completions",
@@ -1242,6 +1252,32 @@ mod tests {
                 .unwrap(),
             "https://openrouter.ai/api/v1/chat/completions"
         );
+        // z.ai / Zhipu endpoints: full URLs ending in /chat/completions are
+        // accepted verbatim, so providers with otherwise-unrecognised paths
+        // (direct API and coding-plan gateway) can be used via base_url only.
+        assert_eq!(
+            OpenAiCompatClient::normalize_base_url("https://api.z.ai/api/paas/v4/chat/completions")
+                .unwrap(),
+            "https://api.z.ai/api/paas/v4/chat/completions"
+        );
+        assert_eq!(
+            OpenAiCompatClient::normalize_base_url(
+                "https://api.z.ai/api/coding/paas/v4/chat/completions"
+            )
+            .unwrap(),
+            "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        );
+        // Trailing slash on a full endpoint URL is trimmed
+        assert_eq!(
+            OpenAiCompatClient::normalize_base_url(
+                "https://api.z.ai/api/coding/paas/v4/chat/completions/"
+            )
+            .unwrap(),
+            "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        );
+        // Paths that are not full chat/completions URLs and are not a known
+        // shorthand are still rejected.
+        assert!(OpenAiCompatClient::normalize_base_url("https://api.z.ai/api/paas/v4").is_err());
         // Test arbitrary deep nested paths that shouldn't be accepted
         assert!(
             OpenAiCompatClient::normalize_base_url(


### PR DESCRIPTION
## Problem

The `openai-compatible` provider's `normalize_base_url()` accepts only a fixed set of path shorthands (bare host, `/v1`, `/api/v1`) and rejects every other path with `Invalid OpenAI url`:

```rust
let path = match path.as_str() {
    "" => "/chat/completions",
    "/v1" | "/v1/chat/completions" => "/v1/chat/completions",
    "/api/v1" | "/api/v1/chat/completions" => "/api/v1/chat/completions",
    _ => return Err(anyhow::anyhow!("Invalid OpenAI url {}", url)),
};
```

This blocks providers whose endpoint path is not on that allowlist. The most notable case is **z.ai / Zhipu** (`glm-*` models), whose OpenAI-compatible gateways use:

- `…/api/paas/v4/chat/completions` — direct API (billed to the API resource package)
- `…/api/coding/paas/v4/chat/completions` — coding-plan gateway (billed to the coding-plan subscription)

Both are rejected today. `default_base_url_for_model()` already special-cases `glm-*` to the China endpoint `open.bigmodel.cn`, but the international `api.z.ai` endpoint and its separately-billed coding-plan gateway cannot be configured at all.

## Solution

Instead of extending the per-provider allowlist, accept any `base_url` that already targets a chat completions endpoint verbatim:

```rust
// If the caller supplied a full URL that already targets a chat
// completions endpoint, accept it verbatim.
if path.ends_with("/chat/completions") {
    return Ok(format!("{base}{path}"));
}
```

This makes **any** OpenAI-compatible provider configurable via `base_url` alone, while the existing shorthand matching (and rejection of unknown shorthand paths) is fully preserved. It's strictly more permissive for explicit full URLs and changes no existing behaviour.

z.ai then works purely from config:

```toml
[ai]
provider = "openai-compatible"
model = "glm-5.2"

[ai.openai_compat]
base_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"
context_window_size = 128000
max_tokens = 16384
```

## Changes

- `src/ai/openai.rs`: passthrough for full `/chat/completions` URLs + unit tests.
- `docs/llm-providers.md`: document both `base_url` forms and add a z.ai coding-plan example.

## Notes

- `glm-5.2` is a reasoning model whose thinking tokens count against `max_tokens`; the doc example uses 16384 to avoid truncation during review.

## Testing

- `cargo test --lib` (new + existing `normalize_base_url` tests pass)
- `cargo clippy --all-targets` clean
- `cargo fmt --check` clean
