### PR TITLE
reviewer: surface git am error in baseline apply log

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -928,8 +928,13 @@ impl Reviewer {
                     );
 
                     // Try git am
-                    if (worktree.apply_patch(&mbox).await).is_ok() {
-                        applied = true;
+                    match worktree.apply_patch(&mbox).await {
+                        Ok(_) => applied = true,
+                        Err(e) => {
+                            let msg = format!("git am error: {}\n", e);
+                            info!("{}", msg);
+                            apply_logs.push_str(&msg);
+                        }
                     }
                 }
 


### PR DESCRIPTION
The baseline apply loop dropped the git am error via is_ok(), so the
View Log only showed a generic failure line with no reason. Capture the
error from apply_patch and append it to the baseline log so the actual
git am stdout/stderr is visible when a patch fails to apply.

Fixes: #388 

Assisted-by: deepseek-v4-flash
Signed-off-by: derekbarbosa <derekasobrab@gmail.com>
