### PR TITLE
email_policy: send positive review for DAMON patches

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -46,6 +46,7 @@ subject_prefixes = ["bpf", "bpf-next"]
 lists = ["damon@lists.linux.dev"]
 reply_to_author = true
 cc = ["damon@lists.linux.dev"]
+send_positive_review = true
 
 [subsystems.devicetree]
 lists = ["devicetree@vger.kernel.org"]


### PR DESCRIPTION
Knowing if Sashiko found no issue could be helpful at reducing unnecessary refreshes on Sashiko web page.  Let DAMON onboard to this new feature.