### PR TITLE
docs: clarify author-only reviews

### DIFF
--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -39,4 +39,18 @@ Sashiko provides flexible delivery mechanisms that can be configured per mailing
 *   **`embargo_hours`:** The number of hours to wait before sending out a review, providing a delay period. When a patch is sent to multiple mailing lists, the shortest explicitly configured embargo period among the matched subsystems will be used. If no matched subsystems explicitly configure this value, it falls back to the default policy.
 *   **`send_positive_review`**: Determines whether to send a review email even when no issues are found. If set to `true`, Sashiko will send a reply indicating that the review was positive. Defaults to `false`.
 
+**Author-only delivery:** To *track* a subsystem's list (so its patches are
+ingested and reviewed) without *pinging* the list, send the review only to
+the patch author. No extra flag is needed — combine `reply_all = false`
+(strips the list from recipients), `reply_to_author = true`, and
+`cc_individuals = false`:
+
+```toml
+[subsystems.drm-intel]
+lists = ["intel-xe@lists.freedesktop.org"]
+reply_all = false
+reply_to_author = true
+cc_individuals = false
+```
+
 **Configuration:** The email policies and delivery preferences are defined in the [`sashiko.dev/email_policy.toml`](sashiko.dev/email_policy.toml) file. To request a change to your configuration, please open a GitHub Issue or email the development mailing list (`sashiko@lists.linux.dev`).

--- a/designs/DESIGN_CC_IF_AUTHOR.md
+++ b/designs/DESIGN_CC_IF_AUTHOR.md
@@ -1,0 +1,75 @@
+# Direct-to-Author Review Notifications
+
+## 1. Problem Statement
+
+Two related requests from developers who contribute to subsystems whose
+mailing lists are currently **silent / dashboard-only** (Sashiko reviews
+patches but sends no email, or pings the whole list):
+
+1. "I develop for intel-xe. The list is currently silent/dashboard-only,
+   but I would love to receive the reviews on my own patches. Add a
+   mechanism so individual devs can opt-in to direct emails without
+   spamming the whole list."
+2. "We have people in the developer group who would like to get the review
+   mails for their patches but don't need to see everything."
+
+Both reduce to a single recipient-routing outcome: a subsystem can
+**track a mailing list** (so its patches are ingested and reviewed) while
+**not sending the review to that list** — instead the review goes **only to
+the patch author**.
+
+## 2. Decision: No New Flag — Use the Existing Combination
+
+Investigation and empirical testing (all 8 `email_router` unit tests pass)
+confirmed the existing flags in `email_policy.toml` already produce
+author-only delivery. No new `cc_if_author` flag is required, so none is
+added (per implementation economy).
+
+The combination that yields "track the list, email only the author":
+
+```toml
+[defaults]
+reply_all = false          # never send to public lists
+reply_to_author = false    # (see note below)
+cc_individuals = false     # drop non-list individuals
+
+# --- per-subsystem (intel-xe case) ---
+[subsystems.drm-intel]
+lists = ["intel-xe@lists.freedesktop.org"]
+reply_all = false
+reply_to_author = true
+cc_individuals = false
+```
+
+Why it works (`src/email_router.rs`, `resolve_recipients`):
+
+- `reply_all = false` sets `is_private = true`, which strips every
+  mailing-list address from the outgoing `To`/`Cc` (the list is still
+  matched and tracked via `lists`, so its patches are reviewed).
+- `reply_to_author = true` adds the patch author.
+- `cc_individuals = false` drops non-list individual recipients.
+
+Net result: the review goes **only to the author**. Because each review
+targets exactly one author, this delivers "reviews on my own patches"
+without pinging the list.
+
+## 3. Known Interaction
+
+**Multi-subsystem "union" rule** (`src/email_router.rs:415`): if a single
+patch matches both a public subsystem (e.g. `cc_individuals = true`) and a
+private one, the union keeps non-list individuals. This is an edge case,
+not a blocker for author-only delivery on a single subsystem.
+
+## 4. Deliverables
+
+- A focused regression unit test in `src/email_router.rs` asserting the
+  author-only combination (list stripped, author kept, individuals empty).
+- Documentation updates: `docs/configuration.md`,
+  `docs/examples/email_policy.toml`, `MAINTAINERS_GUIDE.md`,
+  `email_policy.toml`.
+
+## 5. Out of Scope
+
+- A `cc_if_author` config flag (redundant with the existing combination).
+- Self-service per-developer subscriptions via UI/API.
+- Patchwork delivery changes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,29 @@ fields as `[defaults]`, plus:
 | `patchwork.min_severity` | string | -- | Minimum finding severity to include in patchwork checks. Findings below this threshold are excluded. Accepts: `Low`, `Medium`, `High`, `Critical` (case-insensitive). Default: all findings included. |
 | `patchwork.fail_severity` | string | `High` | Minimum severity of NEW findings that triggers the `fail` check state instead of `warning`. New findings at or above this threshold produce `fail`; below it produce `warning`. Pre-existing findings never affect the check state. |
 
+### Author-only delivery
+
+A subsystem can **track** a mailing list (its patches are ingested and
+reviewed) while **not pinging** that list with the review email — sending
+only to the patch author instead. This is useful for silent /
+dashboard-only lists where individual contributors want direct reviews of
+their own patches without spamming the whole list.
+
+It is achieved with the existing flags, no extra key needed:
+
+```toml
+[subsystems.drm-intel]
+lists = ["intel-xe@lists.freedesktop.org"]
+reply_all = false          # never send to the public list
+reply_to_author = true     # send the review to the patch author
+cc_individuals = false     # drop non-list individual recipients
+```
+
+The list address is still matched via `lists` (so reviews happen), but
+`reply_all = false` strips it from the outgoing recipients, leaving only
+the author. Because each review targets exactly one author, this delivers
+reviews to individual developers without pinging the list.
+
 ### Patchwork integration
 
 Sashiko can report review results as

--- a/docs/examples/email_policy.toml
+++ b/docs/examples/email_policy.toml
@@ -28,6 +28,18 @@ ignored_emails = []
 # If true, Sashiko will send a reply indicating that the review was positive.
 send_positive_review = false
 
+# --- Author-only delivery ---
+# To TRACK a subsystem's list (so its patches are reviewed) but NOT ping the
+# list with the review email, send only to the patch author. No extra flag is
+# needed; combine reply_all=false (strips the list) with reply_to_author=true
+# and cc_individuals=false.
+#
+# [subsystems.drm-intel]
+# lists = ["intel-xe@lists.freedesktop.org"]
+# reply_all = false
+# reply_to_author = true
+# cc_individuals = false
+
 # --- Patchwork integration examples ---
 #
 # API mode: direct REST API calls with retry-queuing (3 attempts).

--- a/email_policy.toml
+++ b/email_policy.toml
@@ -23,3 +23,15 @@ ignored_emails = []
 # If true, Sashiko will send a reply indicating that the review was positive.
 send_positive_review = false
 
+# --- Author-only delivery ---
+# To TRACK a subsystem's list (so its patches are reviewed) but NOT ping the
+# list with the review email, send only to the patch author. No extra flag is
+# needed; combine reply_all=false (strips the list) with reply_to_author=true
+# and cc_individuals=false.
+#
+# [subsystems.drm-intel]
+# lists = ["intel-xe@lists.freedesktop.org"]
+# reply_all = false
+# reply_to_author = true
+# cc_individuals = false
+

--- a/src/email_router.rs
+++ b/src/email_router.rs
@@ -421,6 +421,50 @@ mod tests {
     }
 
     #[test]
+    fn test_author_only_delivery() {
+        // A subsystem that tracks its list but sends the review only to the
+        // patch author: reply_all=false strips the list, reply_to_author adds
+        // the author, cc_individuals=false drops non-list individuals.
+        let mut subsystems = HashMap::new();
+        subsystems.insert(
+            "drm-intel".to_string(),
+            SubsystemPolicy {
+                lists: vec!["intel-xe@lists.freedesktop.org".to_string()],
+                reply_all: false,
+                reply_to_author: true,
+                cc_individuals: false,
+                mute_all: false,
+                ..Default::default()
+            },
+        );
+        let policy = EmailPolicyConfig {
+            defaults: SubsystemPolicy {
+                reply_all: false,
+                reply_to_author: false,
+                cc_individuals: false,
+                mute_all: false,
+                ..Default::default()
+            },
+            subsystems,
+        };
+        let action = EmailRouter::resolve_recipients(
+            &policy,
+            &["intel-xe@lists.freedesktop.org".to_string()],
+            &["maintainer@test.com".to_string()],
+            "author@test.com",
+            "bot@sashiko.dev",
+        );
+        match action {
+            Action::Send { to, cc, .. } => {
+                assert!(to.contains(&"author@test.com".to_string()));
+                assert!(!to.contains(&"intel-xe@lists.freedesktop.org".to_string()));
+                assert!(cc.is_empty(), "non-list individuals should be dropped");
+            }
+            Action::Mute => panic!("Should not mute"),
+        }
+    }
+
+    #[test]
     fn test_defaults() {
         let policy = build_test_policy();
         // Unknown list -> defaults apply (private, reply_to_author=true, cc_individuals=true)


### PR DESCRIPTION
Sashiko already supports author-only review delivery through existing
flags (reply_all=false + reply_to_author=true + cc_individuals=false).

Document that combination and add a regression test to
effectively "verify" the behavior.

Fixes: #322 