### PR TITLE
baseline: Try custom remotes before linux-next and mainline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,10 +149,34 @@ Optional array of additional git remotes to track.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `name` | string | -- | Remote name. |
-| `url` | string | -- | Remote URL. |
-| `check_all_branches` | bool | -- | Try all branches as baselines. |
-| `only_branches` | list | -- | Restrict to specific branches (optional). |
+| `name` | string | -- | Remote name. Required. |
+| `url` | string | -- | Remote URL. Required. |
+| `check_all_branches` | bool | -- | Try all branches as baselines. Required -- omitting it is a parse error, not a default of `false`. |
+| `only_branches` | list | -- | Additional specific branches to try (optional). Additive: when `check_all_branches` is also true, these are appended to the full branch list rather than replacing it. |
+
+Baselines are tried in order and the first one the series applies to wins.
+Custom remotes are tried after any `base-commit:` trailer and the MAINTAINERS
+subsystem heuristic, but **before** linux-next and mainline. A subsystem topic
+branch is where a series was actually developed, whereas linux-next carries a
+snapshot of that branch which lags by at least one daily build -- and shares no
+SHAs with it once the maintainer rebases.
+
+Use this to reach topic branches that the MAINTAINERS `T:` entry doesn't name.
+For example, the NFSD entry lists a tree but no branch, so the only candidate it
+yields is `cel/HEAD` (a symref to `cel/master`):
+
+```toml
+[[git.custom_remotes]]
+name = "cel"
+url = "git://git.kernel.org/pub/scm/linux/kernel/git/cel/linux.git"
+check_all_branches = false
+only_branches = ["nfsd-next", "nfsd-testing"]
+```
+
+Match `name` and `url` to a remote already in the repository when one exists.
+`ensure_remote` rewrites the URL whenever the configured one differs, so an
+`https://` URL here against a `git://` remote flips it back and forth on every
+pass.
 
 ### `[review]`
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -284,27 +284,11 @@ impl BaselineRegistry {
         let heuristic_candidates = self.resolve_subsystem_heuristic(files, subject);
         candidates.extend(heuristic_candidates);
 
-        // 3. Linux Next
-        // Hardcoded linux-next URL
-        let linux_next_url = "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git";
-        candidates.push(self.resolve_url(linux_next_url, None));
-
-        // 4. Mainline
-        // Use the identified mainline remote (Linus tree or origin) as a
-        // RemoteTarget so that ensure_remote fetches it before use. A bare
-        // LocalRef("HEAD") would resolve to the local checkout, which nothing
-        // in Sashiko ever advances after fetching.
-        if let Some((url, name)) = &self.mainline_remote {
-            candidates.push(BaselineResolution::RemoteTarget {
-                url: url.clone(),
-                name: name.clone(),
-                branch: Some("master".to_string()),
-            });
-        } else {
-            candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
-        }
-
-        // 5. Custom Remotes
+        // 3. Custom Remotes
+        // Ahead of linux-next because the first candidate that applies wins,
+        // and a topic-branch series usually applies to linux-next too -- but
+        // against a stale snapshot: a daily build behind, and sharing no SHAs
+        // with the topic branch once the maintainer rebases.
         if let Some(custom_remotes) = &self.custom_remotes {
             for remote in custom_remotes {
                 // Fetch to ensure we have the latest branches (Issue 1)
@@ -349,6 +333,25 @@ impl BaselineRegistry {
                     }
                 }
             }
+        }
+
+        // 4. Linux Next
+        let linux_next_url = "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git";
+        candidates.push(self.resolve_url(linux_next_url, None));
+
+        // 5. Mainline
+        // Use the identified mainline remote (Linus tree or origin) as a
+        // RemoteTarget so that ensure_remote fetches it before use. A bare
+        // LocalRef("HEAD") would resolve to the local checkout, which nothing
+        // in Sashiko ever advances after fetching.
+        if let Some((url, name)) = &self.mainline_remote {
+            candidates.push(BaselineResolution::RemoteTarget {
+                url: url.clone(),
+                name: name.clone(),
+                branch: Some("master".to_string()),
+            });
+        } else {
+            candidates.push(BaselineResolution::LocalRef("HEAD".to_string()));
         }
 
         // Deduplicate
@@ -657,8 +660,8 @@ mod tests {
 
         let candidates = registry.resolve_candidates(&[], "Subject", None).await;
 
-        // The last candidate before custom remotes should be a RemoteTarget
-        // for origin/master, not a LocalRef("HEAD").
+        // The mainline candidate should be a RemoteTarget for origin/master,
+        // not a LocalRef("HEAD").
         let mainline = candidates.iter().find(|c| match c {
             BaselineResolution::RemoteTarget { name, branch, .. } => {
                 name == "origin" && branch.as_deref() == Some("master")
@@ -928,5 +931,51 @@ F: patterns/
             .collect();
 
         assert!(candidate_names.contains(&"dummy-repo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_custom_remotes_precede_linux_next() {
+        use crate::settings::CustomRemoteSettings;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path();
+
+        std::process::Command::new("git")
+            .current_dir(repo_path)
+            .arg("init")
+            .output()
+            .unwrap();
+
+        let dummy_url = repo_path.join("dummy_remote").to_str().unwrap().to_string();
+        let registry = BaselineRegistry {
+            entries: Vec::new(),
+            remote_map: HashMap::new(),
+            custom_remotes: Some(vec![CustomRemoteSettings {
+                name: "topic-tree".to_string(),
+                url: dummy_url,
+                check_all_branches: false,
+                only_branches: Some(vec!["topic-next".to_string()]),
+            }]),
+            repo_path: repo_path.to_path_buf(),
+            mainline_remote: None,
+        };
+
+        let candidates = registry.resolve_candidates(&[], "Subject", None).await;
+        let names: Vec<String> = candidates
+            .iter()
+            .filter_map(|c| match c {
+                BaselineResolution::RemoteTarget { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let pos_custom = names.iter().position(|n| n == "topic-tree").unwrap();
+        let pos_next = names.iter().position(|n| n == "linux-next").unwrap();
+        assert!(
+            pos_custom < pos_next,
+            "custom remote at {} should precede linux-next at {}: {:?}",
+            pos_custom,
+            pos_next,
+            names
+        );
     }
 }


### PR DESCRIPTION
The first baseline candidate a series applies to becomes the tree the review runs against, and custom remotes were tried last. A series developed on a maintainer's topic branch usually applies to linux-next as well, so linux-next won, and the review ran against a snapshot at least one daily build behind the topic branch — and one sharing no SHAs with it at all once the maintainer rebases.

The base-commit trailer and the MAINTAINERS heuristic keep their places at the front; only the custom remotes move, ahead of linux-next and mainline.

Also documents the resulting order, along with two custom-remote keys the configuration table left unstated: `check_all_branches` is required, and `only_branches` adds to the branch list rather than replacing it.
