### PR TITLE
email: email the MPTCP ML and authors

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -69,8 +69,10 @@ subject_prefixes = ["net", "net-next"]
 
 [subsystems.mptcp]
 lists = ["mptcp@lists.linux.dev"]
-mute_all = true
-subject_prefixes = ["mptcp", "mptcp-next"]
+reply_to_author = true
+cc = ["mptcp@lists.linux.dev"]
+embargo_hours = 0
+subject_prefixes = ["mptcp", "mptcp-net", "mptcp-next"]
 
 [subsystems.mptcp.patchwork]
 enabled = true


### PR DESCRIPTION
Thank you for this service!

At the last MPTCP Upstream bi-weekly meeting, with @mjmartineau, we both agree that having Sashiko sending emails would help authors to see these reviews and reply to them, and reviewers to detect early when a path shouldn't be taken.

While at it, add the missing "mptcp-net" prefix, and set the embargo hours to 0, similar to the settings for the BPF subsystem.