### PR TITLE
feat: prefer local Settings.toml over embedded defaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -901,7 +901,15 @@ fn handle_init_command(
         std::fs::create_dir_all(parent)?;
     }
 
-    std::fs::write(&path, DEFAULT_SETTINGS)?;
+    // Prefer a local Settings.toml in the current directory if it exists,
+    // otherwise fall back to the embedded default settings.
+    let settings_content = if Path::new("Settings.toml").exists() {
+        std::fs::read_to_string("Settings.toml")?
+    } else {
+        DEFAULT_SETTINGS.to_string()
+    };
+
+    std::fs::write(&path, &settings_content)?;
     println!("Wrote {}", path.display());
 
     let prompts_root = prompt_bundle::install_prompt_bundle(reinstall_prompts)?;


### PR DESCRIPTION
In the project README.md, it said

"""
  To get started with the default (Gemini):

  cp docs/examples/Settings.example.toml Settings.toml

  [ ... ]

  sashiko init
"""

Which gives users an impression that the init will use Settings.toml. But it actually uses the Settings.example.toml by default.

When running 'sashiko init', let's check for a Settings.toml in the current directory first and use its contents if found. Falls back to the embedded DEFAULT_SETTINGS otherwise.