### PR TITLE
email: add reply_to_author=true for livepatch

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -116,6 +116,7 @@ cc = ["antonio@mandelbit.com", "ralf@mandelbit.com", "sd@queasysnail.net"]
 [subsystems.live-patching]
 lists = ["live-patching@vger.kernel.org"]
 reply_all = true
+reply_to_author = true
 
 [subsystems.pci]
 lists = ["linux-pci@vger.kernel.org"]


### PR DESCRIPTION
Confusingly, reply_all=true replies to everybody BUT the author.  Add reply_to_author=true for livepatch.