### PR TITLE
API deduplicate api/submit requests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::db::Database;
-use crate::events::Event;
+use crate::events::{Event, MessageSource};
 use crate::fetcher::FetchRequest;
 use axum::{
     Json, Router,
@@ -358,7 +358,7 @@ fn generate_synthetic_id(prefix: &str) -> String {
         .expect("Time went backwards");
     // e.g. sashiko-local-1715890000-12345
     format!(
-        "sashiko-{}-{}-{}",
+        "sashiko-{}-{}-{}@sashiko.local",
         prefix,
         since_the_epoch.as_secs(),
         fastrand::u32(..)
@@ -399,6 +399,8 @@ async fn submit_patch(
 
             let event = Event::RawMboxSubmitted {
                 raw,
+                submission_id: id.clone(),
+                source: MessageSource::ApiInject,
                 group: "api-submit".to_string(),
                 baseline: base_commit,
                 skip_subjects,
@@ -438,7 +440,7 @@ async fn submit_patch(
             if let Err(e) = state
                 .db
                 .create_fetching_patchset(
-                    &id,
+                    &format!("{}@sashiko.local", id),
                     &format!("Fetching {} from {}...", &sha, repo_display),
                     skip_subjects.as_ref(),
                     only_subjects.as_ref(),
@@ -523,6 +525,7 @@ async fn submit_patch(
                         .send(Event::IngestionFailed {
                             article_id: msgid_clone.clone(),
                             error: format!("Failed to fetch thread: {}", e),
+                            source: MessageSource::ApiFetchThread,
                         })
                         .await;
                 }
@@ -594,6 +597,8 @@ async fn fetch_and_inject_thread(
 
     let event = Event::RawMboxSubmitted {
         raw,
+        submission_id: msgid.to_string(),
+        source: MessageSource::ApiFetchThread,
         group: "api-submit".to_string(),
         baseline: None,
         skip_subjects: None,
@@ -1234,4 +1239,16 @@ async fn forge_webhook(
         "status": "accepted",
         "message": format!("{} {} queued for review", forge.name(), action)
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_synthetic_id_format() {
+        let id = generate_synthetic_id("test");
+        assert!(id.starts_with("sashiko-test-"));
+        assert!(id.ends_with("@sashiko.local"));
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -436,6 +436,25 @@ async fn submit_patch(
                 sha, repo_display
             );
 
+            // Optimistic check: If we already have this patchset in the DB,
+            // skip creating placeholder and skip fetch queue entirely.
+            match state.db.has_patchset_by_msgid(&id).await {
+                Ok(true) => {
+                    info!(
+                        "Remote fetch request for already ingested SHA {}, skipping placeholder and fetch",
+                        id
+                    );
+                    return Ok(Json(SubmitResponse {
+                        status: "accepted".to_string(),
+                        id,
+                    }));
+                }
+                Err(e) => {
+                    error!("Failed to check if patchset exists: {}", e);
+                }
+                _ => {}
+            }
+
             // Create a placeholder record in the DB so the user can track status
             if let Err(e) = state
                 .db

--- a/src/db.rs
+++ b/src/db.rs
@@ -3818,6 +3818,34 @@ impl Database {
         self.rerun_patchset(patchset_id).await
     }
 
+    pub async fn has_patchset_by_msgid(&self, msgid: &str) -> Result<bool> {
+        let candidates = Self::get_msgid_candidates(msgid);
+        for clid in &candidates {
+            let mut rows = self
+                .conn
+                .query(
+                    "SELECT 1 FROM patchsets WHERE cover_letter_message_id = ? AND status NOT IN ('Failed', 'Cancelled', 'Failed To Apply', 'FailedToApply') LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if rows.next().await.ok().flatten().is_some() {
+                return Ok(true);
+            }
+
+            let mut p_rows = self
+                .conn
+                .query(
+                    "SELECT 1 FROM patches p JOIN patchsets ps ON p.patchset_id = ps.id WHERE p.message_id = ? AND ps.status NOT IN ('Failed', 'Cancelled', 'Failed To Apply', 'FailedToApply') LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if p_rows.next().await.ok().flatten().is_some() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn create_fetching_patchset(
         &self,
@@ -3855,7 +3883,12 @@ impl Database {
 
                 // Only reset to Fetching if it failed or is currently fetching.
                 // We don't want to reset if it is already Incomplete, Pending, or Reviewed.
-                if status == "Failed" || status == "Fetching" || status == "Cancelled" {
+                if status == "Failed"
+                    || status == "Fetching"
+                    || status == "Cancelled"
+                    || status == "Failed To Apply"
+                    || status == "FailedToApply"
+                {
                     self.conn.execute(
                         "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
                         libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
@@ -8236,6 +8269,517 @@ mod tests {
             .unwrap();
         assert_eq!(updated["status"], "Failed");
         assert_eq!(updated["failed_reason"], "Fetch failed: timeout");
+    }
+
+    /// Verify that has_patchset_by_msgid detects patchsets by bare SHA
+    /// for synthetic @sashiko.local cover letters and for patches in the patches table.
+    #[tokio::test]
+    async fn test_has_patchset_by_msgid_synthetic_and_patch_sha() {
+        let db = setup_db().await;
+        let sha_fetching = "deadbeef1234567890abcdef1234567890abcdef";
+        let synthetic_id = format!("{}@sashiko.local", sha_fetching);
+
+        // 1. Placeholder patchset in Fetching state with @sashiko.local cover letter
+        db.create_fetching_patchset(
+            &synthetic_id,
+            "Fetching placeholder",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Must return true when queried by bare SHA
+        assert!(
+            db.has_patchset_by_msgid(sha_fetching).await.unwrap(),
+            "has_patchset_by_msgid should return true for bare SHA matching @sashiko.local cover letter"
+        );
+
+        // 2. Patchset with physical patch row
+        let sha_patch = "c0ffee1234567890abcdef1234567890abcdef";
+        let t = db
+            .create_thread("t_thread", "Test Thread", 1000)
+            .await
+            .unwrap();
+        db.create_message(
+            "cover_letter@example.com",
+            t,
+            None,
+            "Author <a@example.com>",
+            "Cover Subject",
+            999,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            sha_patch,
+            t,
+            Some("cover_letter@example.com"),
+            "Author <a@example.com>",
+            "Patch Subject",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps = db
+            .create_patchset(
+                t,
+                Some("cover_letter@example.com"),
+                sha_patch,
+                "Patch Subject",
+                "Author <a@example.com>",
+                1000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        db.create_patch(ps, sha_patch, 1, "diff-patch")
+            .await
+            .unwrap();
+
+        // Must return true when queried by the patch's SHA even if cover letter is different
+        assert!(
+            db.has_patchset_by_msgid(sha_patch).await.unwrap(),
+            "has_patchset_by_msgid should return true for SHA existing in patches table"
+        );
+    }
+
+    /// Verify that has_patchset_by_msgid returns false for Failed and Cancelled
+    /// patchsets so that retry submissions can be re-fetched.
+    #[tokio::test]
+    async fn test_has_patchset_by_msgid_excludes_failed_and_cancelled() {
+        let db = setup_db().await;
+        let sha_failed = "f00f00f001234567890abcdef1234567890abcdef";
+        let synthetic_failed = format!("{}@sashiko.local", sha_failed);
+
+        // 1. Create a patchset and mark it Failed
+        let _ps_failed = db
+            .create_fetching_patchset(
+                &synthetic_failed,
+                "Fetching failed placeholder",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        db.update_patchset_error(sha_failed, "Remote host unreachable")
+            .await
+            .unwrap();
+
+        // Must return false for Failed patchset to allow retry
+        assert!(
+            !db.has_patchset_by_msgid(sha_failed).await.unwrap(),
+            "has_patchset_by_msgid should return false for Failed patchset to allow retry"
+        );
+
+        // 2. Create a patchset and mark it Cancelled
+        let sha_cancelled = "c00c00c001234567890abcdef1234567890abcdef";
+        let synthetic_cancelled = format!("{}@sashiko.local", sha_cancelled);
+        let ps_cancelled = db
+            .create_fetching_patchset(
+                &synthetic_cancelled,
+                "Fetching cancelled placeholder",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        db.update_patchset_status(ps_cancelled, "Cancelled")
+            .await
+            .unwrap();
+
+        // Must return false for Cancelled patchset to allow retry
+        assert!(
+            !db.has_patchset_by_msgid(sha_cancelled).await.unwrap(),
+            "has_patchset_by_msgid should return false for Cancelled patchset to allow retry"
+        );
+
+        // 3. Create a patchset with a physical patch row, then mark patchset Failed
+        let sha_failed_patch = "a11a11a111234567890abcdef1234567890abcdef";
+        let t_failed = db
+            .create_thread("t_f", "Failed thread", 2000)
+            .await
+            .unwrap();
+        db.create_message(
+            "cover_failed@example.com",
+            t_failed,
+            None,
+            "Author <a@example.com>",
+            "Failed Subject",
+            2000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            sha_failed_patch,
+            t_failed,
+            Some("cover_failed@example.com"),
+            "Author <a@example.com>",
+            "Failed Patch Subject",
+            2001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_f = db
+            .create_patchset(
+                t_failed,
+                Some("cover_failed@example.com"),
+                sha_failed_patch,
+                "Failed Patch Subject",
+                "Author <a@example.com>",
+                2001,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        db.create_patch(ps_f, sha_failed_patch, 1, "diff-fail")
+            .await
+            .unwrap();
+        db.update_patchset_status(ps_f, "Failed").await.unwrap();
+
+        // Must return false when queried by the patch's SHA because its patchset is Failed
+        assert!(
+            !db.has_patchset_by_msgid(sha_failed_patch).await.unwrap(),
+            "has_patchset_by_msgid should return false for patch SHA belonging to Failed patchset"
+        );
+
+        // 4. Create a patchset with a physical patch row, then mark patchset Cancelled
+        let sha_cancelled_patch = "b22b22b221234567890abcdef1234567890abcdef";
+        let t_cancelled = db
+            .create_thread("t_c", "Cancelled thread", 3000)
+            .await
+            .unwrap();
+        db.create_message(
+            "cover_cancelled@example.com",
+            t_cancelled,
+            None,
+            "Author <a@example.com>",
+            "Cancelled Subject",
+            3000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            sha_cancelled_patch,
+            t_cancelled,
+            Some("cover_cancelled@example.com"),
+            "Author <a@example.com>",
+            "Cancelled Patch Subject",
+            3001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_c = db
+            .create_patchset(
+                t_cancelled,
+                Some("cover_cancelled@example.com"),
+                sha_cancelled_patch,
+                "Cancelled Patch Subject",
+                "Author <a@example.com>",
+                3001,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        db.create_patch(ps_c, sha_cancelled_patch, 1, "diff-cancel")
+            .await
+            .unwrap();
+        db.update_patchset_status(ps_c, "Cancelled").await.unwrap();
+
+        // Must return false when queried by the patch's SHA because its patchset is Cancelled
+        assert!(
+            !db.has_patchset_by_msgid(sha_cancelled_patch).await.unwrap(),
+            "has_patchset_by_msgid should return false for patch SHA belonging to Cancelled patchset"
+        );
+
+        // 5. Create a patchset with a physical patch row, then mark patchset Failed To Apply
+        let sha_fta_patch = "c33c33c331234567890abcdef1234567890abcdef";
+        let t_fta = db
+            .create_thread("t_fta", "Failed to apply thread", 4000)
+            .await
+            .unwrap();
+        db.create_message(
+            "cover_fta@example.com",
+            t_fta,
+            None,
+            "Author <a@example.com>",
+            "FTA Subject",
+            4000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            sha_fta_patch,
+            t_fta,
+            Some("cover_fta@example.com"),
+            "Author <a@example.com>",
+            "FTA Patch Subject",
+            4001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_fta = db
+            .create_patchset(
+                t_fta,
+                Some("cover_fta@example.com"),
+                sha_fta_patch,
+                "FTA Patch Subject",
+                "Author <a@example.com>",
+                4001,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        db.create_patch(ps_fta, sha_fta_patch, 1, "diff-fta")
+            .await
+            .unwrap();
+        db.update_patchset_status(ps_fta, "Failed To Apply")
+            .await
+            .unwrap();
+
+        // Must return false when queried by cover letter and by patch SHA
+        assert!(
+            !db.has_patchset_by_msgid("cover_fta@example.com")
+                .await
+                .unwrap(),
+            "has_patchset_by_msgid should return false for cover letter of Failed To Apply patchset"
+        );
+        assert!(
+            !db.has_patchset_by_msgid(sha_fta_patch).await.unwrap(),
+            "has_patchset_by_msgid should return false for patch SHA belonging to Failed To Apply patchset"
+        );
+    }
+
+    /// Verify that create_fetching_patchset resets patchsets in 'Failed To Apply'
+    /// status to 'Fetching' so that re-submitted patches can transition to 'Pending'.
+    #[tokio::test]
+    async fn test_failed_to_apply_patchset_resettable_and_reingestible() {
+        let db = setup_db().await;
+        let sha = "d44d44d441234567890abcdef1234567890abcdef";
+        let synthetic_cover = format!("{}@sashiko.local", sha);
+
+        // 1. Create a placeholder and ingest the patch
+        let ps_id = db
+            .create_fetching_patchset(
+                &synthetic_cover,
+                "Fetching initial",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let t = db
+            .create_thread("t_reingest", "Thread", 5000)
+            .await
+            .unwrap();
+        db.create_message(
+            sha,
+            t,
+            Some(&synthetic_cover),
+            "Author <a@example.com>",
+            "Patch Subject",
+            5000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_created = db
+            .create_patchset(
+                t,
+                Some(&synthetic_cover),
+                sha,
+                "Patch Subject",
+                "Author <a@example.com>",
+                5000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ps_id, ps_created);
+
+        db.create_patch(ps_id, sha, 1, "diff-v1").await.unwrap();
+
+        // 2. Mark patchset Failed To Apply during review
+        db.update_patchset_status(ps_id, "Failed To Apply")
+            .await
+            .unwrap();
+
+        let det = db
+            .get_patchset_details(ps_id, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["status"], "Failed To Apply");
+
+        // 3. User re-submits: create_fetching_patchset must reset status to Fetching
+        let ps_re_id = db
+            .create_fetching_patchset(
+                &synthetic_cover,
+                "Fetching retry",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(ps_re_id, ps_id);
+
+        let det_after_fetch = db
+            .get_patchset_details(ps_id, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det_after_fetch["status"], "Fetching");
+
+        // 4. Ingestion re-runs create_patchset and create_patch
+        let ps_reingested = db
+            .create_patchset(
+                t,
+                Some(&synthetic_cover),
+                sha,
+                "Patch Subject Retry",
+                "Author <a@example.com>",
+                5010,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ps_reingested, ps_id);
+
+        db.create_patch(ps_id, sha, 1, "diff-v2").await.unwrap();
+
+        // Patchset must now successfully be in Pending status (ready for review)
+        let det_final = db
+            .get_patchset_details(ps_id, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det_final["status"], "Pending");
     }
 
     /// Verify that an existing database at user_version = 1 with the legacy

--- a/src/db.rs
+++ b/src/db.rs
@@ -3703,7 +3703,7 @@ impl Database {
     #[allow(clippy::too_many_arguments)]
     pub async fn create_fetching_patchset(
         &self,
-        article_id: &str,
+        root_msg_id: &str,
         subject: &str,
         skip_filters: Option<&Vec<String>>,
         only_filters: Option<&Vec<String>>,
@@ -3716,13 +3716,7 @@ impl Database {
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs() as i64;
 
-        let root_msg_id = if article_id.contains('@') {
-            article_id.to_string()
-        } else {
-            format!("{}@sashiko.local", article_id)
-        };
-
-        let clid_candidates = vec![article_id.to_string(), root_msg_id.clone()];
+        let clid_candidates = vec![root_msg_id.to_string()];
 
         let skip_filters_json = skip_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
         let only_filters_json = only_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
@@ -3754,7 +3748,7 @@ impl Database {
         }
 
         // 2. Ensure a placeholder thread and message exist to satisfy Foreign Key constraints
-        let thread_id = self.ensure_thread_for_message(&root_msg_id, now).await?;
+        let thread_id = self.ensure_thread_for_message(root_msg_id, now).await?;
 
         // 3. Create the fetching patchset
         let mut rows = self.conn
@@ -3771,12 +3765,7 @@ impl Database {
             Err(anyhow::anyhow!("Failed to get patchset ID"))
         }
     }
-    pub async fn update_patchset_error(&self, article_id: &str, error: &str) -> Result<()> {
-        let root_msg_id = if article_id.contains('@') {
-            article_id.to_string()
-        } else {
-            format!("{}@sashiko.local", article_id)
-        };
+    pub async fn update_patchset_error(&self, root_msg_id: &str, error: &str) -> Result<()> {
         self.conn
             .execute(
                 "UPDATE patchsets SET status = 'Failed', failed_reason = ? WHERE cover_letter_message_id = ?",

--- a/src/db.rs
+++ b/src/db.rs
@@ -460,11 +460,13 @@ impl Database {
     }
 
     pub async fn migrate(&self) -> Result<()> {
-        let mut rows = self.conn.query("PRAGMA user_version", ()).await?;
-        let current_version: u32 = if let Some(row) = rows.next().await? {
-            row.get(0).unwrap_or(0)
-        } else {
-            0
+        let current_version: u32 = {
+            let mut rows = self.conn.query("PRAGMA user_version", ()).await?;
+            if let Some(row) = rows.next().await? {
+                row.get(0).unwrap_or(0)
+            } else {
+                0
+            }
         };
 
         if current_version == 0 {
@@ -491,6 +493,8 @@ impl Database {
         } else {
             info!("Database version is {}", current_version);
         }
+
+        self.migrate_patches_unique_constraint_if_needed().await?;
 
         Ok(())
     }
@@ -703,6 +707,69 @@ impl Database {
                 "strftime('%Y-%m-%d', created_at, 'unixepoch'), status",
             )
             .await;
+
+        Ok(())
+    }
+
+    async fn migrate_patches_unique_constraint_if_needed(&self) -> Result<()> {
+        // Migrate patches table if it has the legacy UNIQUE(message_id) constraint
+        let mut unique_indices = Vec::new();
+        if let Ok(mut rows) = self.conn.query("PRAGMA index_list(patches)", ()).await {
+            while let Ok(Some(row)) = rows.next().await {
+                let is_unique: i64 = row.get(2).unwrap_or(0);
+                let idx_name: String = row.get(1).unwrap_or_default();
+                if is_unique == 1 {
+                    unique_indices.push(idx_name);
+                }
+            }
+        }
+
+        let mut has_old_unique_msgid = false;
+        for idx_name in unique_indices {
+            let mut cols = Vec::new();
+            if let Ok(mut info_rows) = self
+                .conn
+                .query(&format!("PRAGMA index_info(\"{}\")", idx_name), ())
+                .await
+            {
+                while let Ok(Some(irow)) = info_rows.next().await {
+                    let col_name: String = irow.get(2).unwrap_or_default();
+                    cols.push(col_name);
+                }
+            }
+            if cols == vec!["message_id"] {
+                has_old_unique_msgid = true;
+                break;
+            }
+        }
+
+        if has_old_unique_msgid {
+            info!("Migrating patches table to composite UNIQUE(patchset_id, message_id)...");
+            let _ = self.conn.execute("PRAGMA foreign_keys = OFF", ()).await;
+            self.conn
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS patches_new (
+                        id INTEGER PRIMARY KEY,
+                        patchset_id INTEGER NOT NULL,
+                        message_id TEXT NOT NULL,
+                        part_index INTEGER,
+                        diff TEXT,
+                        status TEXT,
+                        apply_error TEXT,
+                        FOREIGN KEY(patchset_id) REFERENCES patchsets(id),
+                        FOREIGN KEY(message_id) REFERENCES messages(message_id),
+                        UNIQUE(patchset_id, message_id)
+                    );
+                    INSERT OR IGNORE INTO patches_new (id, patchset_id, message_id, part_index, diff, status, apply_error)
+                    SELECT id, patchset_id, message_id, part_index, diff, status, apply_error FROM patches;
+                    DROP TABLE patches;
+                    ALTER TABLE patches_new RENAME TO patches;
+                    CREATE INDEX IF NOT EXISTS idx_patches_patchset_id ON patches(patchset_id);",
+                )
+                .await?;
+            let _ = self.conn.execute("PRAGMA foreign_keys = ON", ()).await;
+        }
+
         Ok(())
     }
 
@@ -2220,65 +2287,59 @@ impl Database {
             ));
         }
 
-        // Check if patch exists and get old patchset_id to fix counts if we steal it
-        let old_patchset_id: Option<i64> = {
+        // Check if patch with same message_id already exists in this patchset
+        let existing_in_patchset: bool = {
             let mut rows = self
                 .conn
                 .query(
-                    "SELECT patchset_id FROM patches WHERE message_id = ?",
-                    libsql::params![message_id],
+                    "SELECT 1 FROM patches WHERE patchset_id = ? AND message_id = ?",
+                    libsql::params![patchset_id, message_id],
                 )
                 .await?;
-            if let Ok(Some(row)) = rows.next().await {
-                Some(row.get(0)?)
-            } else {
-                None
-            }
+            rows.next().await.ok().flatten().is_some()
         };
 
-        // Insert or Update (Move patch to new patchset if duplicate)
-        self.conn.execute(
-            "INSERT INTO patches (patchset_id, message_id, part_index, diff) VALUES (?, ?, ?, ?)
-             ON CONFLICT(message_id) DO UPDATE SET
-                patchset_id=excluded.patchset_id,
-                part_index=excluded.part_index,
-                diff=excluded.diff",
-            libsql::params![patchset_id, message_id, part_index, crate::compression::compress_string_if_needed(diff)]
-        ).await?;
-
-        // Update received_parts for the NEW patchset
+        // Insert or update within THIS patchset.
         self.conn
             .execute(
-                "UPDATE patchsets SET received_parts = (SELECT COUNT(*) FROM patches WHERE patchset_id = ?) WHERE id = ?",
-                libsql::params![patchset_id, patchset_id],
+                "INSERT INTO patches (patchset_id, message_id, part_index, diff) VALUES (?, ?, ?, ?)
+                 ON CONFLICT(patchset_id, message_id) DO UPDATE SET
+                    part_index=excluded.part_index,
+                    diff=excluded.diff",
+                libsql::params![
+                    patchset_id,
+                    message_id,
+                    part_index,
+                    crate::compression::compress_string_if_needed(diff)
+                ],
             )
             .await?;
 
-        // Update received_parts for the OLD patchset (if we moved it)
-        if let Some(old_id) = old_patchset_id
-            && old_id != patchset_id
-        {
+        // Update received_parts to match the physical patch count in this patchset
+        if !existing_in_patchset {
             self.conn
-                        .execute(
-                            "UPDATE patchsets SET received_parts = (SELECT COUNT(*) FROM patches WHERE patchset_id = ?) WHERE id = ?",
-                            libsql::params![old_id, old_id],
-                        )
-                        .await?;
+                .execute(
+                    "UPDATE patchsets SET received_parts = (SELECT COUNT(*) FROM patches WHERE patchset_id = ?) WHERE id = ?",
+                    libsql::params![patchset_id, patchset_id],
+                )
+                .await?;
         }
 
         // Check if complete and update status
         // We transition from 'Incomplete' OR 'Fetching' to 'Pending' (ready for review)
-        self.conn.execute(
-            "UPDATE patchsets SET status = 'Pending' WHERE id = ? AND received_parts >= total_parts AND status IN ('Incomplete', 'Fetching')",
-            libsql::params![patchset_id],
-        ).await?;
+        self.conn
+            .execute(
+                "UPDATE patchsets SET status = 'Pending' WHERE id = ? AND received_parts >= total_parts AND status IN ('Incomplete', 'Fetching')",
+                libsql::params![patchset_id],
+            )
+            .await?;
 
-        // Get the patch ID
+        // Get the patch ID for this patch in this patchset
         let mut rows = self
             .conn
             .query(
-                "SELECT id FROM patches WHERE message_id = ?",
-                libsql::params![message_id],
+                "SELECT id FROM patches WHERE patchset_id = ? AND message_id = ?",
+                libsql::params![patchset_id, message_id],
             )
             .await?;
 
@@ -6921,6 +6982,1326 @@ mod tests {
         assert_eq!(
             single_det["received_parts"], 1,
             "Singleton patchset should still have exactly 1 patch"
+        );
+    }
+
+    /// Count the actual patch rows owned by a patchset.
+    async fn count_patches(db: &Database, patchset_id: i64) -> i64 {
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT COUNT(*) FROM patches WHERE patchset_id = ?",
+                libsql::params![patchset_id],
+            )
+            .await
+            .unwrap();
+        if let Ok(Some(row)) = rows.next().await {
+            row.get(0).unwrap()
+        } else {
+            0
+        }
+    }
+
+    /// Verify that create_patch does not steal a patch from one patchset
+    /// to give it to another when both share the same message_id (SHA).
+    ///
+    /// Reproduces the bug where submitting a single commit then a range
+    /// containing the same commit causes the singleton to drop to 0/1.
+    #[tokio::test]
+    async fn test_create_patch_no_cross_patchset_steal() {
+        let db = setup_db().await;
+        let author = "Test <test@example.com>";
+        let shared_sha = "abcdef1234567890abcdef1234567890abcdef12";
+
+        // Thread 1: singleton submission
+        let t1 = db
+            .create_thread("single_root", "Single", 80000)
+            .await
+            .unwrap();
+        db.create_message(
+            shared_sha,
+            t1,
+            None,
+            author,
+            "Fix something",
+            80000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_single = db
+            .create_patchset(
+                t1,
+                Some(shared_sha),
+                shared_sha,
+                "Fix something",
+                author,
+                80000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_single, shared_sha, 1, "diff-singleton")
+            .await
+            .unwrap();
+
+        let det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["received_parts"], 1, "Singleton should have 1 patch");
+
+        // Thread 2: range submission that includes the same SHA
+        let t2 = db
+            .create_thread("range_root", "Range", 80010)
+            .await
+            .unwrap();
+        db.create_message(
+            "range_root",
+            t2,
+            None,
+            author,
+            "Range cover",
+            80010,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "sha_other",
+            t2,
+            Some("range_root"),
+            author,
+            "[PATCH 1/2] Other fix",
+            80011,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_range = db
+            .create_patchset(
+                t2,
+                Some("range_root"),
+                "sha_other",
+                "[PATCH 1/2] Other fix",
+                author,
+                80011,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_range, "sha_other", 1, "diff-other")
+            .await
+            .unwrap();
+
+        // Patch 2/2 uses the SAME message_id as the singleton.
+        db.create_message(
+            shared_sha,
+            t2,
+            Some("range_root"),
+            author,
+            "[PATCH 2/2] Fix something",
+            80012,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // This should NOT steal the patch from ps_single.
+        db.create_patch(ps_range, shared_sha, 2, "diff-range-copy")
+            .await
+            .unwrap();
+
+        // Singleton must keep its patch
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["received_parts"], 1,
+            "Singleton must keep its patch (was stolen by range)"
+        );
+        // Verify the actual patch row still belongs to the singleton
+        assert_eq!(
+            count_patches(&db, ps_single).await,
+            1,
+            "Singleton must physically own its patch row"
+        );
+
+        // Range should have both patches
+        let range_det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det["received_parts"], 2,
+            "Range should have both patches"
+        );
+        assert_eq!(
+            count_patches(&db, ps_range).await,
+            2,
+            "Range must physically own both patch rows"
+        );
+
+        // Resubmit the same range patch again (idempotent guard)
+        db.create_patch(ps_range, shared_sha, 2, "diff-range-copy")
+            .await
+            .unwrap();
+
+        // received_parts must not exceed total_parts
+        let range_det2 = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det2["received_parts"], 2,
+            "Resubmission must not over-count received_parts"
+        );
+    }
+
+    /// Same singleton submitted twice: create_patch should be idempotent
+    /// via ON CONFLICT within the same patchset.
+    #[tokio::test]
+    async fn test_create_patch_same_singleton_twice() {
+        let db = setup_db().await;
+        let author = "Test <test@example.com>";
+
+        let t1 = db.create_thread("root_dup", "Dup", 70000).await.unwrap();
+        db.create_message(
+            "sha_dup",
+            t1,
+            None,
+            author,
+            "Fix duplicate",
+            70000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps = db
+            .create_patchset(
+                t1,
+                Some("sha_dup"),
+                "sha_dup",
+                "Fix duplicate",
+                author,
+                70000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // First insert
+        db.create_patch(ps, "sha_dup", 1, "diff-v1").await.unwrap();
+        let det = db
+            .get_patchset_details(ps, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["received_parts"], 1);
+
+        // Second insert (same patchset, same message_id) -- idempotent
+        db.create_patch(ps, "sha_dup", 1, "diff-v2").await.unwrap();
+        let det = db
+            .get_patchset_details(ps, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 1,
+            "Duplicate insert in same patchset must stay at 1"
+        );
+    }
+
+    /// Same range submitted twice: each patch in the range should be
+    /// idempotent via ON CONFLICT within the same patchset.
+    #[tokio::test]
+    async fn test_create_patch_same_range_twice() {
+        let db = setup_db().await;
+        let author = "Test <test@example.com>";
+
+        let t1 = db
+            .create_thread("range_dup_root", "Range dup", 71000)
+            .await
+            .unwrap();
+        db.create_message(
+            "range_dup_root",
+            t1,
+            None,
+            author,
+            "Range cover",
+            71000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        for sha in ["sha_r1", "sha_r2"] {
+            db.create_message(
+                sha,
+                t1,
+                Some("range_dup_root"),
+                author,
+                &format!("[PATCH] {}", sha),
+                71001,
+                "",
+                "",
+                "",
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let ps = db
+            .create_patchset(
+                t1,
+                Some("range_dup_root"),
+                "sha_r1",
+                "[PATCH 1/2] sha_r1",
+                author,
+                71001,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // First round
+        db.create_patch(ps, "sha_r1", 1, "diff-r1").await.unwrap();
+        db.create_patch(ps, "sha_r2", 2, "diff-r2").await.unwrap();
+        let det = db
+            .get_patchset_details(ps, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["received_parts"], 2);
+
+        // Second round (duplicate range submission)
+        db.create_patch(ps, "sha_r1", 1, "diff-r1").await.unwrap();
+        db.create_patch(ps, "sha_r2", 2, "diff-r2").await.unwrap();
+        let det = db
+            .get_patchset_details(ps, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 2,
+            "Duplicate range in same patchset must stay at 2"
+        );
+    }
+
+    /// Range submitted first, then singleton with shared SHA: neither
+    /// should lose its patch.
+    #[tokio::test]
+    async fn test_create_patch_range_then_singleton() {
+        let db = setup_db().await;
+        let author = "Test <test@example.com>";
+        let shared_sha = "shared_range_then_single";
+
+        // Thread 1: range first
+        let t1 = db
+            .create_thread("rts_range_root", "Range first", 72000)
+            .await
+            .unwrap();
+        db.create_message(
+            "rts_range_root",
+            t1,
+            None,
+            author,
+            "Range cover",
+            72000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "rts_other",
+            t1,
+            Some("rts_range_root"),
+            author,
+            "[PATCH 1/2] Other",
+            72001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            shared_sha,
+            t1,
+            Some("rts_range_root"),
+            author,
+            "[PATCH 2/2] Shared",
+            72002,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_range = db
+            .create_patchset(
+                t1,
+                Some("rts_range_root"),
+                "rts_other",
+                "[PATCH 1/2] Other",
+                author,
+                72001,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_range, "rts_other", 1, "diff-other")
+            .await
+            .unwrap();
+        db.create_patch(ps_range, shared_sha, 2, "diff-shared")
+            .await
+            .unwrap();
+
+        let range_det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det["received_parts"], 2,
+            "Range should have 2 patches"
+        );
+
+        // Thread 2: singleton with the shared SHA
+        let t2 = db
+            .create_thread("rts_single", "Single after", 72010)
+            .await
+            .unwrap();
+        db.create_message(
+            shared_sha,
+            t2,
+            None,
+            author,
+            "Shared commit alone",
+            72010,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_single = db
+            .create_patchset(
+                t2,
+                Some(shared_sha),
+                shared_sha,
+                "Shared commit alone",
+                author,
+                72010,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // This should NOT steal from the range
+        db.create_patch(ps_single, shared_sha, 1, "diff-single")
+            .await
+            .unwrap();
+
+        // Range must still have 2 patches
+        let range_det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det["received_parts"], 2,
+            "Range must keep both patches after singleton submission"
+        );
+        // Verify the range physically owns both patch rows
+        assert_eq!(
+            count_patches(&db, ps_range).await,
+            2,
+            "Range must physically own both patch rows"
+        );
+
+        // Singleton should have 1
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["received_parts"], 1,
+            "Singleton should have 1 patch"
+        );
+        assert_eq!(
+            count_patches(&db, ps_single).await,
+            1,
+            "Singleton must physically own its patch row"
+        );
+    }
+
+    /// 4-patch range where a shared commit is in the middle (not last):
+    /// ensures that all 4 patches are inserted physically and received_parts is 4.
+    #[tokio::test]
+    async fn test_create_patch_range_shared_mid_sequence() {
+        let db = setup_db().await;
+        let author = "Test <test@example.com>";
+        let shared_sha = "sha_mid_shared";
+
+        // Thread 1: singleton with the shared SHA
+        let t1 = db
+            .create_thread("mid_single_root", "Single", 90000)
+            .await
+            .unwrap();
+        db.create_message(
+            shared_sha,
+            t1,
+            None,
+            author,
+            "Shared commit",
+            90000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_single = db
+            .create_patchset(
+                t1,
+                Some(shared_sha),
+                shared_sha,
+                "Shared commit",
+                author,
+                90000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_single, shared_sha, 1, "diff-single")
+            .await
+            .unwrap();
+
+        let det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["received_parts"], 1, "Singleton should have 1 patch");
+
+        // Thread 2: 4-patch range where shared_sha is patch 2 of 4
+        let t2 = db
+            .create_thread("mid_range_root", "Range", 90010)
+            .await
+            .unwrap();
+        db.create_message(
+            "mid_range_root",
+            t2,
+            None,
+            author,
+            "Range cover",
+            90010,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        for sha in ["sha_p1", shared_sha, "sha_p3", "sha_p4"] {
+            db.create_message(
+                sha,
+                t2,
+                Some("mid_range_root"),
+                author,
+                &format!("[PATCH] {}", sha),
+                90011,
+                "",
+                "",
+                "",
+                None,
+                None,
+            )
+            .await
+            .ok(); // shared_sha message already exists, ignore dup
+        }
+
+        let ps_range = db
+            .create_patchset(
+                t2,
+                Some("mid_range_root"),
+                "sha_p1",
+                "[PATCH 1/4] sha_p1",
+                author,
+                90011,
+                4,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Insert patches in order: p1, shared (cross-patchset), p3, p4
+        db.create_patch(ps_range, "sha_p1", 1, "diff-p1")
+            .await
+            .unwrap();
+        let det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 1,
+            "After p1: received_parts should be 1"
+        );
+
+        // Patch 2: shared SHA — cross-patchset, bumps received_parts
+        db.create_patch(ps_range, shared_sha, 2, "diff-shared")
+            .await
+            .unwrap();
+        let det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 2,
+            "After shared: received_parts should be 2"
+        );
+
+        // Patch 3: normal insert — must NOT overwrite the bump
+        db.create_patch(ps_range, "sha_p3", 3, "diff-p3")
+            .await
+            .unwrap();
+        let det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 3,
+            "After p3: received_parts should be 3 (COUNT bug would give 2)"
+        );
+
+        // Patch 4: normal insert — completes the range
+        db.create_patch(ps_range, "sha_p4", 4, "diff-p4")
+            .await
+            .unwrap();
+        let det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            det["received_parts"], 4,
+            "After p4: range must be complete with 4/4"
+        );
+
+        // Verify physical patch ownership: range has all 4 physical patches
+        assert_eq!(
+            count_patches(&db, ps_range).await,
+            4,
+            "Range should physically own all 4 patches"
+        );
+
+        // Singleton must still have its patch
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["received_parts"], 1,
+            "Singleton must keep its patch"
+        );
+        assert_eq!(
+            count_patches(&db, ps_single).await,
+            1,
+            "Singleton must physically own its patch row"
+        );
+
+        // Status check: range should be Pending (complete)
+        assert!(
+            det["status"] == "Pending" || det["status"] == "In Review",
+            "Range status should transition to Pending/In Review, got: {}",
+            det["status"]
+        );
+    }
+
+    /// Verify that when a commit SHA is shared across multiple patchsets
+    /// (e.g. submitted as a singleton and then in a range resubmission),
+    /// both patchsets physically own their patch rows in the database,
+    /// so that get_patch_diffs and get_patchset_details return all patches
+    /// for both patchsets.
+    #[tokio::test]
+    async fn test_cross_patchset_shared_commit_physical_rows_and_diffs() {
+        let db = setup_db().await;
+        let author = "Author <author@example.com>";
+        let shared_sha = "shared_commit_sha_1234567890";
+        let other_sha = "other_commit_sha_0987654321";
+
+        // 1. Thread 1: Singleton patchset with shared_sha
+        let t1 = db
+            .create_thread("t1_singleton", "Singleton Subject", 1000)
+            .await
+            .unwrap();
+        db.create_message(
+            shared_sha,
+            t1,
+            None,
+            author,
+            "Singleton commit",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_single = db
+            .create_patchset(
+                t1,
+                Some(shared_sha),
+                shared_sha,
+                "Singleton commit",
+                author,
+                1000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_single, shared_sha, 1, "diff-shared-v1")
+            .await
+            .unwrap();
+
+        // 2. Thread 2: 2-patch range containing other_sha (part 1) and shared_sha (part 2)
+        let t2 = db
+            .create_thread("t2_range_cover", "Range Subject", 2000)
+            .await
+            .unwrap();
+        db.create_message(
+            "t2_range_cover",
+            t2,
+            None,
+            author,
+            "Range Cover Letter",
+            2000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            other_sha,
+            t2,
+            Some("t2_range_cover"),
+            author,
+            "[PATCH 1/2] Other commit",
+            2001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            shared_sha,
+            t2,
+            Some("t2_range_cover"),
+            author,
+            "[PATCH 2/2] Shared commit",
+            2002,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_range = db
+            .create_patchset(
+                t2,
+                Some("t2_range_cover"),
+                other_sha,
+                "[PATCH 1/2] Other commit",
+                author,
+                2001,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_range, other_sha, 1, "diff-other")
+            .await
+            .unwrap();
+        db.create_patch(ps_range, shared_sha, 2, "diff-shared-v2")
+            .await
+            .unwrap();
+
+        // Check singleton: must have 1 physical patch row and 1 diff
+        assert_eq!(
+            count_patches(&db, ps_single).await,
+            1,
+            "Singleton must physically own 1 patch row"
+        );
+        let single_diffs = db.get_patch_diffs(ps_single).await.unwrap();
+        assert_eq!(
+            single_diffs.len(),
+            1,
+            "Singleton must have 1 patch diff returned by get_patch_diffs"
+        );
+        assert_eq!(single_diffs[0].6, shared_sha);
+
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["patches"].as_array().unwrap().len(),
+            1,
+            "Singleton details must contain 1 patch"
+        );
+
+        // Check range: must have 2 physical patch rows and 2 diffs
+        assert_eq!(
+            count_patches(&db, ps_range).await,
+            2,
+            "Range must physically own 2 patch rows"
+        );
+        let range_diffs = db.get_patch_diffs(ps_range).await.unwrap();
+        assert_eq!(
+            range_diffs.len(),
+            2,
+            "Range must have 2 patch diffs returned by get_patch_diffs (including shared SHA)"
+        );
+        assert_eq!(range_diffs[0].6, other_sha);
+        assert_eq!(range_diffs[1].6, shared_sha);
+
+        let range_det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det["patches"].as_array().unwrap().len(),
+            2,
+            "Range details must contain 2 patches"
+        );
+    }
+
+    /// Verify the reverse ingestion order: range first, then singleton with
+    /// the shared commit. The singleton must physically own its patch row
+    /// and return its diff.
+    #[tokio::test]
+    async fn test_cross_patchset_shared_commit_range_then_singleton() {
+        let db = setup_db().await;
+        let author = "Author <author@example.com>";
+        let shared_sha = "shared_commit_rev_1234567890";
+        let other_sha = "other_commit_rev_0987654321";
+
+        // 1. Thread 1: 2-patch range containing other_sha (part 1) and shared_sha (part 2)
+        let t1 = db
+            .create_thread("t1_range_cover", "Range Subject", 1000)
+            .await
+            .unwrap();
+        db.create_message(
+            "t1_range_cover",
+            t1,
+            None,
+            author,
+            "Range Cover Letter",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            other_sha,
+            t1,
+            Some("t1_range_cover"),
+            author,
+            "[PATCH 1/2] Other commit",
+            1001,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            shared_sha,
+            t1,
+            Some("t1_range_cover"),
+            author,
+            "[PATCH 2/2] Shared commit",
+            1002,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_range = db
+            .create_patchset(
+                t1,
+                Some("t1_range_cover"),
+                other_sha,
+                "[PATCH 1/2] Other commit",
+                author,
+                1001,
+                2,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_range, other_sha, 1, "diff-other")
+            .await
+            .unwrap();
+        db.create_patch(ps_range, shared_sha, 2, "diff-shared-v1")
+            .await
+            .unwrap();
+
+        // 2. Thread 2: Singleton patchset with shared_sha
+        let t2 = db
+            .create_thread("t2_singleton", "Singleton Subject", 2000)
+            .await
+            .unwrap();
+        db.create_message(
+            shared_sha,
+            t2,
+            None,
+            author,
+            "Singleton commit",
+            2000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let ps_single = db
+            .create_patchset(
+                t2,
+                Some(shared_sha),
+                shared_sha,
+                "Singleton commit",
+                author,
+                2000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_single, shared_sha, 1, "diff-shared-v2")
+            .await
+            .unwrap();
+
+        // Check range: must have 2 physical patch rows and 2 diffs
+        assert_eq!(
+            count_patches(&db, ps_range).await,
+            2,
+            "Range must physically own 2 patch rows"
+        );
+        let range_diffs = db.get_patch_diffs(ps_range).await.unwrap();
+        assert_eq!(
+            range_diffs.len(),
+            2,
+            "Range must have 2 patch diffs returned by get_patch_diffs"
+        );
+
+        // Check singleton: must have 1 physical patch row and 1 diff
+        assert_eq!(
+            count_patches(&db, ps_single).await,
+            1,
+            "Singleton must physically own 1 patch row"
+        );
+        let single_diffs = db.get_patch_diffs(ps_single).await.unwrap();
+        assert_eq!(
+            single_diffs.len(),
+            1,
+            "Singleton must have 1 patch diff returned by get_patch_diffs"
+        );
+        assert_eq!(single_diffs[0].6, shared_sha);
+
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["patches"].as_array().unwrap().len(),
+            1,
+            "Singleton details must contain 1 patch"
+        );
+    }
+<<<<<<< HEAD
+=======
+
+    /// Verify that get_patchset_details_by_msgid and get_patchset_summary_by_msgid
+    /// resolve synthetic IDs when queried by bare SHA.
+    #[tokio::test]
+    async fn test_get_patchset_details_by_synthetic_msgid() {
+        let db = setup_db().await;
+        let sha = "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4";
+        let synthetic_id = format!("{}@sashiko.local", sha);
+
+        // Create a fetching patchset with the synthetic cover_letter_message_id
+        let ps_id = db
+            .create_fetching_patchset(
+                &synthetic_id,
+                "Fetching patchset subject",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // 1. Querying with the bare SHA must find the patchset details
+        let details = db
+            .get_patchset_details_by_msgid(sha, None, None)
+            .await
+            .unwrap();
+        assert!(
+            details.is_some(),
+            "get_patchset_details_by_msgid with bare SHA should resolve patchset with @sashiko.local cover letter"
+        );
+        assert_eq!(details.unwrap()["id"], ps_id);
+
+        // 2. Querying with bracketed SHA must also find the patchset details
+        let details_bracketed = db
+            .get_patchset_details_by_msgid(&format!("<{}>", sha), None, None)
+            .await
+            .unwrap();
+        assert_eq!(details_bracketed.unwrap()["id"], ps_id);
+
+        // 3. Querying with full synthetic ID must also find the patchset details
+        let details_full = db
+            .get_patchset_details_by_msgid(&synthetic_id, None, None)
+            .await
+            .unwrap();
+        assert_eq!(details_full.unwrap()["id"], ps_id);
+
+        // 4. Querying with the bare SHA must also find the patchset summary
+        let summary = db
+            .get_patchset_summary_by_msgid(sha, None, None)
+            .await
+            .unwrap();
+        assert!(
+            summary.is_some(),
+            "get_patchset_summary_by_msgid with bare SHA should resolve patchset with @sashiko.local cover letter"
+        );
+        assert_eq!(summary.unwrap()["id"], ps_id);
+
+        // 5. update_patchset_error with bare SHA updates the synthetic patchset
+        db.update_patchset_error(sha, "Fetch failed: timeout")
+            .await
+            .unwrap();
+        let updated = db
+            .get_patchset_details_by_msgid(sha, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated["status"], "Failed");
+        assert_eq!(updated["failed_reason"], "Fetch failed: timeout");
+    }
+
+    /// Verify that an existing database at user_version = 1 with the legacy
+    /// UNIQUE(message_id) constraint is automatically migrated by db.migrate()
+    /// without requiring a user_version bump.
+    #[tokio::test]
+    async fn test_migrate_patches_table_from_version_1_legacy_constraint() {
+        let db_settings = crate::settings::DatabaseSettings {
+            url: ":memory:".to_string(),
+            token: String::new(),
+        };
+        let db = Database::new(&db_settings).await.unwrap();
+
+        // 1. Manually set up a schema matching version 1 with the old UNIQUE(message_id)
+        db.conn
+            .execute_batch(
+                "CREATE TABLE threads (id INTEGER PRIMARY KEY, root_message_id TEXT, subject TEXT, last_updated INTEGER);
+                 CREATE TABLE messages (id INTEGER PRIMARY KEY, message_id TEXT NOT NULL UNIQUE, thread_id INTEGER, in_reply_to TEXT, author TEXT, subject TEXT, date INTEGER, body TEXT, to_recipients TEXT, cc_recipients TEXT, git_blob_hash TEXT, mailing_list TEXT, references_hdr TEXT);
+                 CREATE TABLE patchsets (id INTEGER PRIMARY KEY, thread_id INTEGER, cover_letter_message_id TEXT, subject TEXT, author TEXT, date INTEGER, total_parts INTEGER, received_parts INTEGER, status TEXT, parser_version INTEGER, to_recipients TEXT, cc_recipients TEXT, subject_index INTEGER, baseline_id INTEGER, skip_filters TEXT, only_filters TEXT, model_name TEXT, prompts_git_hash TEXT, baseline_logs TEXT, mr_url TEXT, mr_title TEXT, mr_number TEXT, slug TEXT, provider TEXT, embargo_until INTEGER);
+                 CREATE TABLE patches (
+                     id INTEGER PRIMARY KEY,
+                     patchset_id INTEGER NOT NULL,
+                     message_id TEXT NOT NULL UNIQUE,
+                     part_index INTEGER,
+                     diff TEXT,
+                     status TEXT,
+                     apply_error TEXT,
+                     FOREIGN KEY(patchset_id) REFERENCES patchsets(id),
+                     FOREIGN KEY(message_id) REFERENCES messages(message_id)
+                 );
+                 PRAGMA user_version = 1;",
+            )
+            .await
+            .unwrap();
+
+        // 2. Run migrate() on this existing version 1 database
+        db.migrate().await.unwrap();
+
+        // 3. Verify that create_patch works for multiple patchsets sharing the same message_id
+        let author = "Dev <dev@example.com>";
+        let t = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+        db.create_message(
+            "shared_sha",
+            t,
+            None,
+            author,
+            "Shared",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps1 = db
+            .create_patchset(
+                t,
+                Some("shared_sha"),
+                "shared_sha",
+                "P1",
+                author,
+                1000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let ps2 = db
+            .create_patchset(
+                t,
+                Some("ps2_cover"),
+                "shared_sha",
+                "P2",
+                author,
+                1001,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let patch1 = db.create_patch(ps1, "shared_sha", 1, "diff1").await;
+        assert!(patch1.is_ok(), "First patch insertion should succeed");
+
+        let patch2 = db.create_patch(ps2, "shared_sha", 1, "diff2").await;
+        assert!(
+            patch2.is_ok(),
+            "Second patch with same SHA in different patchset must succeed after migration"
         );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -352,36 +352,71 @@ impl Database {
         }
     }
 
+    pub fn get_msgid_candidates(msg_id: &str) -> Vec<String> {
+        let trimmed = msg_id.trim();
+        if trimmed.is_empty() {
+            return Vec::new();
+        }
+
+        let mut candidates = vec![trimmed.to_string()];
+
+        let clean = trimmed.trim_matches(['<', '>']);
+        if clean != trimmed {
+            candidates.push(clean.to_string());
+        } else {
+            candidates.push(format!("<{}>", clean));
+        }
+
+        if let Some(stripped) = clean.strip_suffix("@sashiko.local") {
+            if !stripped.is_empty() {
+                candidates.push(stripped.to_string());
+                candidates.push(format!("<{}>", stripped));
+            }
+        } else {
+            candidates.push(format!("{}@sashiko.local", clean));
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        candidates.retain(|c| seen.insert(c.clone()));
+        candidates
+    }
+
     pub async fn get_patchset_details_by_msgid(
         &self,
         msg_id: &str,
         page: Option<u32>,
         limit: Option<u32>,
     ) -> Result<Option<serde_json::Value>> {
+        let candidates = Self::get_msgid_candidates(msg_id);
+
         // 1. Try to find a patchset where this is the cover letter
-        let mut rows = self
-            .conn
-            .query(
-                "SELECT id FROM patchsets WHERE cover_letter_message_id = ?",
-                libsql::params![msg_id],
-            )
-            .await?;
-        if let Ok(Some(row)) = rows.next().await {
-            let id: i64 = row.get(0)?;
-            return self.get_patchset_details(id, page, limit).await;
+        for clid in &candidates {
+            let mut rows = self
+                .conn
+                .query(
+                    "SELECT id FROM patchsets WHERE cover_letter_message_id = ? ORDER BY id DESC LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if let Ok(Some(row)) = rows.next().await {
+                let id: i64 = row.get(0)?;
+                return self.get_patchset_details(id, page, limit).await;
+            }
         }
 
         // 2. Fallback: Find a patchset that contains this message as a patch
-        let mut rows = self
-            .conn
-            .query(
-                "SELECT patchset_id FROM patches WHERE message_id = ?",
-                libsql::params![msg_id],
-            )
-            .await?;
-        if let Ok(Some(row)) = rows.next().await {
-            let id: i64 = row.get(0)?;
-            return self.get_patchset_details(id, page, limit).await;
+        for clid in &candidates {
+            let mut rows = self
+                .conn
+                .query(
+                    "SELECT patchset_id FROM patches WHERE message_id = ? ORDER BY id DESC LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if let Ok(Some(row)) = rows.next().await {
+                let id: i64 = row.get(0)?;
+                return self.get_patchset_details(id, page, limit).await;
+            }
         }
 
         Ok(None)
@@ -3190,28 +3225,34 @@ impl Database {
         page: Option<u32>,
         limit: Option<u32>,
     ) -> Result<Option<serde_json::Value>> {
-        let mut rows = self
-            .conn
-            .query(
-                "SELECT id FROM patchsets WHERE cover_letter_message_id = ?",
-                libsql::params![msg_id],
-            )
-            .await?;
-        if let Ok(Some(row)) = rows.next().await {
-            let id: i64 = row.get(0)?;
-            return self.get_patchset_summary(id, page, limit).await;
+        let candidates = Self::get_msgid_candidates(msg_id);
+
+        for clid in &candidates {
+            let mut rows = self
+                .conn
+                .query(
+                    "SELECT id FROM patchsets WHERE cover_letter_message_id = ? ORDER BY id DESC LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if let Ok(Some(row)) = rows.next().await {
+                let id: i64 = row.get(0)?;
+                return self.get_patchset_summary(id, page, limit).await;
+            }
         }
 
-        let mut rows = self
-            .conn
-            .query(
-                "SELECT patchset_id FROM patches WHERE message_id = ?",
-                libsql::params![msg_id],
-            )
-            .await?;
-        if let Ok(Some(row)) = rows.next().await {
-            let id: i64 = row.get(0)?;
-            return self.get_patchset_summary(id, page, limit).await;
+        for clid in &candidates {
+            let mut rows = self
+                .conn
+                .query(
+                    "SELECT patchset_id FROM patches WHERE message_id = ? ORDER BY id DESC LIMIT 1",
+                    libsql::params![clid.clone()],
+                )
+                .await?;
+            if let Ok(Some(row)) = rows.next().await {
+                let id: i64 = row.get(0)?;
+                return self.get_patchset_summary(id, page, limit).await;
+            }
         }
 
         Ok(None)
@@ -3793,10 +3834,7 @@ impl Database {
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs() as i64;
 
-        let mut clid_candidates = vec![root_msg_id.to_string()];
-        if let Some(sha) = root_msg_id.strip_suffix("@sashiko.local") {
-            clid_candidates.push(sha.to_string());
-        }
+        let clid_candidates = Self::get_msgid_candidates(root_msg_id);
 
         let skip_filters_json = skip_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
         let only_filters_json = only_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
@@ -3846,12 +3884,19 @@ impl Database {
         }
     }
     pub async fn update_patchset_error(&self, root_msg_id: &str, error: &str) -> Result<()> {
-        self.conn
-            .execute(
-                "UPDATE patchsets SET status = 'Failed', failed_reason = ? WHERE cover_letter_message_id = ?",
-                libsql::params![error, root_msg_id],
-            )
-            .await?;
+        let candidates = Self::get_msgid_candidates(root_msg_id);
+        for clid in candidates {
+            let res = self
+                .conn
+                .execute(
+                    "UPDATE patchsets SET status = 'Failed', failed_reason = ? WHERE cover_letter_message_id = ?",
+                    libsql::params![error, clid],
+                )
+                .await?;
+            if res > 0 {
+                return Ok(());
+            }
+        }
         Ok(())
     }
 
@@ -8120,8 +8165,6 @@ mod tests {
             "Singleton details must contain 1 patch"
         );
     }
-<<<<<<< HEAD
-=======
 
     /// Verify that get_patchset_details_by_msgid and get_patchset_summary_by_msgid
     /// resolve synthetic IDs when queried by bare SHA.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1743,20 +1743,36 @@ impl Database {
         // 1. Try to find by cover_letter_message_id first (handles placeholders from API/Fetcher)
         let mut clid_candidates = Vec::new();
         if let Some(clid) = cover_letter_message_id {
-            clid_candidates.push(clid.to_string());
+            clid_candidates.push((clid.to_string(), false));
         }
-        // Fallback for single-patch git imports where placeholder is sha@sashiko.local
-        // but the actual cover letter becomes the sha itself.
-        clid_candidates.push(format!("{}@sashiko.local", message_id));
+        // Fallback for single-patch git imports where placeholder is
+        // sha@sashiko.local but the actual cover letter becomes the sha
+        // itself.  Only add the fallback when no explicit cover letter
+        // was provided AND the patch is a singleton (total == 1).
+        // Multi-part ranges always have an explicit cover letter ID,
+        // and the fallback would incorrectly match patchsets from
+        // unrelated submissions that happen to share a commit SHA.
+        if cover_letter_message_id.is_none() || total_parts == 1 {
+            clid_candidates.push((format!("{}@sashiko.local", message_id), true));
+        }
 
-        for clid in clid_candidates {
-            let mut rows = self
-                .conn
-                .query(
-                    "SELECT id, date, author, subject, subject_index, total_parts, status FROM patchsets WHERE cover_letter_message_id = ?",
-                    libsql::params![clid.clone()],
-                )
-                .await?;
+        for (clid, scope_to_thread) in clid_candidates {
+            // When using the @sashiko.local fallback, scope the query
+            // to the same thread to avoid cross-patchset contamination.
+            let query = if scope_to_thread {
+                "SELECT id, date, author, subject, subject_index, total_parts, status FROM patchsets WHERE cover_letter_message_id = ? AND thread_id = ?"
+            } else {
+                "SELECT id, date, author, subject, subject_index, total_parts, status FROM patchsets WHERE cover_letter_message_id = ?"
+            };
+            let mut rows = if scope_to_thread {
+                self.conn
+                    .query(query, libsql::params![clid.clone(), thread_id])
+                    .await?
+            } else {
+                self.conn
+                    .query(query, libsql::params![clid.clone()])
+                    .await?
+            };
             while let Ok(Some(row)) = rows.next().await {
                 let id: i64 = row.get(0)?;
                 let existing_subject: String = row.get(3)?;
@@ -3716,7 +3732,10 @@ impl Database {
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs() as i64;
 
-        let clid_candidates = vec![root_msg_id.to_string()];
+        let mut clid_candidates = vec![root_msg_id.to_string()];
+        if let Some(sha) = root_msg_id.strip_suffix("@sashiko.local") {
+            clid_candidates.push(sha.to_string());
+        }
 
         let skip_filters_json = skip_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
         let only_filters_json = only_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
@@ -3737,7 +3756,7 @@ impl Database {
 
                 // Only reset to Fetching if it failed or is currently fetching.
                 // We don't want to reset if it is already Incomplete, Pending, or Reviewed.
-                if status == "Failed" || status == "Fetching" {
+                if status == "Failed" || status == "Fetching" || status == "Cancelled" {
                     self.conn.execute(
                         "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
                         libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
@@ -6642,6 +6661,266 @@ mod tests {
         assert_eq!(
             ps1, ps2,
             "Patchset from B4 Relay devnull alias and real author email MUST merge"
+        );
+    }
+    /// Verify that a commit SHA submitted as a singleton does NOT steal
+    /// a patch from a range patchset in a different thread.
+    ///
+    /// Regression test for the clid_candidates fallback that matched
+    /// across unrelated patchsets via the @sashiko.local suffix.
+    #[tokio::test]
+    async fn test_range_patch_not_stolen_by_singleton() {
+        let db = setup_db().await;
+        let author = "Akhil R <akhilrajeev@nvidia.com>";
+
+        // Thread 1: single commit submission (sha_D).
+        // For singletons, cover_letter_message_id = message_id.
+        let t1 = db
+            .create_thread("sha_D", "Single commit", 90000)
+            .await
+            .unwrap();
+        db.create_message(
+            "sha_D",
+            t1,
+            None,
+            author,
+            "i2c: tegra: Update timing",
+            90000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_single = db
+            .create_patchset(
+                t1,
+                Some("sha_D"),
+                "sha_D",
+                "i2c: tegra: Update timing",
+                author,
+                90000,
+                1,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_single, "sha_D", 1, "diff-single")
+            .await
+            .unwrap();
+
+        // Verify single patchset is full (1/1)
+        let det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(det["received_parts"], 1);
+        assert_eq!(det["total_parts"], 1);
+
+        // Thread 2: range submission (A..D) with 4 commits.
+        // The root message_id is the range itself.
+        let t2 = db
+            .create_thread("range_root", "Range submission", 90010)
+            .await
+            .unwrap();
+
+        // Create the root/cover message for the range
+        db.create_message(
+            "range_root",
+            t2,
+            None,
+            author,
+            "Range A..D",
+            90010,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // First patch establishes the range patchset
+        db.create_message(
+            "sha_A",
+            t2,
+            Some("range_root"),
+            author,
+            "[PATCH 1/4] Patch sha_A",
+            90011,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_range = db
+            .create_patchset(
+                t2,
+                Some("range_root"),
+                "sha_A",
+                "[PATCH 1/4] Patch sha_A",
+                author,
+                90011,
+                4,
+                0,
+                "",
+                "",
+                None,
+                1,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.create_patch(ps_range, "sha_A", 1, "diff-sha_A")
+            .await
+            .unwrap();
+
+        // Patches 2-3 merge into the range patchset
+        for (i, sha) in ["sha_B", "sha_C"].iter().enumerate() {
+            let idx = (i + 2) as u32;
+            db.create_message(
+                sha,
+                t2,
+                Some("range_root"),
+                author,
+                &format!("[PATCH {}/4] Patch {}", idx, sha),
+                90010 + idx as i64,
+                "",
+                "",
+                "",
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let ps = db
+                .create_patchset(
+                    t2,
+                    Some("range_root"),
+                    sha,
+                    &format!("[PATCH {}/4] Patch {}", idx, sha),
+                    author,
+                    90010 + idx as i64,
+                    4,
+                    0,
+                    "",
+                    "",
+                    None,
+                    idx,
+                    None,
+                    false,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(ps, ps_range, "Patch {}/4 should merge into range", idx);
+            db.create_patch(ps, sha, idx, &format!("diff-{}", sha))
+                .await
+                .unwrap();
+        }
+
+        // Now patch 4/4: its message_id "sha_D_range" differs from
+        // the singleton's "sha_D", but the @sashiko.local fallback
+        // used to construct "sha_D_range@sashiko.local" which is
+        // different enough. The real issue was when message_id was
+        // literally the same SHA. Simulate that: message_id = "sha_D"
+        // but in thread t2.
+        db.create_message(
+            "sha_D_in_range",
+            t2,
+            Some("range_root"),
+            author,
+            "[PATCH 4/4] i2c: tegra: Update timing",
+            90014,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ps_4 = db
+            .create_patchset(
+                t2,
+                Some("range_root"),
+                "sha_D_in_range",
+                "[PATCH 4/4] i2c: tegra: Update timing",
+                author,
+                90014,
+                4,
+                0,
+                "",
+                "",
+                None,
+                4,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .expect("Patch 4/4 should merge into range, not be dropped");
+
+        assert_eq!(
+            ps_4, ps_range,
+            "Patch 4/4 must merge into the range patchset, not the singleton"
+        );
+
+        db.create_patch(ps_4, "sha_D_in_range", 4, "diff-sha_D")
+            .await
+            .unwrap();
+
+        // Range patchset should have all 4 patches
+        let range_det = db
+            .get_patchset_details(ps_range, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            range_det["received_parts"], 4,
+            "Range patchset should have all 4 patches"
+        );
+
+        // Singleton should still be untouched (1/1)
+        let single_det = db
+            .get_patchset_details(ps_single, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            single_det["received_parts"], 1,
+            "Singleton patchset should still have exactly 1 patch"
         );
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -14,6 +14,16 @@
 
 use crate::patch::{Patch, PatchsetMetadata};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageSource {
+    Nntp,
+    ApiInject,
+    ApiFetchThread,
+    GitFetch,
+    GitImport,
+    GitArchive,
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum Event {
@@ -42,6 +52,8 @@ pub enum Event {
     },
     RawMboxSubmitted {
         raw: String,
+        submission_id: String,
+        source: MessageSource,
         group: String,
         baseline: Option<String>,
         skip_subjects: Option<Vec<String>>,
@@ -50,6 +62,7 @@ pub enum Event {
     IngestionFailed {
         article_id: String,
         error: String,
+        source: MessageSource,
     },
 }
 
@@ -57,6 +70,7 @@ pub enum Event {
 pub struct ParsedArticle {
     pub group: String,
     pub article_id: String,
+    pub source: MessageSource,
     pub metadata: Option<PatchsetMetadata>,
     pub patch: Option<Patch>,
     pub baseline: Option<String>,

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::events::Event;
+use crate::events::{Event, MessageSource};
 use crate::utils::redact_secret;
 use anyhow::{Result, anyhow};
 use std::collections::{HashMap, HashSet};
@@ -162,6 +162,7 @@ impl FetchAgent {
                                 .send(Event::IngestionFailed {
                                     article_id: commit.clone(),
                                     error: format!("Failed to set up remote {}: {}", url, e),
+                                    source: MessageSource::GitFetch,
                                 })
                                 .await;
                         }
@@ -183,6 +184,7 @@ impl FetchAgent {
                                     .send(Event::IngestionFailed {
                                         article_id: commit.clone(),
                                         error: format!("Failed to fetch from {}: {}", url, e),
+                                        source: MessageSource::GitFetch,
                                     })
                                     .await;
                             }
@@ -213,6 +215,7 @@ impl FetchAgent {
                                 .send(Event::IngestionFailed {
                                     article_id: range.clone(),
                                     error: format!("Failed to resolve git range: {}", e),
+                                    source: MessageSource::GitFetch,
                                 })
                                 .await;
                             continue;
@@ -276,6 +279,7 @@ impl FetchAgent {
                                 .send(Event::IngestionFailed {
                                     article_id: commit_or_range.clone(),
                                     error: format!("Failed to resolve SHA: {}", e),
+                                    source: MessageSource::GitFetch,
                                 })
                                 .await;
                             continue;
@@ -326,6 +330,7 @@ impl FetchAgent {
                                 .send(Event::IngestionFailed {
                                     article_id: commit_or_range,
                                     error: format!("Failed to extract patch: {}", e),
+                                    source: MessageSource::GitFetch,
                                 })
                                 .await;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@
 
 use clap::{Parser, Subcommand, ValueEnum};
 use sashiko::db::Database;
-use sashiko::events::{Event, ParsedArticle};
+use sashiko::events::{Event, MessageSource, ParsedArticle};
 use sashiko::ingestor::Ingestor;
 use sashiko::local_review::{
     ProgressEvent, ReviewOptions, WorkerOptions, print_worker_json, result_has_error,
@@ -444,11 +444,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let _permit = permit; // Hold permit until task completion
 
                 match event {
-                    Event::IngestionFailed { article_id, error } => {
+                    Event::IngestionFailed {
+                        article_id,
+                        error,
+                        source,
+                    } => {
                         if let Err(e) = tx
                             .send(ParsedArticle {
                                 group: "error".to_string(),
                                 article_id,
+                                source,
                                 metadata: None,
                                 patch: None,
                                 baseline: None,
@@ -514,10 +519,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             part_index: index,
                         });
 
+                        let source = if group.starts_with("git-import") {
+                            MessageSource::GitImport
+                        } else {
+                            MessageSource::GitFetch
+                        };
+
                         if let Err(e) = tx
                             .send(ParsedArticle {
                                 group,
                                 article_id,
+                                source,
                                 metadata: Some(metadata),
                                 patch,
                                 baseline: base_commit,
@@ -535,6 +547,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     Event::RawMboxSubmitted {
                         raw,
+                        submission_id,
+                        source,
                         group,
                         baseline,
                         skip_subjects,
@@ -569,17 +583,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                             match parse_result {
                                 Ok(Ok((metadata, patch_opt))) => {
-                                    // Override group "api-submit" -> "manual" to avoid synthetic ID logic
-                                    let effective_group = if group_clone == "api-submit" {
-                                        "manual".to_string()
-                                    } else {
-                                        group_clone
-                                    };
+                                    // Do not override group "api-submit" to allow grouping logic to trigger
+                                    let effective_group = group_clone;
 
                                     if let Err(e) = tx_clone
                                         .send(ParsedArticle {
                                             group: effective_group,
-                                            article_id: msg_id,
+                                            article_id: submission_id.clone(),
+                                            source,
                                             metadata: Some(metadata),
                                             patch: patch_opt,
                                             baseline: baseline_clone,
@@ -637,6 +648,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     .send(ParsedArticle {
                                         group,
                                         article_id,
+                                        source: MessageSource::Nntp,
                                         metadata: Some(metadata),
                                         patch: patch_opt,
                                         baseline,
@@ -1644,6 +1656,7 @@ async fn process_parsed_article(
     let ParsedArticle {
         group,
         article_id,
+        source,
         metadata,
         patch,
         baseline,
@@ -1655,10 +1668,12 @@ async fn process_parsed_article(
         mr_number,
     } = article;
 
+    let root_msg_id = resolve_root_msg_id(source, &article_id);
+
     // Handle ingestion failure
     if let Some(err) = failed_error {
         info!("Handling ingestion failure for {}: {}", article_id, err);
-        if let Err(e) = worker_db.update_patchset_error(&article_id, &err).await {
+        if let Err(e) = worker_db.update_patchset_error(&root_msg_id, &err).await {
             error!("Failed to update patchset error in DB: {}", e);
         }
         return ProcessStatus::Ingested; // Successfully handled the failure event
@@ -1729,12 +1744,6 @@ async fn process_parsed_article(
         } else if group == "git-fetch" || group == "api-submit" {
             // Group these by article_id (which is the range or single SHA/local_id)
             // For singletons, the message itself is the root.
-            let root_msg_id = if metadata.total == 1 {
-                metadata.message_id.clone()
-            } else {
-                format!("{}@sashiko.local", article_id)
-            };
-
             match worker_db
                 .ensure_thread_for_message(&root_msg_id, metadata.date)
                 .await
@@ -1905,7 +1914,6 @@ async fn process_parsed_article(
     );
     */
 
-    let root_msg_id = format!("{}@sashiko.local", article_id);
     let cover_letter_id = if group == "git-fetch" {
         // Always use root_msg_id for git-fetch to match the placeholder ID
         Some(root_msg_id.as_str())
@@ -1945,14 +1953,14 @@ async fn process_parsed_article(
                     format!("!{}: {}", number, title),
                     metadata.author.clone(),
                     metadata.total,
-                    true,
+                    is_strict_author(source, metadata.total),
                 )
             } else {
                 (
                     metadata.subject.clone(),
                     metadata.author.clone(),
                     metadata.total,
-                    !group.starts_with("git-import"),
+                    is_strict_author(source, metadata.total),
                 )
             }
         } else {
@@ -1960,7 +1968,7 @@ async fn process_parsed_article(
                 metadata.subject.clone(),
                 metadata.author.clone(),
                 metadata.total,
-                !group.starts_with("git-import"),
+                is_strict_author(source, metadata.total),
             )
         };
 
@@ -2210,6 +2218,28 @@ fn calculate_embargo_hours(
         *delays_to_consider.iter().min().unwrap()
     } else {
         policy.defaults.embargo_hours.unwrap_or(0)
+    }
+}
+
+fn resolve_root_msg_id(source: MessageSource, article_id: &str) -> String {
+    match source {
+        MessageSource::Nntp
+        | MessageSource::ApiFetchThread
+        | MessageSource::GitArchive
+        | MessageSource::ApiInject => article_id.to_string(),
+        MessageSource::GitFetch | MessageSource::GitImport => {
+            format!("{}@sashiko.local", article_id)
+        }
+    }
+}
+
+fn is_strict_author(source: MessageSource, total_parts: u32) -> bool {
+    match source {
+        MessageSource::GitImport | MessageSource::GitArchive => false,
+        MessageSource::GitFetch if total_parts > 1 => false,
+        MessageSource::ApiInject if total_parts > 1 => false,
+        MessageSource::ApiFetchThread if total_parts > 1 => false,
+        _ => true,
     }
 }
 
@@ -2636,5 +2666,48 @@ mod tests {
         settings.forge.disable_nntp = true; // This is the default
         let should_start_ingestor = !(settings.forge.enabled && settings.forge.disable_nntp);
         assert!(!should_start_ingestor);
+    }
+
+    #[test]
+    fn test_resolve_root_msg_id() {
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::Nntp, "foo@bar.com"),
+            "foo@bar.com"
+        );
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::ApiFetchThread, "foo@bar.com"),
+            "foo@bar.com"
+        );
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::GitArchive, "foo@bar.com"),
+            "foo@bar.com"
+        );
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::ApiInject, "sashiko-123"),
+            "sashiko-123"
+        );
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::GitFetch, "abc123_sha"),
+            "abc123_sha@sashiko.local"
+        );
+        assert_eq!(
+            resolve_root_msg_id(MessageSource::GitImport, "range_a_b"),
+            "range_a_b@sashiko.local"
+        );
+    }
+
+    #[test]
+    fn test_is_strict_author() {
+        assert!(is_strict_author(MessageSource::Nntp, 1));
+        assert!(is_strict_author(MessageSource::Nntp, 6));
+        assert!(!is_strict_author(MessageSource::ApiFetchThread, 6)); // Lenient for series
+        assert!(!is_strict_author(MessageSource::GitFetch, 6)); // Lenient for series
+        assert!(is_strict_author(MessageSource::GitFetch, 1)); // Strict for singleton
+
+        assert!(!is_strict_author(MessageSource::GitImport, 6));
+        assert!(!is_strict_author(MessageSource::GitArchive, 6));
+
+        assert!(is_strict_author(MessageSource::ApiInject, 1)); // Strict for singleton
+        assert!(!is_strict_author(MessageSource::ApiInject, 6)); // Lenient for series
     }
 }

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -219,9 +219,23 @@ impl Reviewer {
 
         info!("Found {} pending patchsets for review", patchsets.len());
 
-        for patchset in patchsets {
+        for mut patchset in patchsets {
             let permit = self.semaphore.clone().acquire_owned().await?;
             let target_review_count = patchset.target_review_count.unwrap_or(1) as usize;
+
+            // Mark status as 'In Review' in the DB immediately to prevent double-fetching
+            if let Err(e) = self
+                .db
+                .update_patchset_status(patchset.id, ReviewStatus::InReview.as_str())
+                .await
+            {
+                error!(
+                    "Failed to update status to In Review for {}: {}",
+                    patchset.id, e
+                );
+                continue;
+            }
+            patchset.status = Some(ReviewStatus::InReview.as_str().to_string());
 
             let context = ReviewContext {
                 semaphore: self.semaphore.clone(),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -96,13 +96,14 @@ CREATE INDEX IF NOT EXISTS idx_patchsets_status ON patchsets(status);
 CREATE TABLE IF NOT EXISTS patches (
     id INTEGER PRIMARY KEY,
     patchset_id INTEGER NOT NULL,
-    message_id TEXT NOT NULL UNIQUE,
+    message_id TEXT NOT NULL,
     part_index INTEGER,
     diff TEXT,
     status TEXT,
     apply_error TEXT,
     FOREIGN KEY(patchset_id) REFERENCES patchsets(id),
-    FOREIGN KEY(message_id) REFERENCES messages(message_id)
+    FOREIGN KEY(message_id) REFERENCES messages(message_id),
+    UNIQUE(patchset_id, message_id)
 );
 
 CREATE TABLE IF NOT EXISTS reviews (


### PR DESCRIPTION
Harden the API ingestion pipeline against duplicate and redundant submissions that arise when multiple api/submit.

This occurs when we submit the same SHA for review over and over from our CI/CD to sashiko