### PR TITLE
docker: prevent deletion of queued commits on container restart

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -49,9 +49,7 @@ setup_kernel() {
         # Prune unreachable objects and run gc to keep the repo healthy
         echo "Pruning and garbage collecting..."
         git remote prune origin || true
-        git reflog expire --all --expire=now
         git gc --auto
-        git prune
         # Ensure we are on master and it's clean
         git pull origin master || echo "Warning: Failed to update kernel tree, continuing with existing version."
     fi


### PR DESCRIPTION
Removing the aggressive git reflog expire and git prune commands from the container startup script.

Previously, these commands immediately deleted all unreachable commits from the persistent git repository. Because pending reviews in the database queue are not pointed to by any git branch or tag, they were marked as unreachable and pruned during restarts, leading to Failed to Apply errors when the workers attempted to start reviews.

Relying on git gc --auto instead, which safely preserves unreachable commits for the default 2-week grace period.