### PR TITLE
Use server timestamp for api/submit reviews

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -397,6 +397,11 @@ async fn submit_patch(
             let id = generate_synthetic_id("inject");
             info!("Received raw mbox injection: {} (len: {})", id, raw.len());
 
+            let submitted_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .ok();
+
             let event = Event::RawMboxSubmitted {
                 raw,
                 submission_id: id.clone(),
@@ -405,6 +410,7 @@ async fn submit_patch(
                 baseline: base_commit,
                 skip_subjects,
                 only_subjects,
+                submitted_at,
             };
 
             if let Err(e) = state.sender.send(event).await {
@@ -614,6 +620,11 @@ async fn fetch_and_inject_thread(
     })
     .await??;
 
+    let submitted_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .ok();
+
     let event = Event::RawMboxSubmitted {
         raw,
         submission_id: msgid.to_string(),
@@ -622,6 +633,7 @@ async fn fetch_and_inject_thread(
         baseline: None,
         skip_subjects: None,
         only_subjects: None,
+        submitted_at,
     };
 
     sender.send(event).await?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -58,6 +58,10 @@ pub enum Event {
         baseline: Option<String>,
         skip_subjects: Option<Vec<String>>,
         only_subjects: Option<Vec<String>>,
+        /// Server-side timestamp for when the submission was received.
+        /// Used instead of the email's Date: header for patchset ordering
+        /// to prevent stale mbox timestamps from skewing the queue.
+        submitted_at: Option<i64>,
     },
     IngestionFailed {
         article_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         baseline,
                         skip_subjects,
                         only_subjects,
+                        submitted_at,
                     } => {
                         let messages = sashiko::ingestor::split_mbox(raw.as_bytes());
                         let count = messages.len();
@@ -591,7 +592,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             group: effective_group,
                                             article_id: submission_id.clone(),
                                             source,
-                                            metadata: Some(metadata),
+                                            metadata: {
+                                                let mut m = metadata;
+                                                if submitted_at.is_some() {
+                                                    m.received_date = submitted_at;
+                                                }
+                                                Some(m)
+                                            },
                                             patch: patch_opt,
                                             baseline: baseline_clone,
                                             failed_error: None,
@@ -1993,7 +2000,10 @@ async fn process_parsed_article(
                 metadata.message_id.as_str(),
                 &subject,
                 &author,
-                metadata.date,
+                // Use server-side timestamp (received_date) when available,
+                // falling back to the email's Date: header. This prevents
+                // stale mbox timestamps from skewing queue ordering.
+                metadata.received_date.unwrap_or(metadata.date),
                 total_parts,
                 PARSER_VERSION,
                 &metadata.to,


### PR DESCRIPTION
On top of #411 . The only new commit is the last:

api: use server timestamp for API-injected mbox submissions

Add a submitted_at field to Event::RawMboxSubmitted, stamped with
the server's current time when a raw mbox is submitted via POST
/api/submit (Inject variant). This timestamp is propagated through
metadata.received_date and used as the patchset date instead of
the email's Date: header.

This prevents stale mbox timestamps (which can be arbitrarily far
in the past) from skewing queue ordering. The original email date
is preserved in the messages table for display purposes.

The Thread and Remote submission paths are unaffected as they
already use server-side timestamps via create_fetching_patchset().
