### PR TITLE
Cherry-pick merge conflict review

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -148,3 +148,13 @@ worktree_dir = "review_trees"
 timeout_seconds = 7200
 max_retries = 3
 ignore_files = ["MAINTAINERS", ".mailmap", ".gitignore", "LICENSES/"]
+
+# Priority rules for patchset queue ordering (evaluated in order; last match wins).
+# Range is 1 to 999. Default priority is 500. Values > 500 are elevated; values < 500 are deprioritized.
+# [[review.priority_rules]]
+# regex = "(?i)^PRODKERNEL:"
+# priority = 750
+#
+# [[review.priority_rules]]
+# regex = "(?i)security"
+# priority = 999

--- a/src/api.rs
+++ b/src/api.rs
@@ -397,6 +397,11 @@ async fn submit_patch(
             let id = generate_synthetic_id("inject");
             info!("Received raw mbox injection: {} (len: {})", id, raw.len());
 
+            let submitted_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .ok();
+
             let event = Event::RawMboxSubmitted {
                 raw,
                 submission_id: id.clone(),
@@ -405,6 +410,7 @@ async fn submit_patch(
                 baseline: base_commit,
                 skip_subjects,
                 only_subjects,
+                submitted_at,
             };
 
             if let Err(e) = state.sender.send(event).await {
@@ -614,6 +620,11 @@ async fn fetch_and_inject_thread(
     })
     .await??;
 
+    let submitted_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .ok();
+
     let event = Event::RawMboxSubmitted {
         raw,
         submission_id: msgid.to_string(),
@@ -622,6 +633,7 @@ async fn fetch_and_inject_thread(
         baseline: None,
         skip_subjects: None,
         only_subjects: None,
+        submitted_at,
     };
 
     sender.send(event).await?;

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,7 +14,6 @@
 
 use crate::db::Database;
 use crate::events::{Event, MessageSource};
-use crate::fetcher::FetchRequest;
 use axum::{
     Json, Router,
     extract::{ConnectInfo, Path, Query, Request, State},
@@ -126,7 +125,6 @@ pub struct AppState {
     pub settings: Arc<crate::settings::Settings>,
     pub db: Arc<Database>,
     pub sender: mpsc::Sender<Event>,
-    pub fetch_sender: mpsc::Sender<FetchRequest>,
     pub forge_registry: Arc<crate::forge::ForgeRegistry>,
     pub read_only: bool,
     pub allow_all_submit: bool,
@@ -260,7 +258,6 @@ pub fn build_router(
     settings: Arc<crate::settings::Settings>,
     db: Arc<Database>,
     sender: mpsc::Sender<Event>,
-    fetch_sender: mpsc::Sender<FetchRequest>,
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
@@ -272,7 +269,6 @@ pub fn build_router(
         settings: settings.clone(),
         db,
         sender,
-        fetch_sender,
         read_only,
         forge_registry,
         allow_all_submit,
@@ -318,7 +314,6 @@ pub async fn run_server(
     settings: Arc<crate::settings::Settings>,
     db: Arc<Database>,
     sender: mpsc::Sender<Event>,
-    fetch_sender: mpsc::Sender<FetchRequest>,
     allow_all_submit: bool,
     smtp_enabled: bool,
     dry_run: bool,
@@ -327,7 +322,6 @@ pub async fn run_server(
         settings.clone(),
         db,
         sender,
-        fetch_sender,
         allow_all_submit,
         smtp_enabled,
         dry_run,
@@ -462,10 +456,11 @@ async fn submit_patch(
             }
 
             // Create a placeholder record in the DB so the user can track status
-            if let Err(e) = state
+            let cover_id = format!("{}@sashiko.local", id);
+            let patchset_id = match state
                 .db
                 .create_fetching_patchset(
-                    &format!("{}@sashiko.local", id),
+                    &cover_id,
                     &format!("Fetching {} from {}...", &sha, repo_display),
                     skip_subjects.as_ref(),
                     only_subjects.as_ref(),
@@ -478,20 +473,29 @@ async fn submit_patch(
                 )
                 .await
             {
-                error!("Failed to create placeholder patchset: {}", e);
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-            }
-
-            let req = FetchRequest {
-                repo_url: repo,
-                commit_hash: sha,
-                mr_url: None,
-                mr_title: None,
-                mr_number: None,
+                Ok(pid) => pid,
+                Err(e) => {
+                    error!("Failed to create placeholder patchset: {}", e);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
             };
 
-            if let Err(e) = state.fetch_sender.send(req).await {
-                error!("Failed to send fetch request to queue: {}", e);
+            // Persist the fetch durably; the FetchWorker will pick it up.
+            if let Err(e) = state
+                .db
+                .enqueue_fetch(
+                    Some(patchset_id),
+                    Some(&cover_id),
+                    repo.as_deref(),
+                    &sha,
+                    None,
+                    None,
+                    None,
+                    500,
+                )
+                .await
+            {
+                error!("Failed to enqueue fetch request: {}", e);
                 return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
 
@@ -1234,14 +1238,14 @@ async fn forge_webhook(
     let subject = metadata.pr_title.as_deref().unwrap_or(&default_subject);
 
     let commit_range = format!("{}..{}", metadata.base_sha, metadata.head_sha);
-    let placeholder_id = format!("mr-{}-{}", metadata.pr_number, commit_range);
+    let placeholder_id = format!("mr-{}-{}@sashiko.local", metadata.pr_number, commit_range);
 
     let slug = metadata.pr_url.as_ref().map(|url| {
         let repo = crate::forge::extract_repo_name_from_url(url);
         format!("{}-{}", repo, metadata.pr_number)
     });
 
-    state
+    let patchset_id = state
         .db
         .create_fetching_patchset(
             &placeholder_id,
@@ -1252,7 +1256,7 @@ async fn forge_webhook(
             Some(subject),
             Some(metadata.pr_number),
             slug.as_deref(),
-            None,
+            metadata.repo_url.as_deref(),
             None,
         )
         .await
@@ -1261,18 +1265,24 @@ async fn forge_webhook(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let req = FetchRequest {
-        repo_url: metadata.repo_url,
-        commit_hash: commit_range,
-        mr_url: metadata.pr_url,
-        mr_title: metadata.pr_title,
-        mr_number: Some(metadata.pr_number),
-    };
-
-    state.fetch_sender.send(req).await.map_err(|e| {
-        error!("Failed to send fetch request to queue: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    // Persist the fetch durably; the FetchWorker will pick it up.
+    state
+        .db
+        .enqueue_fetch(
+            Some(patchset_id),
+            Some(&placeholder_id),
+            metadata.repo_url.as_deref(),
+            &commit_range,
+            metadata.pr_url.as_deref(),
+            metadata.pr_title.as_deref(),
+            Some(metadata.pr_number),
+            500,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to enqueue fetch request: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(serde_json::json!({
         "status": "accepted",

--- a/src/api.rs
+++ b/src/api.rs
@@ -473,6 +473,7 @@ async fn submit_patch(
                     None,
                     None,
                     None,
+                    repo.as_deref(),
                     None,
                 )
                 .await
@@ -528,6 +529,7 @@ async fn submit_patch(
                 .create_fetching_patchset(
                     &clean_msgid,
                     &format!("Fetching thread {}...", clean_msgid),
+                    None,
                     None,
                     None,
                     None,
@@ -1250,6 +1252,7 @@ async fn forge_webhook(
             Some(subject),
             Some(metadata.pr_number),
             slug.as_deref(),
+            None,
             None,
         )
         .await

--- a/src/api.rs
+++ b/src/api.rs
@@ -473,6 +473,7 @@ async fn submit_patch(
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
             {
@@ -527,6 +528,7 @@ async fn submit_patch(
                 .create_fetching_patchset(
                     &clean_msgid,
                     &format!("Fetching thread {}...", clean_msgid),
+                    None,
                     None,
                     None,
                     None,
@@ -1248,6 +1250,7 @@ async fn forge_webhook(
             Some(subject),
             Some(metadata.pr_number),
             slug.as_deref(),
+            None,
         )
         .await
         .map_err(|e| {

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,6 +14,7 @@
 
 use crate::db::Database;
 use crate::events::{Event, MessageSource};
+use crate::review_kind::ReviewKind;
 use axum::{
     Json, Router,
     extract::{ConnectInfo, Path, Query, Request, State},
@@ -219,6 +220,15 @@ pub enum SubmitRequest {
     #[serde(rename = "remote-range")]
     RemoteRange {
         sha: String,
+        repo: Option<String>,
+        skip_subjects: Option<Vec<String>>,
+        only_subjects: Option<Vec<String>>,
+    },
+    #[serde(rename = "cherry-pick")]
+    CherryPick {
+        sha: String,
+        original_sha: String,
+        base_sha: Option<String>,
         repo: Option<String>,
         skip_subjects: Option<Vec<String>>,
         only_subjects: Option<Vec<String>>,
@@ -492,6 +502,104 @@ async fn submit_patch(
                     None,
                     None,
                     500,
+                )
+                .await
+            {
+                error!("Failed to enqueue fetch request: {}", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+
+            Ok(Json(SubmitResponse {
+                status: "accepted".to_string(),
+                id,
+            }))
+        }
+        SubmitRequest::CherryPick {
+            sha,
+            original_sha,
+            base_sha,
+            repo,
+            skip_subjects,
+            only_subjects,
+        } => {
+            let id = sha.clone();
+            let repo_display = repo.as_deref().unwrap_or("local");
+            info!(
+                "Received cherry-pick review request: {} (original {}) from {}",
+                sha, original_sha, repo_display
+            );
+
+            // Create a placeholder record so the user can track status.
+            let cover_id = format!("{}@sashiko.local", id);
+            let patchset_id = match state
+                .db
+                .create_fetching_patchset(
+                    &cover_id,
+                    &format!("Fetching cherry-pick {} from {}...", &sha, repo_display),
+                    skip_subjects.as_ref(),
+                    only_subjects.as_ref(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    repo.as_deref(),
+                    None,
+                )
+                .await
+            {
+                Ok(pid) => pid,
+                Err(e) => {
+                    error!("Failed to create placeholder patchset: {}", e);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            };
+
+            // The original (and base) commits live on divergent history and are
+            // not reachable from the resolution commit, so git will not pull
+            // them transitively. Fetch them explicitly as supporting commits so
+            // the pipeline can hydrate the full three-commit context at review
+            // time; they are fetched but never ingested as separate patches.
+            let mut supporting_commits: Vec<String> = vec![original_sha.clone()];
+            if let Some(ref base) = base_sha {
+                supporting_commits.push(base.clone());
+            }
+
+            // Persist the minimal cherry-pick selector; the reviewer forwards it
+            // to the pipeline, which hydrates the rest of the context from git.
+            let review_context = ReviewKind::CherryPick {
+                original_sha,
+                base_sha,
+            };
+            match serde_json::to_string(&review_context) {
+                Ok(json) => {
+                    if let Err(e) = state.db.set_review_context(patchset_id, &json).await {
+                        error!(
+                            "Failed to persist review_context for {}: {}",
+                            patchset_id, e
+                        );
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to serialize review_context: {}", e);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
+
+            // Persist the fetch durably; the FetchWorker will pick it up and
+            // ensure the resolution plus its supporting commits are present.
+            if let Err(e) = state
+                .db
+                .enqueue_fetch_with_support(
+                    Some(patchset_id),
+                    Some(&cover_id),
+                    repo.as_deref(),
+                    &sha,
+                    None,
+                    None,
+                    None,
+                    500,
+                    &supporting_commits,
                 )
                 .await
             {

--- a/src/bin/review.rs
+++ b/src/bin/review.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use sashiko::local_review::{WorkerOptions, print_worker_json, run_worker_from_stdin};
 use sashiko::prompt_bundle;
+use sashiko::review_kind::ReviewKind;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
@@ -68,6 +69,11 @@ struct Args {
     /// Select which stages from 1-7 to run.
     #[arg(long, hide = true, value_delimiter = ',')]
     stages: Option<Vec<u8>>,
+
+    /// Alternate review pipeline selector as JSON (e.g. the cherry-pick review
+    /// context). Absent selects the default patch-review pipeline.
+    #[arg(long)]
+    review_context: Option<String>,
 }
 
 #[tokio::main]
@@ -96,6 +102,11 @@ async fn main() -> Result<()> {
         stages: args.stages,
         scratch_clone: false,
         current_tree: false,
+        review_context: args
+            .review_context
+            .map(|s| serde_json::from_str::<ReviewKind>(&s))
+            .transpose()
+            .context("parsing --review-context JSON")?,
     })
     .await?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -219,6 +219,94 @@ pub struct PatchworkOutboxRow {
     pub created_at: i64,
 }
 
+/// Status of an entry in the fetch queue.
+///
+/// Stored as TEXT in SQLite with a CHECK constraint limiting values
+/// to the three valid states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchStatus {
+    Pending,
+    Fetching,
+    Failed,
+}
+
+impl FetchStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Fetching => "Fetching",
+            Self::Failed => "Failed",
+        }
+    }
+}
+
+impl std::fmt::Display for FetchStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for FetchStatus {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(Self::Pending),
+            "Fetching" => Ok(Self::Fetching),
+            "Failed" => Ok(Self::Failed),
+            other => Err(anyhow::anyhow!("unknown FetchStatus: {}", other)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchQueueRow {
+    pub id: i64,
+    pub patchset_id: Option<i64>,
+    pub cover_letter_message_id: Option<String>,
+    pub repo_url: Option<String>,
+    pub commit_hash: String,
+    pub mr_url: Option<String>,
+    pub mr_title: Option<String>,
+    pub mr_number: Option<i64>,
+    pub status: FetchStatus,
+    pub attempts: i64,
+    pub first_attempt_at: Option<i64>,
+    pub next_retry_at: Option<i64>,
+    pub locked_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub priority: i64,
+    pub created_at: i64,
+    /// Extra commit SHAs that must be present locally for the review to hydrate
+    /// its context, but are never ingested as patches. Loaded from the
+    /// `fetch_supporting_commits` table. Used by cherry-pick reviews to carry
+    /// the original and base commits.
+    pub supporting_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StuckFetchPlaceholder {
+    pub patchset_id: i64,
+    pub cover_letter_message_id: Option<String>,
+    pub repo_url: Option<String>,
+    pub mr_url: Option<String>,
+    pub mr_title: Option<String>,
+    pub mr_number: Option<i64>,
+    pub priority: i64,
+}
+
+/// Recover a fetch source URL from a placeholder subject of the form
+/// "Fetching <rev> from <url>...". Returns None when the subject carries no URL
+/// source (e.g. a local fetch, or a thread/PR placeholder).
+fn repo_url_from_subject(subject: &str) -> Option<String> {
+    let after = subject.split_once(" from ")?.1;
+    let url = after.strip_suffix("...").unwrap_or(after).trim();
+    if url.is_empty() || url == "local" {
+        None
+    } else {
+        Some(url.to_string())
+    }
+}
+
 impl Database {
     pub async fn get_oldest_message_timestamp(&self) -> Result<Option<i64>> {
         let mut rows = self
@@ -532,6 +620,7 @@ impl Database {
 
         self.migrate_patches_unique_constraint_if_needed().await?;
         self.migrate_priority_columns_if_needed().await?;
+        self.migrate_fetch_queue_if_needed().await?;
 
         Ok(())
     }
@@ -551,6 +640,10 @@ impl Database {
             .await;
         let _ = self
             .try_add_column("patchsets", "priority", "INTEGER DEFAULT 500")
+            .await;
+        let _ = self.try_add_column("patchsets", "repo_url", "TEXT").await;
+        let _ = self
+            .try_add_column("patchsets", "review_context", "TEXT")
             .await;
         let _ = self
             .try_create_index(
@@ -844,6 +937,49 @@ impl Database {
                 "status, priority DESC, date ASC",
             )
             .await;
+        Ok(())
+    }
+
+    async fn migrate_fetch_queue_if_needed(&self) -> Result<()> {
+        let _ = self.try_add_column("patchsets", "repo_url", "TEXT").await;
+        let _ = self
+            .try_add_column("patchsets", "review_context", "TEXT")
+            .await;
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS fetch_queue (
+                    id INTEGER PRIMARY KEY,
+                    patchset_id INTEGER,
+                    cover_letter_message_id TEXT,
+                    repo_url TEXT,
+                    commit_hash TEXT NOT NULL,
+                    mr_url TEXT,
+                    mr_title TEXT,
+                    mr_number INTEGER,
+                    status TEXT NOT NULL DEFAULT 'Pending' CHECK(status IN ('Pending', 'Fetching', 'Failed')),
+                    attempts INTEGER DEFAULT 0,
+                    first_attempt_at INTEGER,
+                    next_retry_at INTEGER,
+                    locked_at INTEGER,
+                    last_error TEXT,
+                    priority INTEGER DEFAULT 500,
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY(patchset_id) REFERENCES patchsets(id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_fetch_queue_claim
+                    ON fetch_queue(status, next_retry_at, priority, created_at);
+                CREATE INDEX IF NOT EXISTS idx_fetch_queue_commit ON fetch_queue(commit_hash);
+
+                CREATE TABLE IF NOT EXISTS fetch_supporting_commits (
+                    id INTEGER PRIMARY KEY,
+                    fetch_id INTEGER NOT NULL,
+                    commit_hash TEXT NOT NULL,
+                    FOREIGN KEY(fetch_id) REFERENCES fetch_queue(id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_fetch_supporting_fetch_id
+                    ON fetch_supporting_commits(fetch_id);",
+            )
+            .await?;
         Ok(())
     }
 
@@ -1959,7 +2095,9 @@ impl Database {
         // 1. Try to find by cover_letter_message_id first (handles placeholders from API/Fetcher)
         let mut clid_candidates = Vec::new();
         if let Some(clid) = cover_letter_message_id {
-            clid_candidates.push((clid.to_string(), false));
+            for c in Self::get_msgid_candidates(clid) {
+                clid_candidates.push((c, false));
+            }
         }
         // Fallback for single-patch git imports where placeholder is
         // sha@sashiko.local but the actual cover letter becomes the sha
@@ -1969,8 +2107,12 @@ impl Database {
         // and the fallback would incorrectly match patchsets from
         // unrelated submissions that happen to share a commit SHA.
         if cover_letter_message_id.is_none() || total_parts == 1 {
-            clid_candidates.push((format!("{}@sashiko.local", message_id), true));
+            for c in Self::get_msgid_candidates(&format!("{}@sashiko.local", message_id)) {
+                clid_candidates.push((c, true));
+            }
         }
+        let mut seen = std::collections::HashSet::new();
+        clid_candidates.retain(|(c, _)| seen.insert(c.clone()));
 
         for (clid, scope_to_thread) in clid_candidates {
             // When using the @sashiko.local fallback, scope the query
@@ -3907,6 +4049,36 @@ impl Database {
         }
     }
 
+    /// Fetch the serialized alternate-pipeline selector for a patchset, if any.
+    ///
+    /// A `NULL` column (the default) yields `None`, selecting the standard
+    /// patch-review pipeline.
+    pub async fn get_review_context(&self, id: i64) -> Result<Option<String>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT review_context FROM patchsets WHERE id = ?",
+                libsql::params![id],
+            )
+            .await?;
+        if let Some(row) = rows.next().await? {
+            Ok(row.get::<Option<String>>(0).ok().flatten())
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Persist the serialized alternate-pipeline selector for a patchset.
+    pub async fn set_review_context(&self, id: i64, review_context: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE patchsets SET review_context = ? WHERE id = ?",
+                libsql::params![review_context, id],
+            )
+            .await?;
+        Ok(())
+    }
+
     pub async fn cancel_patchset(&self, id: i64, force: bool) -> Result<bool> {
         let query = if force {
             "UPDATE patchsets SET status = 'Cancelled' WHERE id = ? AND status IN ('Pending', 'Incomplete', 'In Review')"
@@ -3990,6 +4162,310 @@ impl Database {
         self.rerun_patchset(patchset_id).await
     }
 
+    // --- Durable fetch queue -------------------------------------------------
+    //
+    // These operations back the FetchWorker. They mirror the patchwork_outbox
+    // pattern: work is claimed under a lease (locked_at), retried with backoff
+    // (next_retry_at), completed, terminally failed, or reclaimed by a ghost
+    // sweep when a worker dies mid-flight.
+
+    /// Enqueue a git fetch. Idempotent: an active (Pending/Fetching) row for the
+    /// same commit and repo is left untouched so duplicate submissions collapse.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn enqueue_fetch(
+        &self,
+        patchset_id: Option<i64>,
+        cover_letter_message_id: Option<&str>,
+        repo_url: Option<&str>,
+        commit_hash: &str,
+        mr_url: Option<&str>,
+        mr_title: Option<&str>,
+        mr_number: Option<i64>,
+        priority: i32,
+    ) -> Result<()> {
+        self.enqueue_fetch_with_support(
+            patchset_id,
+            cover_letter_message_id,
+            repo_url,
+            commit_hash,
+            mr_url,
+            mr_title,
+            mr_number,
+            priority,
+            &[],
+        )
+        .await
+    }
+
+    /// Like `enqueue_fetch`, but also records `supporting_commits`: extra commit
+    /// SHAs the worker must ensure are present locally (e.g. the original and
+    /// base commits of a cherry-pick) without ingesting them as patches. Only
+    /// `commit_hash` is ingested; the supporting commits are fetched purely so
+    /// downstream reviews (like the cherry-pick pipeline) can hydrate their full
+    /// context from git.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn enqueue_fetch_with_support(
+        &self,
+        patchset_id: Option<i64>,
+        cover_letter_message_id: Option<&str>,
+        repo_url: Option<&str>,
+        commit_hash: &str,
+        mr_url: Option<&str>,
+        mr_title: Option<&str>,
+        mr_number: Option<i64>,
+        priority: i32,
+        supporting_commits: &[String],
+    ) -> Result<()> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs() as i64;
+
+        let mut existing = self
+            .conn
+            .query(
+                "SELECT 1 FROM fetch_queue \
+                 WHERE commit_hash = ? \
+                   AND IFNULL(repo_url, '') = IFNULL(?, '') \
+                   AND IFNULL(cover_letter_message_id, '') = IFNULL(?, '') \
+                   AND status IN ('Pending', 'Fetching') LIMIT 1",
+                libsql::params![commit_hash, repo_url, cover_letter_message_id],
+            )
+            .await?;
+        if existing.next().await.ok().flatten().is_some() {
+            return Ok(());
+        }
+
+        let mut rows = self
+            .conn
+            .query(
+                "INSERT INTO fetch_queue \
+                 (patchset_id, cover_letter_message_id, repo_url, commit_hash, \
+                  mr_url, mr_title, mr_number, status, attempts, priority, \
+                  created_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 'Pending', 0, ?, ?) RETURNING id",
+                libsql::params![
+                    patchset_id,
+                    cover_letter_message_id,
+                    repo_url,
+                    commit_hash,
+                    mr_url,
+                    mr_title,
+                    mr_number,
+                    priority,
+                    now
+                ],
+            )
+            .await?;
+        let fetch_id: i64 = match rows.next().await? {
+            Some(row) => row.get(0)?,
+            None => return Err(anyhow::anyhow!("INSERT into fetch_queue returned no id")),
+        };
+
+        // Record each supporting commit as its own row (1-to-N) so an arbitrary
+        // number can be stored without packing them into a single column.
+        for sha in supporting_commits {
+            self.conn
+                .execute(
+                    "INSERT INTO fetch_supporting_commits (fetch_id, commit_hash) \
+                     VALUES (?, ?)",
+                    libsql::params![fetch_id, sha.as_str()],
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Atomically claim the highest-priority due fetch, leasing it to the caller
+    /// and bumping its attempt count. Returns None if nothing is due.
+    pub async fn lock_pending_fetch(&self) -> Result<Option<FetchQueueRow>> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs() as i64;
+
+        let mut rows = self
+            .conn
+            .query(
+                "UPDATE fetch_queue \
+                 SET status = 'Fetching', locked_at = ?, attempts = attempts + 1, \
+                     first_attempt_at = COALESCE(first_attempt_at, ?) \
+                 WHERE id = ( \
+                     SELECT id FROM fetch_queue \
+                     WHERE status = 'Pending' \
+                       AND (next_retry_at IS NULL OR next_retry_at <= ?) \
+                     ORDER BY priority DESC, created_at ASC LIMIT 1 \
+                 ) \
+                 RETURNING id, patchset_id, cover_letter_message_id, repo_url, \
+                     commit_hash, mr_url, mr_title, mr_number, status, attempts, \
+                     first_attempt_at, next_retry_at, locked_at, last_error, \
+                     priority, created_at",
+                libsql::params![now, now, now],
+            )
+            .await?;
+
+        match rows.next().await {
+            Ok(Some(row)) => {
+                let mut row = Self::row_to_fetch_queue(&row)?;
+                row.supporting_commits = self.load_supporting_commits(row.id).await?;
+                Ok(Some(row))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Load the supporting commit SHAs recorded for a claimed fetch, in
+    /// insertion order.
+    async fn load_supporting_commits(&self, fetch_id: i64) -> Result<Vec<String>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT commit_hash FROM fetch_supporting_commits \
+                 WHERE fetch_id = ? ORDER BY id ASC",
+                libsql::params![fetch_id],
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            out.push(row.get::<String>(0)?);
+        }
+        Ok(out)
+    }
+
+    /// Remove a fetch from the queue once it has been successfully processed.
+    ///
+    /// Completed fetches serve no further purpose: idempotency is guaranteed by
+    /// the local git repository (`is_present`), not by queue history, and no code
+    /// path reads `Done` rows (dedup and stuck-placeholder recovery only consider
+    /// `Pending`/`Fetching`). Deleting the row instead of marking it `Done` keeps
+    /// the queue table bounded to in-flight work.
+    pub async fn mark_fetch_done(&self, id: i64) -> Result<()> {
+        // Foreign-key cascade is not enabled on this connection, so remove the
+        // child supporting-commit rows explicitly before the parent.
+        self.conn
+            .execute(
+                "DELETE FROM fetch_supporting_commits WHERE fetch_id = ?",
+                libsql::params![id],
+            )
+            .await?;
+        self.conn
+            .execute("DELETE FROM fetch_queue WHERE id = ?", libsql::params![id])
+            .await?;
+        Ok(())
+    }
+
+    /// Release a fetch back to Pending with a future retry time and record the
+    /// last error. Used for transient failures within the retry window.
+    pub async fn set_fetch_retry_at(&self, id: i64, next_retry_at: i64, error: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE fetch_queue \
+                 SET status = 'Pending', next_retry_at = ?, last_error = ?, \
+                     locked_at = NULL WHERE id = ?",
+                libsql::params![next_retry_at, error, id],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Terminally fail a fetch after its retry window is exhausted.
+    pub async fn mark_fetch_failed(&self, id: i64, error: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE fetch_queue SET status = 'Failed', last_error = ?, \
+                 locked_at = NULL WHERE id = ?",
+                libsql::params![error, id],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Reclaim fetches whose lease has expired because their worker died
+    /// mid-flight. Returns the number of rows reset to Pending.
+    pub async fn sweep_ghost_fetches(&self, lease_secs: i64) -> Result<u64> {
+        let cutoff = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs() as i64)
+            - lease_secs;
+        let count = self
+            .conn
+            .execute(
+                "UPDATE fetch_queue SET status = 'Pending', locked_at = NULL \
+                 WHERE status = 'Fetching' AND locked_at IS NOT NULL \
+                   AND locked_at < ?",
+                libsql::params![cutoff],
+            )
+            .await?;
+        Ok(count)
+    }
+
+    /// Return patchsets stuck in 'Fetching' that have no active fetch_queue row.
+    /// Used at startup to recover placeholders created before the durable queue
+    /// existed, or orphaned by a crash.
+    pub async fn get_stuck_fetch_placeholders(&self) -> Result<Vec<StuckFetchPlaceholder>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT p.id, p.cover_letter_message_id, \
+                        COALESCE(p.repo_url, b.repo_url), p.mr_url, \
+                        p.mr_title, p.mr_number, IFNULL(p.priority, 500), \
+                        p.subject \
+                 FROM patchsets p \
+                 LEFT JOIN baselines b ON p.baseline_id = b.id \
+                 WHERE p.status = 'Fetching' \
+                   AND NOT EXISTS ( \
+                       SELECT 1 FROM fetch_queue fq \
+                       WHERE fq.patchset_id = p.id \
+                         AND fq.status IN ('Pending', 'Fetching') \
+                   )",
+                (),
+            )
+            .await?;
+
+        let mut out = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            // Prefer persisted patchsets.repo_url / baseline url; for old
+            // placeholders that predate the column and have no baseline, recover
+            // the source URL from the subject ("Fetching <rev> from <url>...").
+            let subject = row.get::<Option<String>>(7)?.unwrap_or_default();
+            let repo_url = row
+                .get::<Option<String>>(2)?
+                .or_else(|| repo_url_from_subject(&subject));
+            out.push(StuckFetchPlaceholder {
+                patchset_id: row.get(0)?,
+                cover_letter_message_id: row.get::<Option<String>>(1)?,
+                repo_url,
+                mr_url: row.get::<Option<String>>(3)?,
+                mr_title: row.get::<Option<String>>(4)?,
+                mr_number: row.get::<Option<i64>>(5)?,
+                priority: row.get(6)?,
+            });
+        }
+        Ok(out)
+    }
+
+    fn row_to_fetch_queue(row: &libsql::Row) -> Result<FetchQueueRow> {
+        Ok(FetchQueueRow {
+            id: row.get(0)?,
+            patchset_id: row.get::<Option<i64>>(1)?,
+            cover_letter_message_id: row.get::<Option<String>>(2)?,
+            repo_url: row.get::<Option<String>>(3)?,
+            commit_hash: row.get(4)?,
+            mr_url: row.get::<Option<String>>(5)?,
+            mr_title: row.get::<Option<String>>(6)?,
+            mr_number: row.get::<Option<i64>>(7)?,
+            status: row.get::<String>(8)?.parse()?,
+            attempts: row.get(9)?,
+            first_attempt_at: row.get::<Option<i64>>(10)?,
+            next_retry_at: row.get::<Option<i64>>(11)?,
+            locked_at: row.get::<Option<i64>>(12)?,
+            last_error: row.get::<Option<String>>(13)?,
+            priority: row.get(14)?,
+            created_at: row.get(15)?,
+            // Populated separately from fetch_supporting_commits after the row
+            // is claimed; see lock_pending_fetch.
+            supporting_commits: Vec::new(),
+        })
+    }
+
     pub async fn has_patchset_by_msgid(&self, msgid: &str) -> Result<bool> {
         let candidates = Self::get_msgid_candidates(msgid);
         for clid in &candidates {
@@ -4029,6 +4505,7 @@ impl Database {
         mr_title: Option<&str>,
         mr_number: Option<i64>,
         slug: Option<&str>,
+        repo_url: Option<&str>,
         priority: Option<i32>,
     ) -> Result<i64> {
         let now = std::time::SystemTime::now()
@@ -4064,13 +4541,13 @@ impl Database {
                 {
                     if let Some(prio) = priority {
                         self.conn.execute(
-                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ?, base_priority = ?, priority = ? WHERE id = ?",
-                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, prio, prio, id]
+                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ?, repo_url = ?, base_priority = ?, priority = ? WHERE id = ?",
+                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, repo_url, prio, prio, id]
                         ).await?;
                     } else {
                         self.conn.execute(
-                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
-                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
+                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ?, repo_url = ? WHERE id = ?",
+                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, repo_url, id]
                         ).await?;
                     }
                 }
@@ -4085,9 +4562,9 @@ impl Database {
         let eff_priority = priority.unwrap_or(crate::settings::DEFAULT_PRIORITY);
         let mut rows = self.conn
             .query(
-                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters, mr_url, mr_title, mr_number, slug, base_priority, priority)
-                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
-                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json, mr_url, mr_title, mr_number, slug, eff_priority, eff_priority],
+                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters, mr_url, mr_title, mr_number, slug, repo_url, base_priority, priority)
+                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json, mr_url, mr_title, mr_number, slug, repo_url, eff_priority, eff_priority],
             )
             .await?;
 
@@ -4534,6 +5011,370 @@ mod tests {
         let db = Database::new(&settings).await.unwrap();
         db.migrate().await.unwrap();
         Arc::new(db)
+    }
+
+    #[tokio::test]
+    async fn test_fetch_queue_claim_is_exclusive_and_ordered() {
+        let db = setup_db().await;
+        db.enqueue_fetch(
+            None,
+            Some("a@x"),
+            Some("repo"),
+            "sha_low",
+            None,
+            None,
+            None,
+            100,
+        )
+        .await
+        .unwrap();
+        db.enqueue_fetch(
+            None,
+            Some("b@x"),
+            Some("repo"),
+            "sha_high",
+            None,
+            None,
+            None,
+            900,
+        )
+        .await
+        .unwrap();
+
+        // Higher priority is claimed first.
+        let first = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(first.commit_hash, "sha_high");
+        assert_eq!(first.status, FetchStatus::Fetching);
+        assert_eq!(first.attempts, 1);
+        assert!(first.first_attempt_at.is_some());
+        assert!(first.locked_at.is_some());
+
+        // A claimed row is not handed out again.
+        let second = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(second.commit_hash, "sha_low");
+
+        assert!(db.lock_pending_fetch().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_queue_enqueue_is_idempotent() {
+        let db = setup_db().await;
+        db.enqueue_fetch(None, None, Some("repo"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        db.enqueue_fetch(None, None, Some("repo"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let _ = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert!(db.lock_pending_fetch().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_queue_enqueue_distinct_cover_ids_not_dropped() {
+        let db = setup_db().await;
+        // Two distinct MRs for the same commit range and repo must both be enqueued
+        db.enqueue_fetch(
+            None,
+            Some("mr-1-base..head@sashiko.local"),
+            Some("repo"),
+            "base..head",
+            Some("http://mr1"),
+            Some("MR 1"),
+            Some(1),
+            500,
+        )
+        .await
+        .unwrap();
+        db.enqueue_fetch(
+            None,
+            Some("mr-2-base..head@sashiko.local"),
+            Some("repo"),
+            "base..head",
+            Some("http://mr2"),
+            Some("MR 2"),
+            Some(2),
+            500,
+        )
+        .await
+        .unwrap();
+
+        let first = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(
+            first.cover_letter_message_id.as_deref(),
+            Some("mr-1-base..head@sashiko.local")
+        );
+        let second = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(
+            second.cover_letter_message_id.as_deref(),
+            Some("mr-2-base..head@sashiko.local")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_fetch_queue_on_version_1_db() {
+        let settings = DatabaseSettings {
+            url: ":memory:".to_string(),
+            token: String::new(),
+        };
+        let db = Database::new(&settings).await.unwrap();
+        // Simulate a legacy DB already at user_version 1 without fetch_queue
+        db.conn
+            .execute("PRAGMA user_version = 1", ())
+            .await
+            .unwrap();
+        db.conn
+            .execute(
+                "CREATE TABLE patchsets (id INTEGER PRIMARY KEY, cover_letter_message_id TEXT, status TEXT)",
+                (),
+            )
+            .await
+            .unwrap();
+
+        // migrate() must create fetch_queue and patchsets columns even though user_version == 1
+        db.migrate().await.unwrap();
+
+        db.enqueue_fetch(None, None, Some("repo"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(row.commit_hash, "sha");
+    }
+
+    #[tokio::test]
+    async fn test_create_patchset_matches_placeholder_without_suffix() {
+        let db = setup_db().await;
+        // Create a placeholder with unsuffixed ID (as might exist from older webhooks)
+        let placeholder_id = "mr-99-base..head";
+        let pid = db
+            .create_fetching_patchset(
+                placeholder_id,
+                "Fetching MR 99",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Ingestion passes suffixed root_msg_id as cover_letter_id
+        let suffixed_id = "mr-99-base..head@sashiko.local";
+        let thread_id = db
+            .ensure_thread_for_message(suffixed_id, 1000)
+            .await
+            .unwrap();
+        let matched_id = db
+            .create_patchset_with_priority(
+                thread_id,
+                Some(suffixed_id),
+                "commit_sha_1",
+                "MR 99 Subject",
+                "Author",
+                1000,
+                2,
+                1,
+                "to",
+                "cc",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(matched_id, Some(pid));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_queue_retry_gating() {
+        let db = setup_db().await;
+        db.enqueue_fetch(None, None, Some("repo"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+
+        // A retry scheduled in the far future must not be claimable now.
+        db.set_fetch_retry_at(row.id, 4_000_000_000, "transient")
+            .await
+            .unwrap();
+        assert!(db.lock_pending_fetch().await.unwrap().is_none());
+
+        // A retry scheduled in the past becomes claimable again.
+        db.set_fetch_retry_at(row.id, 1, "transient").await.unwrap();
+        let again = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(again.attempts, 2);
+        assert_eq!(again.commit_hash, "sha");
+        assert_eq!(again.last_error.as_deref(), Some("transient"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_queue_done_and_failed_are_terminal() {
+        let db = setup_db().await;
+        db.enqueue_fetch(None, None, Some("r"), "done_sha", None, None, None, 500)
+            .await
+            .unwrap();
+        db.enqueue_fetch(None, None, Some("r"), "fail_sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let a = db.lock_pending_fetch().await.unwrap().unwrap();
+        db.mark_fetch_done(a.id).await.unwrap();
+        let b = db.lock_pending_fetch().await.unwrap().unwrap();
+        db.mark_fetch_failed(b.id, "boom").await.unwrap();
+        assert!(db.lock_pending_fetch().await.unwrap().is_none());
+    }
+
+    async fn count_supporting(db: &Database) -> i64 {
+        let mut rows = db
+            .conn
+            .query("SELECT COUNT(*) FROM fetch_supporting_commits", ())
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_fetch_supporting_commits_roundtrip() {
+        let db = setup_db().await;
+        let supporting = vec!["original_sha".to_string(), "base_sha".to_string()];
+        db.enqueue_fetch_with_support(
+            None,
+            Some("cover@x"),
+            Some("repo"),
+            "resolution_sha",
+            None,
+            None,
+            None,
+            500,
+            &supporting,
+        )
+        .await
+        .unwrap();
+
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+        // Only the resolution commit is ingested; the original and base commits
+        // ride along as supporting commits, preserved in insertion order.
+        assert_eq!(row.commit_hash, "resolution_sha");
+        assert_eq!(row.supporting_commits, supporting);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_without_support_has_no_supporting_commits() {
+        let db = setup_db().await;
+        db.enqueue_fetch(None, None, Some("repo"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert!(row.supporting_commits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mark_fetch_done_removes_supporting_commits() {
+        let db = setup_db().await;
+        db.enqueue_fetch_with_support(
+            None,
+            None,
+            Some("repo"),
+            "resolution_sha",
+            None,
+            None,
+            None,
+            500,
+            &["original_sha".to_string(), "base_sha".to_string()],
+        )
+        .await
+        .unwrap();
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(count_supporting(&db).await, 2);
+
+        db.mark_fetch_done(row.id).await.unwrap();
+        // Completing a fetch removes its supporting-commit child rows so the
+        // table stays bounded to in-flight work.
+        assert_eq!(count_supporting(&db).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_sweep_ghost_fetches_reclaims_expired_lease() {
+        let db = setup_db().await;
+        db.enqueue_fetch(None, None, Some("r"), "sha", None, None, None, 500)
+            .await
+            .unwrap();
+        let row = db.lock_pending_fetch().await.unwrap().unwrap();
+
+        // A generous lease keeps the in-flight row locked (nothing reclaimed).
+        assert_eq!(db.sweep_ghost_fetches(1_000_000_000).await.unwrap(), 0);
+        assert!(db.lock_pending_fetch().await.unwrap().is_none());
+
+        // A negative lease treats every lease as already expired, so the
+        // ghosted row is reclaimed and becomes claimable again.
+        assert_eq!(db.sweep_ghost_fetches(-100_000).await.unwrap(), 1);
+        let again = db.lock_pending_fetch().await.unwrap().unwrap();
+        assert_eq!(again.id, row.id);
+    }
+
+    #[test]
+    fn test_repo_url_from_subject() {
+        assert_eq!(
+            repo_url_from_subject("Fetching abc123 from sso://prodkernel/kernel/icebreaker..."),
+            Some("sso://prodkernel/kernel/icebreaker".to_string())
+        );
+        assert_eq!(
+            repo_url_from_subject("Fetching abc123 from https://example.com/repo.git..."),
+            Some("https://example.com/repo.git".to_string())
+        );
+        assert_eq!(repo_url_from_subject("Fetching abc123 from local..."), None);
+        assert_eq!(repo_url_from_subject("Fetching thread <m@id>..."), None);
+        assert_eq!(repo_url_from_subject("some unrelated subject"), None);
+    }
+
+    #[tokio::test]
+    async fn test_get_stuck_fetch_placeholders_finds_orphans() {
+        let db = setup_db().await;
+        // A patchset stuck in 'Fetching' with no queue row is an orphan.
+        db.create_fetching_patchset(
+            "orphan@sashiko.local",
+            "Fetching x",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let stuck = db.get_stuck_fetch_placeholders().await.unwrap();
+        assert_eq!(stuck.len(), 1);
+        assert_eq!(
+            stuck[0].cover_letter_message_id.as_deref(),
+            Some("orphan@sashiko.local")
+        );
+
+        // Once an active queue row exists, it is no longer reported.
+        let pid = stuck[0].patchset_id;
+        db.enqueue_fetch(
+            Some(pid),
+            Some("orphan@sashiko.local"),
+            None,
+            "orphan",
+            None,
+            None,
+            None,
+            500,
+        )
+        .await
+        .unwrap();
+        assert!(db.get_stuck_fetch_placeholders().await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -9437,6 +10278,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -9502,6 +10344,7 @@ mod tests {
         db.create_fetching_patchset(
             &synthetic_id,
             "Fetching placeholder",
+            None,
             None,
             None,
             None,
@@ -9616,6 +10459,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -9636,6 +10480,7 @@ mod tests {
             .create_fetching_patchset(
                 &synthetic_cancelled,
                 "Fetching cancelled placeholder",
+                None,
                 None,
                 None,
                 None,
@@ -9892,6 +10737,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -9959,6 +10805,7 @@ mod tests {
             .create_fetching_patchset(
                 &synthetic_cover,
                 "Fetching retry",
+                None,
                 None,
                 None,
                 None,

--- a/src/db.rs
+++ b/src/db.rs
@@ -531,6 +531,7 @@ impl Database {
         }
 
         self.migrate_patches_unique_constraint_if_needed().await?;
+        self.migrate_priority_columns_if_needed().await?;
 
         Ok(())
     }
@@ -542,6 +543,22 @@ impl Database {
         // let _ = self.conn.execute("UPDATE reviews SET status = 'In Review' WHERE status = 'Applying'", ()).await;
 
         // Manual migrations for existing tables
+        let _ = self
+            .try_add_column("patchsets", "base_priority", "INTEGER DEFAULT 500")
+            .await;
+        let _ = self
+            .try_add_column("patchsets", "priority_cap", "INTEGER")
+            .await;
+        let _ = self
+            .try_add_column("patchsets", "priority", "INTEGER DEFAULT 500")
+            .await;
+        let _ = self
+            .try_create_index(
+                "idx_patchsets_status_priority_date",
+                "patchsets",
+                "status, priority DESC, date ASC",
+            )
+            .await;
         let _ = self
             .try_add_column("messages", "to_recipients", "TEXT")
             .await;
@@ -807,6 +824,26 @@ impl Database {
             let _ = self.conn.execute("PRAGMA foreign_keys = ON", ()).await;
         }
 
+        Ok(())
+    }
+
+    async fn migrate_priority_columns_if_needed(&self) -> Result<()> {
+        let _ = self
+            .try_add_column("patchsets", "base_priority", "INTEGER DEFAULT 500")
+            .await;
+        let _ = self
+            .try_add_column("patchsets", "priority_cap", "INTEGER")
+            .await;
+        let _ = self
+            .try_add_column("patchsets", "priority", "INTEGER DEFAULT 500")
+            .await;
+        let _ = self
+            .try_create_index(
+                "idx_patchsets_status_priority_date",
+                "patchsets",
+                "status, priority DESC, date ASC",
+            )
+            .await;
         Ok(())
     }
 
@@ -1874,6 +1911,49 @@ impl Database {
         skip_filters: Option<&Vec<String>>,
         only_filters: Option<&Vec<String>>,
     ) -> Result<Option<i64>> {
+        self.create_patchset_with_priority(
+            thread_id,
+            cover_letter_message_id,
+            message_id,
+            subject,
+            author,
+            date,
+            total_parts,
+            parser_version,
+            to,
+            cc,
+            version,
+            part_index,
+            baseline_id,
+            strict_author,
+            skip_filters,
+            only_filters,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_patchset_with_priority(
+        &self,
+        thread_id: i64,
+        cover_letter_message_id: Option<&str>,
+        message_id: &str,
+        subject: &str,
+        author: &str,
+        date: i64,
+        total_parts: u32,
+        parser_version: i32,
+        to: &str,
+        cc: &str,
+        version: Option<u32>,
+        part_index: u32,
+        baseline_id: Option<i64>,
+        strict_author: bool,
+        skip_filters: Option<&Vec<String>>,
+        only_filters: Option<&Vec<String>>,
+        priority: Option<i32>,
+    ) -> Result<Option<i64>> {
         let skip_filters_json = skip_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
         let only_filters_json = only_filters.map(|f| serde_json::to_string(f).unwrap_or_default());
         // 1. Try to find by cover_letter_message_id first (handles placeholders from API/Fetcher)
@@ -1971,12 +2051,49 @@ impl Database {
                         .await?;
                 }
 
-                // Update subject if this is a better index (e.g. going from placeholder to real subject)
                 if part_index < subject_index {
+                    if is_placeholder {
+                        // A fetch/API placeholder is created at default priority (500)
+                        // before its real subject is known. Apply the rule-based priority
+                        // authoritatively here if provided, or leave at default.
+                        if let Some(prio) = priority {
+                            self.conn
+                                .execute(
+                                    "UPDATE patchsets SET subject = ?, subject_index = ?, base_priority = ?, priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, ?) ELSE ? END WHERE id = ?",
+                                    libsql::params![subject, part_index, prio, prio, prio, id],
+                                )
+                                .await?;
+                        } else {
+                            self.conn
+                                .execute(
+                                    "UPDATE patchsets SET subject = ?, subject_index = ? WHERE id = ?",
+                                    libsql::params![subject, part_index, id],
+                                )
+                                .await?;
+                        }
+                    } else if let Some(prio) = priority {
+                        // Back-filling an earlier part of an existing series:
+                        // Update subject/subject_index and elevate base_priority.
+                        self.conn
+                            .execute(
+                                "UPDATE patchsets SET subject = ?, subject_index = ?, base_priority = MAX(base_priority, ?), priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, MAX(base_priority, ?)) ELSE MAX(base_priority, ?) END WHERE id = ?",
+                                libsql::params![subject, part_index, prio, prio, prio, id],
+                            )
+                            .await?;
+                    } else {
+                        self.conn
+                            .execute(
+                                "UPDATE patchsets SET subject = ?, subject_index = ? WHERE id = ?",
+                                libsql::params![subject, part_index, id],
+                            )
+                            .await?;
+                    }
+                } else if let Some(prio) = priority {
+                    // Even if part_index >= subject_index, elevate base_priority if this part has a higher rule priority.
                     self.conn
                         .execute(
-                            "UPDATE patchsets SET subject = ?, subject_index = ? WHERE id = ?",
-                            libsql::params![subject, part_index, id],
+                            "UPDATE patchsets SET base_priority = MAX(base_priority, ?), priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, MAX(base_priority, ?)) ELSE MAX(base_priority, ?) END WHERE id = ?",
+                            libsql::params![prio, prio, prio, id],
                         )
                         .await?;
                 }
@@ -2196,6 +2313,14 @@ impl Database {
                 let merge_from_id = *merge_from_id;
                 info!("Merging patchset {} into {}", merge_from_id, target_id);
 
+                // Inherit higher base_priority from merged patchset
+                self.conn
+                    .execute(
+                        "UPDATE patchsets SET base_priority = MAX(base_priority, (SELECT COALESCE(base_priority, 500) FROM patchsets WHERE id = ?)), priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, MAX(base_priority, (SELECT COALESCE(base_priority, 500) FROM patchsets WHERE id = ?))) ELSE MAX(base_priority, (SELECT COALESCE(base_priority, 500) FROM patchsets WHERE id = ?)) END WHERE id = ?",
+                        libsql::params![merge_from_id, merge_from_id, merge_from_id, target_id],
+                    )
+                    .await?;
+
                 // Reassign patches
                 self.conn
                     .execute(
@@ -2267,26 +2392,29 @@ impl Database {
                     .await?;
             }
 
-            // Conditionally update subject
-            // Note: We check against the best index found among all merged sets OR the new part_index
             if part_index < current_subject_index {
+                if let Some(prio) = priority {
+                    self.conn
+                        .execute(
+                            "UPDATE patchsets SET subject = ?, subject_index = ?, base_priority = MAX(base_priority, ?), priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, MAX(base_priority, ?)) ELSE MAX(base_priority, ?) END WHERE id = ?",
+                            libsql::params![subject, part_index, prio, prio, prio, target_id],
+                        )
+                        .await?;
+                } else {
+                    self.conn
+                        .execute(
+                            "UPDATE patchsets SET subject = ?, subject_index = ? WHERE id = ?",
+                            libsql::params![subject, part_index, target_id],
+                        )
+                        .await?;
+                }
+            } else if let Some(prio) = priority {
                 self.conn
                     .execute(
-                        "UPDATE patchsets SET subject = ?, subject_index = ? WHERE id = ?",
-                        libsql::params![subject, part_index, target_id],
+                        "UPDATE patchsets SET base_priority = MAX(base_priority, ?), priority = CASE WHEN priority_cap IS NOT NULL THEN MIN(priority_cap, MAX(base_priority, ?)) ELSE MAX(base_priority, ?) END WHERE id = ?",
+                        libsql::params![prio, prio, prio, target_id],
                     )
                     .await?;
-            } else if matches.len() > 1 {
-                // If we merged, we might need to update the subject index of the target to the best one we found.
-                // But we don't have the subject string from the merged one easily available here.
-                // However, the existing target subject is likely fine unless part_index is better.
-                // Update subject_index to be correct if a better one was merged.
-                // Actually, if matches[i].1 was better, we should have used its subject.
-                // But that's complicated. Assuming the target (oldest) usually has the cover letter or we eventually find it.
-                // Simplification: We only update if CURRENT patch is better.
-                // If we merged a patchset that HAD the cover letter, we ideally want that subject.
-                // But we lost it.
-                // TODO: Optimize merge subject selection. For now, this is better than duplicates.
             }
 
             if let Some(clid) = cover_letter_message_id {
@@ -2320,11 +2448,12 @@ impl Database {
         }
 
         // No match found, create new patchset
+        let eff_priority = priority.unwrap_or(crate::settings::DEFAULT_PRIORITY);
         let mut rows = self.conn
             .query(
-                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, author, date, total_parts, received_parts, status, parser_version, to_recipients, cc_recipients, subject_index, baseline_id, baseline_part_index, skip_filters, only_filters)
-                 VALUES (?, ?, ?, ?, ?, ?, 0, 'Incomplete', ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
-                libsql::params![thread_id, cover_letter_message_id, subject, author, date, total_parts, parser_version, to, cc, part_index, baseline_id, baseline_id.map(|_| part_index), skip_filters_json.clone(), only_filters_json.clone()],
+                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, author, date, total_parts, received_parts, status, parser_version, to_recipients, cc_recipients, subject_index, baseline_id, baseline_part_index, skip_filters, only_filters, base_priority, priority)
+                 VALUES (?, ?, ?, ?, ?, ?, 0, 'Incomplete', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+                libsql::params![thread_id, cover_letter_message_id, subject, author, date, total_parts, parser_version, to, cc, part_index, baseline_id, baseline_id.map(|_| part_index), skip_filters_json.clone(), only_filters_json.clone(), eff_priority, eff_priority],
             )
             .await?;
 
@@ -3441,7 +3570,7 @@ impl Database {
     pub async fn get_pending_patchsets(&self, limit: usize) -> Result<Vec<PatchsetRow>> {
         let mut rows = self.conn.query(
             "SELECT id, subject, status, thread_id, author, date, cover_letter_message_id, total_parts, received_parts, baseline_id, failed_reason, target_review_count, skip_filters, only_filters, embargo_until, slug
-             FROM patchsets WHERE status = 'Pending' ORDER BY date ASC LIMIT ?",
+             FROM patchsets WHERE status = 'Pending' ORDER BY priority DESC, date ASC LIMIT ?",
             libsql::params![limit as i64],
         ).await?;
 
@@ -3900,6 +4029,7 @@ impl Database {
         mr_title: Option<&str>,
         mr_number: Option<i64>,
         slug: Option<&str>,
+        priority: Option<i32>,
     ) -> Result<i64> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
@@ -3932,10 +4062,17 @@ impl Database {
                     || status == "Failed To Apply"
                     || status == "FailedToApply"
                 {
-                    self.conn.execute(
-                        "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
-                        libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
-                    ).await?;
+                    if let Some(prio) = priority {
+                        self.conn.execute(
+                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ?, base_priority = ?, priority = ? WHERE id = ?",
+                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, prio, prio, id]
+                        ).await?;
+                    } else {
+                        self.conn.execute(
+                            "UPDATE patchsets SET status = 'Fetching', failed_reason = NULL, skip_filters = ?, only_filters = ?, mr_url = ?, mr_title = ?, mr_number = ?, slug = ? WHERE id = ?",
+                            libsql::params![skip_filters_json.clone(), only_filters_json.clone(), mr_url, mr_title, mr_number, slug, id]
+                        ).await?;
+                    }
                 }
                 return Ok(id);
             }
@@ -3945,11 +4082,12 @@ impl Database {
         let thread_id = self.ensure_thread_for_message(root_msg_id, now).await?;
 
         // 3. Create the fetching patchset
+        let eff_priority = priority.unwrap_or(crate::settings::DEFAULT_PRIORITY);
         let mut rows = self.conn
             .query(
-                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters, mr_url, mr_title, mr_number, slug)
-                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?, ?, ?, ?, ?) RETURNING id",
-                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json, mr_url, mr_title, mr_number, slug],
+                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, status, date, skip_filters, only_filters, mr_url, mr_title, mr_number, slug, base_priority, priority)
+                     VALUES (?, ?, ?, 'Fetching', ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+                libsql::params![thread_id, root_msg_id, subject, now, skip_filters_json, only_filters_json, mr_url, mr_title, mr_number, slug, eff_priority, eff_priority],
             )
             .await?;
 
@@ -3974,6 +4112,22 @@ impl Database {
             }
         }
         Ok(())
+    }
+
+    pub fn calculate_priority(
+        subject: &str,
+        rules: &[crate::settings::CompiledPriorityRule],
+    ) -> Option<i32> {
+        let mut priority = None;
+        for rule in rules {
+            if rule.regex.is_match(subject) {
+                priority = Some(
+                    rule.priority
+                        .clamp(crate::settings::MIN_PRIORITY, crate::settings::MAX_PRIORITY),
+                );
+            }
+        }
+        priority
     }
 
     pub async fn update_patchset_baseline_info(
@@ -4380,6 +4534,620 @@ mod tests {
         let db = Database::new(&settings).await.unwrap();
         db.migrate().await.unwrap();
         Arc::new(db)
+    }
+
+    #[tokio::test]
+    async fn test_patchset_priority_routing() {
+        let db = setup_db().await;
+
+        let thread_id = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+
+        let rules_config = [
+            crate::settings::PriorityRule {
+                regex: "(?i)^PRODKERNEL:".to_string(),
+                priority: 750,
+            },
+            crate::settings::PriorityRule {
+                regex: "security".to_string(),
+                priority: 999,
+            },
+        ];
+        let compiled_rules: Vec<_> = rules_config.iter().map(|r| r.compile().unwrap()).collect();
+
+        assert_eq!(
+            Database::calculate_priority("PRODKERNEL: perf updates", &compiled_rules),
+            Some(750)
+        );
+        assert_eq!(
+            Database::calculate_priority("PRODKERNEL: security leak fix", &compiled_rules),
+            Some(999)
+        );
+        assert_eq!(
+            Database::calculate_priority("staging: standard driver change", &compiled_rules),
+            None
+        );
+
+        let ps_low = db
+            .create_patchset_with_priority(
+                thread_id,
+                None,
+                "msg_low",
+                "staging: driver update",
+                "Author",
+                1000,
+                1,
+                1,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let ps_high = db
+            .create_patchset_with_priority(
+                thread_id,
+                None,
+                "msg_high",
+                "PRODKERNEL: fix memory corruption",
+                "Author",
+                2000,
+                1,
+                1,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                Some(750),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        db.conn
+            .execute(
+                "UPDATE patchsets SET status = 'Pending', received_parts = 1 WHERE id IN (?, ?)",
+                libsql::params![ps_low, ps_high],
+            )
+            .await
+            .unwrap();
+
+        let pending = db.get_pending_patchsets(10).await.unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].id, ps_high);
+        assert_eq!(pending[1].id, ps_low);
+    }
+
+    #[tokio::test]
+    async fn test_patchset_priority_two_column_and_series_elevation() {
+        let db = setup_db().await;
+        let thread_id = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+
+        db.create_message(
+            "msg_part1",
+            thread_id,
+            None,
+            "Author",
+            "PRODKERNEL: memory fix",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_cover",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 0/2] series cover",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_part2",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 2/2] minor tweak",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Scenario 1: Patch 1 arrives first (PRODKERNEL: -> 750), Cover 0 arrives second (None)
+        let ps1 = db
+            .create_patchset_with_priority(
+                thread_id,
+                None,
+                "msg_part1",
+                "PRODKERNEL: memory fix",
+                "Author",
+                1000,
+                2,
+                1,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                Some(750),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Cover letter arrives second (unmatched -> None)
+        let ps_cover = db
+            .create_patchset_with_priority(
+                thread_id,
+                Some("msg_cover"),
+                "msg_cover",
+                "[PATCH 0/2] series cover",
+                "Author",
+                1000,
+                2,
+                1,
+                "",
+                "",
+                None,
+                0,
+                None,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ps1, ps_cover);
+
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT base_priority, priority, priority_cap FROM patchsets WHERE id = ?",
+                libsql::params![ps1],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let base_prio: i32 = row.get(0).unwrap();
+        let eff_prio: i32 = row.get(1).unwrap();
+        let prio_cap: Option<i32> = row.get(2).ok();
+        assert_eq!(base_prio, 750);
+        assert_eq!(eff_prio, 750);
+        assert!(prio_cap.is_none());
+
+        // Test priority_cap (e.g. from batch deprioritization)
+        db.conn
+            .execute(
+                "UPDATE patchsets SET priority_cap = 200, priority = 200 WHERE id = ?",
+                libsql::params![ps1],
+            )
+            .await
+            .unwrap();
+
+        // Patch 2 arrives (unmatched -> None). base_priority must remain 750, priority remains capped at 200.
+        db.create_patchset_with_priority(
+            thread_id,
+            Some("msg_cover"),
+            "msg_part2",
+            "[PATCH 2/2] minor tweak",
+            "Author",
+            1000,
+            2,
+            1,
+            "",
+            "",
+            None,
+            2,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT base_priority, priority, priority_cap FROM patchsets WHERE id = ?",
+                libsql::params![ps1],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let base_prio: i32 = row.get(0).unwrap();
+        let eff_prio: i32 = row.get(1).unwrap();
+        let prio_cap: Option<i32> = row.get(2).ok();
+        assert_eq!(base_prio, 750);
+        assert_eq!(eff_prio, 200);
+        assert_eq!(prio_cap, Some(200));
+    }
+
+    #[tokio::test]
+    async fn test_patchset_priority_series_deprioritization() {
+        let db = setup_db().await;
+        let thread_id = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+
+        db.create_message(
+            "msg_doc_cover",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 0/2] doc updates",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_doc_part1",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 1/2] doc: fix spelling",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_doc_part2",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 2/2] minor grammar",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Cover letter matches low-priority rule (100)
+        let ps = db
+            .create_patchset_with_priority(
+                thread_id,
+                Some("msg_doc_cover"),
+                "msg_doc_cover",
+                "[PATCH 0/2] doc updates",
+                "Author",
+                1000,
+                2,
+                1,
+                "",
+                "",
+                None,
+                0,
+                None,
+                true,
+                None,
+                None,
+                Some(100),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Patch 1 arrives (also matches 100)
+        db.create_patchset_with_priority(
+            thread_id,
+            Some("msg_doc_cover"),
+            "msg_doc_part1",
+            "[PATCH 1/2] doc: fix spelling",
+            "Author",
+            1000,
+            2,
+            1,
+            "",
+            "",
+            None,
+            1,
+            None,
+            true,
+            None,
+            None,
+            Some(100),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Patch 2 arrives (unmatched -> None). Must NOT elevate series back to 500!
+        db.create_patchset_with_priority(
+            thread_id,
+            Some("msg_doc_cover"),
+            "msg_doc_part2",
+            "[PATCH 2/2] minor grammar",
+            "Author",
+            1000,
+            2,
+            1,
+            "",
+            "",
+            None,
+            2,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT base_priority, priority FROM patchsets WHERE id = ?",
+                libsql::params![ps],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let base_prio: i32 = row.get(0).unwrap();
+        let eff_prio: i32 = row.get(1).unwrap();
+        assert_eq!(base_prio, 100, "Deprioritized series must stay at 100");
+        assert_eq!(eff_prio, 100, "Effective priority must stay at 100");
+    }
+
+    #[tokio::test]
+    async fn test_patchset_priority_merge_elevation() {
+        let db = setup_db().await;
+        let thread_id = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+
+        db.create_message(
+            "msg_part1",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 1/2] minor tweak",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_part2",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 2/2] security fix",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.create_message(
+            "msg_cover",
+            thread_id,
+            None,
+            "Author",
+            "[PATCH 0/2] series cover",
+            1000,
+            "",
+            "",
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Patch 1 arrives first (standard priority 500)
+        let ps1 = db
+            .create_patchset_with_priority(
+                thread_id,
+                None,
+                "msg_part1",
+                "[PATCH 1/2] minor tweak",
+                "Author",
+                1000,
+                2,
+                1,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Patch 2 exists as an independent patchset in the same thread (elevated priority 999)
+        let mut rows = db
+            .conn
+            .query(
+                "INSERT INTO patchsets (thread_id, cover_letter_message_id, subject, author, date, total_parts, received_parts, status, parser_version, to_recipients, cc_recipients, subject_index, base_priority, priority)
+                 VALUES (?, NULL, '[PATCH 2/2] security fix', 'Author', 1000, 2, 0, 'Incomplete', 1, '', '', 2, 999, 999) RETURNING id",
+                libsql::params![thread_id],
+            )
+            .await
+            .unwrap();
+        let ps2: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_ne!(ps1, ps2);
+
+        // Cover letter arrives (unmatched -> None) in thread_id, merging both patchsets
+        let ps_merged = db
+            .create_patchset_with_priority(
+                thread_id,
+                Some("msg_cover"),
+                "msg_cover",
+                "[PATCH 0/2] series cover",
+                "Author",
+                1000,
+                2,
+                1,
+                "",
+                "",
+                None,
+                0,
+                None,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(ps_merged, ps1);
+
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT base_priority, priority FROM patchsets WHERE id = ?",
+                libsql::params![ps1],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let base_prio: i32 = row.get(0).unwrap();
+        let eff_prio: i32 = row.get(1).unwrap();
+        assert_eq!(
+            base_prio, 999,
+            "Merged patchset must inherit elevated base_priority from merged series"
+        );
+        assert_eq!(
+            eff_prio, 999,
+            "Merged patchset must inherit elevated effective priority from merged series"
+        );
+
+        // Verify that ps2 was deleted during merge
+        let mut rows = db
+            .conn
+            .query(
+                "SELECT count(*) FROM patchsets WHERE id = ?",
+                libsql::params![ps2],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(count, 0, "ps2 must be deleted after merge");
+    }
+
+    #[tokio::test]
+    async fn test_migration_v1_to_priority_columns() {
+        let db_settings = crate::settings::DatabaseSettings {
+            url: ":memory:".to_string(),
+            token: String::new(),
+        };
+        let db = Database::new(&db_settings).await.unwrap();
+
+        // Manually set up schema version 1 WITHOUT priority columns
+        db.conn
+            .execute_batch(
+                "CREATE TABLE threads (id INTEGER PRIMARY KEY, root_message_id TEXT, subject TEXT, last_updated INTEGER);
+                 CREATE TABLE messages (id INTEGER PRIMARY KEY, message_id TEXT NOT NULL UNIQUE, thread_id INTEGER, in_reply_to TEXT, author TEXT, subject TEXT, date INTEGER, body TEXT, to_recipients TEXT, cc_recipients TEXT, git_blob_hash TEXT, mailing_list TEXT, references_hdr TEXT);
+                 CREATE TABLE patchsets (id INTEGER PRIMARY KEY, thread_id INTEGER, cover_letter_message_id TEXT, subject TEXT, author TEXT, date INTEGER, total_parts INTEGER, received_parts INTEGER, status TEXT, parser_version INTEGER, to_recipients TEXT, cc_recipients TEXT, subject_index INTEGER, baseline_id INTEGER, failed_reason TEXT, skip_filters TEXT, only_filters TEXT, target_review_count INTEGER DEFAULT 1, model_name TEXT, prompts_git_hash TEXT, baseline_logs TEXT, mr_url TEXT, mr_title TEXT, mr_number TEXT, slug TEXT, provider TEXT, embargo_until INTEGER, embargo_release_started_at INTEGER);
+                 CREATE TABLE patches (id INTEGER PRIMARY KEY, patchset_id INTEGER NOT NULL, message_id TEXT NOT NULL, part_index INTEGER, diff TEXT, status TEXT, apply_error TEXT, FOREIGN KEY(patchset_id) REFERENCES patchsets(id), FOREIGN KEY(message_id) REFERENCES messages(message_id), UNIQUE(patchset_id, message_id));
+                 PRAGMA user_version = 1;",
+            )
+            .await
+            .unwrap();
+
+        // Run migrate() on existing version 1 DB
+        db.migrate().await.unwrap();
+
+        // Must now be able to query and insert priority-aware patchsets without column errors
+        let thread_id = db.create_thread("root", "Test Thread", 1000).await.unwrap();
+        let ps_id = db
+            .create_patchset_with_priority(
+                thread_id,
+                None,
+                "msg_m",
+                "Migrated Patch",
+                "Author",
+                1000,
+                1,
+                1,
+                "",
+                "",
+                None,
+                1,
+                None,
+                true,
+                None,
+                None,
+                Some(750),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let pending = db.get_pending_patchsets(10).await.unwrap();
+        assert_eq!(pending.len(), 0);
+
+        db.conn
+            .execute(
+                "UPDATE patchsets SET status = 'Pending', received_parts = 1 WHERE id = ?",
+                libsql::params![ps_id],
+            )
+            .await
+            .unwrap();
+
+        let pending = db.get_pending_patchsets(10).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, ps_id);
     }
 
     #[tokio::test]
@@ -8668,6 +9436,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -8733,6 +9502,7 @@ mod tests {
         db.create_fetching_patchset(
             &synthetic_id,
             "Fetching placeholder",
+            None,
             None,
             None,
             None,
@@ -8816,12 +9586,20 @@ mod tests {
             db.has_patchset_by_msgid(sha_patch).await.unwrap(),
             "has_patchset_by_msgid should return true for SHA existing in patches table"
         );
+
+        // 3. Non-existent SHA must return false
+        assert!(
+            !db.has_patchset_by_msgid("0000000000000000000000000000000000000000")
+                .await
+                .unwrap(),
+            "has_patchset_by_msgid should return false for unknown SHA"
+        );
     }
 
     /// Verify that has_patchset_by_msgid returns false for Failed and Cancelled
     /// patchsets so that retry submissions can be re-fetched.
     #[tokio::test]
-    async fn test_has_patchset_by_msgid_excludes_failed_and_cancelled() {
+    async fn test_has_patchset_by_msgid_ignores_failed_and_cancelled() {
         let db = setup_db().await;
         let sha_failed = "f00f00f001234567890abcdef1234567890abcdef";
         let synthetic_failed = format!("{}@sashiko.local", sha_failed);
@@ -8831,6 +9609,7 @@ mod tests {
             .create_fetching_patchset(
                 &synthetic_failed,
                 "Fetching failed placeholder",
+                None,
                 None,
                 None,
                 None,
@@ -8857,6 +9636,7 @@ mod tests {
             .create_fetching_patchset(
                 &synthetic_cancelled,
                 "Fetching cancelled placeholder",
+                None,
                 None,
                 None,
                 None,
@@ -9111,6 +9891,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -9178,6 +9959,7 @@ mod tests {
             .create_fetching_patchset(
                 &synthetic_cover,
                 "Fetching retry",
+                None,
                 None,
                 None,
                 None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -58,6 +58,10 @@ pub enum Event {
         baseline: Option<String>,
         skip_subjects: Option<Vec<String>>,
         only_subjects: Option<Vec<String>>,
+        /// Server-side timestamp for when the submission was received.
+        /// Used instead of the email's Date: header for patchset ordering
+        /// to prevent stale mbox timestamps from skewing the queue.
+        submitted_at: Option<i64>,
     },
     IngestionFailed {
         article_id: String,

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -12,331 +12,403 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::db::{Database, FetchQueueRow};
 use crate::events::{Event, MessageSource};
 use crate::utils::redact_secret;
 use anyhow::{Result, anyhow};
-use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, interval};
 use tracing::{error, info, warn};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FetchRequest {
-    pub repo_url: Option<String>,
-    pub commit_hash: String,
-    pub mr_url: Option<String>,
-    pub mr_title: Option<String>,
-    pub mr_number: Option<i64>,
+/// How often the worker polls the durable queue for due work.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// How often expired leases from dead workers are reclaimed.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+/// A claimed fetch whose worker stops updating it for this long is treated as a
+/// ghost and reclaimed by the sweep.
+const GHOST_LEASE_SECS: i64 = 600;
+/// Total wall-clock window a fetch keeps retrying before it is failed.
+const RETRY_WINDOW_SECS: i64 = 24 * 60 * 60;
+/// First retry delay; subsequent delays double up to BACKOFF_CAP_SECS.
+const BACKOFF_BASE_SECS: i64 = 30;
+/// Maximum delay between retries.
+const BACKOFF_CAP_SECS: i64 = 600;
+
+/// Maximum number of fetch_queue rows to claim and pre-fetch in a single
+/// `git fetch` call. Batching improves server-side pack negotiation.
+const BATCH_SIZE: usize = 20;
+
+/// Marker error for failures that can never succeed on retry (e.g. a commit
+/// is missing and the row has no remote to fetch from). These bypass the
+/// backoff retry window and fail the fetch immediately, mirroring the
+/// fast-fail behaviour of the old in-memory FetchAgent.
+#[derive(Debug)]
+struct PermanentFetchError(String);
+
+impl std::fmt::Display for PermanentFetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
-pub struct FetchAgent {
+impl std::error::Error for PermanentFetchError {}
+
+/// Derive the git commit or range to fetch from a placeholder message id.
+///
+/// Handles the two placeholder id shapes produced by the API:
+///   - git-fetch:  "<sha>@sashiko.local"        -> "<sha>"
+///   - PR/MR:      "mr-<number>-<base>..<head>"  -> "<base>..<head>"
+pub fn commit_hash_from_placeholder(msgid: &str) -> String {
+    // "mr-<number>-<rest>" -> "<rest>"; anything else passes through.
+    let s = msgid
+        .strip_prefix("mr-")
+        .and_then(|rest| rest.find('-').map(|dash| &rest[dash + 1..]))
+        .unwrap_or(msgid);
+    // Strip any "@sashiko.local" suffix from git-fetch placeholder ids.
+    s.split('@').next().unwrap_or(s).to_string()
+}
+
+/// Current unix time in seconds.
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Exponential backoff (in seconds) for a given attempt count. `attempts` is the
+/// number of attempts already made (>= 1 after the first claim): 1 -> 30s,
+/// 2 -> 60s, 3 -> 120s, ... capped at BACKOFF_CAP_SECS.
+fn backoff_secs(attempts: i64) -> i64 {
+    let exp = attempts.saturating_sub(1).clamp(0, 20) as u32;
+    BACKOFF_BASE_SECS
+        .saturating_mul(2_i64.saturating_pow(exp))
+        .min(BACKOFF_CAP_SECS)
+}
+
+/// Whether a revision string is a full git object id (sha1 = 40 hex chars, or
+/// sha256 = 64). Only full object ids can be requested directly via `want`
+/// without a ref lookup; branch/tag names must be resolved by the server.
+fn looks_like_object_id(rev: &str) -> bool {
+    matches!(rev.len(), 40 | 64) && rev.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Durable, restart-safe git fetch worker.
+///
+/// Replaces the previous in-memory `FetchAgent` channel. Fetch requests live in
+/// the `fetch_queue` table; this worker claims them under a lease, performs the
+/// git fetch and patch extraction, and either completes them, schedules a
+/// backoff retry, or (after RETRY_WINDOW_SECS) fails them terminally. Because
+/// all state lives in the database, requests survive restarts and crashed
+/// workers are recovered by the ghost sweep.
+pub struct FetchWorker {
     repo_path: PathBuf,
-    rx: mpsc::Receiver<FetchRequest>,
+    db: Arc<Database>,
     main_tx: mpsc::Sender<Event>,
-    #[allow(clippy::type_complexity)]
-    mr_metadata: HashMap<String, (Option<String>, Option<String>, Option<i64>)>,
     gitlab_token: Option<String>,
 }
 
-impl FetchAgent {
+impl FetchWorker {
     pub fn new(
         repo_path: PathBuf,
+        db: Arc<Database>,
         main_tx: mpsc::Sender<Event>,
         gitlab_token: Option<String>,
-    ) -> (Self, mpsc::Sender<FetchRequest>) {
-        let (tx, rx) = mpsc::channel(100);
-        (
-            Self {
-                repo_path,
-                rx,
-                main_tx,
-                mr_metadata: HashMap::new(),
-                gitlab_token,
-            },
-            tx,
-        )
+    ) -> Self {
+        Self {
+            repo_path,
+            db,
+            main_tx,
+            gitlab_token,
+        }
     }
 
-    pub async fn run(mut self) {
-        info!("FetchAgent started");
-        let mut queue: HashMap<Option<String>, HashSet<String>> = HashMap::new();
-        let mut ticker = interval(Duration::from_secs(10));
+    pub async fn run(self) {
+        info!("FetchWorker started");
 
+        // Reclaim ghost leases on an independent task so that a long-running (or
+        // stuck) fetch on the main loop can never prevent dead-worker recovery.
+        {
+            let db = self.db.clone();
+            tokio::spawn(async move {
+                let mut sweep = interval(SWEEP_INTERVAL);
+                loop {
+                    sweep.tick().await;
+                    match db.sweep_ghost_fetches(GHOST_LEASE_SECS).await {
+                        Ok(n) if n > 0 => {
+                            warn!("Reclaimed {} ghost fetch(es) from dead workers", n);
+                        }
+                        Ok(_) => {}
+                        Err(e) => error!("Ghost fetch sweep failed: {}", e),
+                    }
+                }
+            });
+        }
+
+        let mut poll = interval(POLL_INTERVAL);
         loop {
-            tokio::select! {
-                Some(req) = self.rx.recv() => {
-                    if req.mr_url.is_some() || req.mr_title.is_some() || req.mr_number.is_some() {
-                        self.mr_metadata.insert(
-                            req.commit_hash.clone(),
-                            (req.mr_url.clone(), req.mr_title.clone(), req.mr_number)
-                        );
-                    }
-                    queue.entry(req.repo_url)
-                        .or_default()
-                        .insert(req.commit_hash);
+            poll.tick().await;
+            // Claim up to BATCH_SIZE rows and pre-fetch their objects in a
+            // single `git fetch` call. Batching lets the server compute one
+            // optimal pack for many wants, avoiding the pathological 11M-object
+            // downloads that happen when unreachable SHAs are fetched one at a
+            // time with poor negotiation.
+            let mut batch = Vec::new();
+            loop {
+                if batch.len() >= BATCH_SIZE {
+                    break;
                 }
-                _ = ticker.tick() => {
-                    if !queue.is_empty() {
-                        self.process_queue(&mut queue).await;
+                match self.db.lock_pending_fetch().await {
+                    Ok(Some(row)) => batch.push(row),
+                    Ok(None) => break,
+                    Err(e) => {
+                        error!("Failed to claim pending fetch: {}", e);
+                        break;
                     }
                 }
+            }
+            if batch.is_empty() {
+                continue;
+            }
+
+            // Pre-fetch all missing objects in one batch call.
+            self.batch_prefetch(&batch).await;
+
+            // Process each row individually for ingestion.
+            for row in batch {
+                self.process_row(row).await;
             }
         }
     }
 
-    async fn process_queue(&self, queue: &mut HashMap<Option<String>, HashSet<String>>) {
-        info!("Processing fetch queue with {} repos", queue.len());
+    /// Process a single claimed fetch: ensure the commits are present locally
+    /// (fetching from the remote if needed), extract the patch(es), and emit the
+    /// corresponding events. On any failure the row is retried with backoff, or
+    /// failed terminally once the retry window is exhausted.
+    async fn process_row(&self, row: FetchQueueRow) {
+        info!(
+            "Processing fetch {} (commit {}, attempt {})",
+            row.id, row.commit_hash, row.attempts
+        );
 
-        for (url_opt, commits) in queue.drain() {
-            if commits.is_empty() {
-                continue;
-            }
+        if let Err(e) = self.ensure_present(&row).await {
+            self.handle_failure(&row, e.context("fetch failed")).await;
+            return;
+        }
 
-            let commit_list: Vec<String> = commits.into_iter().collect();
-            let url_display = url_opt.as_deref().unwrap_or("local");
-
-            info!(
-                "Processing {} commits for remote {}",
-                commit_list.len(),
-                url_display
-            );
-
-            // For ranges (base..head), we need to check both endpoints individually
-            let mut commits_to_check = Vec::new();
-            for commit_or_range in &commit_list {
-                if commit_or_range.contains("..") {
-                    let parts: Vec<&str> = commit_or_range.split("..").collect();
-                    if parts.len() == 2 {
-                        commits_to_check.push(parts[0].to_string());
-                        commits_to_check.push(parts[1].to_string());
-                    }
+        match self.ingest(&row).await {
+            Ok(()) => {
+                if let Err(e) = self.db.mark_fetch_done(row.id).await {
+                    error!("Failed to mark fetch {} done: {}", row.id, e);
                 } else {
-                    commits_to_check.push(commit_or_range.clone());
+                    info!("Fetch complete for {}", row.commit_hash);
                 }
             }
-
-            let mut missing_commits = Vec::new();
-            for commit in &commits_to_check {
-                if !self.is_present(commit).await {
-                    missing_commits.push(commit.clone());
-                }
+            Err(e) => {
+                self.handle_failure(&row, e.context("extract failed")).await;
             }
+        }
+    }
 
-            if missing_commits.is_empty() {
-                info!(
-                    "All commits present locally, skipping fetch for {}",
-                    url_display
-                );
-            } else if let Some(url) = url_opt {
-                // Remote fetch logic
-                let remote_name = self.get_remote_name(&url);
-
-                // Check if repo is local (same as self.repo_path)
-                let is_local = {
-                    let url_path = PathBuf::from(&url);
-                    if let (Ok(canon_url), Ok(canon_repo)) = (
-                        std::fs::canonicalize(&url_path),
-                        std::fs::canonicalize(&self.repo_path),
-                    ) {
-                        canon_url == canon_repo
-                    } else {
-                        false
-                    }
-                };
-
-                if is_local {
-                    warn!(
-                        "Repository is local but commits are missing: {:?}. Cannot fetch.",
-                        missing_commits
-                    );
-                    // Do not continue here; let it fall through to Step 3 where it will fail individually
-                } else {
-                    if let Err(e) = self.ensure_remote(&remote_name, &url).await {
-                        error!("Failed to ensure remote {}: {}", url, e);
-                        for commit in &missing_commits {
-                            let _ = self
-                                .main_tx
-                                .send(Event::IngestionFailed {
-                                    article_id: commit.clone(),
-                                    error: format!("Failed to set up remote {}: {}", url, e),
-                                    source: MessageSource::GitFetch,
-                                })
-                                .await;
-                        }
-                        continue;
-                    }
-
-                    // 1. Try optimistic fetch (fetch specific commits)
-                    if let Err(e) = self.fetch_commits(&remote_name, &missing_commits).await {
-                        warn!(
-                            "Optimistic fetch failed for {}: {}. Falling back to full fetch.",
-                            url, e
-                        );
-                        // 2. Fallback: Fetch everything (heads)
-                        if let Err(e) = self.fetch_all(&remote_name).await {
-                            error!("Full fetch failed for {}: {}", url, e);
-                            for commit in &missing_commits {
-                                let _ = self
-                                    .main_tx
-                                    .send(Event::IngestionFailed {
-                                        article_id: commit.clone(),
-                                        error: format!("Failed to fetch from {}: {}", url, e),
-                                        source: MessageSource::GitFetch,
-                                    })
-                                    .await;
-                            }
-                            continue;
-                        }
-                    }
-                }
+    /// Ensure every commit referenced by the row exists locally, fetching from
+    /// the remote when necessary.
+    async fn ensure_present(&self, row: &FetchQueueRow) -> Result<()> {
+        // For ranges (base..head), both endpoints must be checked individually.
+        let mut to_check = Vec::new();
+        if let Some((start, end)) = row.commit_hash.split_once("..") {
+            to_check.push(start.to_string());
+            to_check.push(end.to_string());
+        } else {
+            to_check.push(row.commit_hash.clone());
+        }
+        for sha in &row.supporting_commits {
+            if let Some((start, end)) = sha.split_once("..") {
+                to_check.push(start.to_string());
+                to_check.push(end.to_string());
             } else {
-                // Local repo, but commits are missing
-                warn!(
-                    "Local repository missing commits: {:?}. Cannot fetch.",
-                    missing_commits
-                );
+                to_check.push(sha.clone());
             }
+        }
 
-            // 3. Process each commit or range
-            for commit_or_range in commit_list {
-                if commit_or_range.contains("..") {
-                    // It's a range
-                    let range = &commit_or_range;
+        let mut missing = Vec::new();
+        for commit in &to_check {
+            if !self.is_present(commit).await {
+                missing.push(commit.clone());
+            }
+        }
+        if missing.is_empty() {
+            return Ok(());
+        }
 
-                    let shas = match crate::git_ops::resolve_git_range(&self.repo_path, range).await
-                    {
-                        Ok(shas) => shas,
-                        Err(e) => {
-                            let _ = self
-                                .main_tx
-                                .send(Event::IngestionFailed {
-                                    article_id: range.clone(),
-                                    error: format!("Failed to resolve git range: {}", e),
-                                    source: MessageSource::GitFetch,
-                                })
-                                .await;
-                            continue;
-                        }
-                    };
-                    let count = shas.len() as u32;
+        let url = match row.repo_url.as_deref().map(str::trim) {
+            Some(u) if !u.is_empty() => u,
+            _ => {
+                return Err(PermanentFetchError(format!(
+                    "commits {:?} missing and no remote is configured",
+                    missing
+                ))
+                .into());
+            }
+        };
 
-                    // Process each SHA
-                    let (mr_url, mr_title, mr_number) = self
-                        .mr_metadata
-                        .get(range)
-                        .cloned()
-                        .unwrap_or((None, None, None));
+        // A local repository cannot be fetched from; the commits simply are not
+        // there.
+        let is_local = {
+            let url_path = PathBuf::from(url);
+            match (
+                std::fs::canonicalize(&url_path),
+                std::fs::canonicalize(&self.repo_path),
+            ) {
+                (Ok(a), Ok(b)) => a == b,
+                _ => false,
+            }
+        };
+        if is_local {
+            return Err(PermanentFetchError(format!(
+                "repository is local but commits are missing: {:?}",
+                missing
+            ))
+            .into());
+        }
 
-                    let article_id = if let Some(number) = mr_number {
-                        format!("mr-{}-{}", number, range)
-                    } else {
-                        range.to_string()
-                    };
+        let remote_name = self.get_remote_name(url);
 
-                    for (i, sha) in shas.iter().enumerate() {
-                        match self
-                            .extract_patch(
-                                sha,
-                                &article_id,
-                                (i + 1) as u32,
-                                count,
-                                mr_url.as_ref(),
-                                mr_title.as_ref(),
-                                mr_number,
-                            )
-                            .await
-                        {
-                            Ok(mut event) => {
-                                if let Event::PatchSubmitted {
-                                    ref mut message_id, ..
-                                } = event
-                                {
-                                    *message_id = sha.clone();
-                                }
-                                if let Err(e) = self.main_tx.send(event).await {
-                                    error!("Failed to send PatchSubmitted event: {}", e);
-                                }
-                            }
-                            Err(e) => {
-                                error!(
-                                    "Failed to extract patch {} from range {}: {}",
-                                    sha, range, e
-                                );
-                            }
-                        }
-                    }
-                    info!("Successfully submitted remote range {}", range);
-                } else {
-                    // Single commit
-                    let full_sha = match self.resolve_sha(&commit_or_range).await {
-                        Ok(sha) => sha,
-                        Err(e) => {
-                            let _ = self
-                                .main_tx
-                                .send(Event::IngestionFailed {
-                                    article_id: commit_or_range.clone(),
-                                    error: format!("Failed to resolve SHA: {}", e),
-                                    source: MessageSource::GitFetch,
-                                })
-                                .await;
-                            continue;
-                        }
-                    };
+        // Acquire the per-remote lock so we never run concurrent fetches
+        // against the same remote (shared with ensure_remote_with_refspecs
+        // and batch_prefetch).
+        let lock = crate::git_ops::get_remote_lock(&remote_name);
+        let _guard = lock.lock().await;
 
-                    let (mr_url, mr_title, mr_number) = self
-                        .mr_metadata
-                        .get(&commit_or_range)
-                        .cloned()
-                        .unwrap_or((None, None, None));
+        self.ensure_remote(&remote_name, url).await?;
 
-                    let article_id = if let Some(number) = mr_number {
-                        format!("mr-{}-{}", number, &commit_or_range)
-                    } else {
-                        commit_or_range.clone()
-                    };
+        // Fetch exactly the missing revisions. We deliberately do NOT fall
+        // back to a full `git fetch` of all refs: large mirrors (e.g. the kernel
+        // repo with hundreds of thousands of refs) make that pathologically
+        // slow, and it is unnecessary -- a still-missing object here is
+        // genuinely unfetchable and should surface as an error.
+        self.fetch_commits(&remote_name, &missing).await?;
+        Ok(())
+    }
 
-                    match self
-                        .extract_patch(
-                            &full_sha,
-                            &article_id,
-                            1,
-                            1,
-                            mr_url.as_ref(),
-                            mr_title.as_ref(),
-                            mr_number,
-                        )
-                        .await
-                    {
-                        Ok(mut event) => {
-                            if let Event::PatchSubmitted {
-                                ref mut message_id, ..
-                            } = event
-                            {
-                                *message_id = full_sha.clone();
-                            }
-                            if let Err(e) = self.main_tx.send(event).await {
-                                error!("Failed to send PatchSubmitted event: {}", e);
-                            } else {
-                                info!("Successfully submitted remote patch {}", commit_or_range);
-                            }
-                        }
-                        Err(e) => {
-                            error!("Failed to extract patch {}: {}", commit_or_range, e);
-                            let _ = self
-                                .main_tx
-                                .send(Event::IngestionFailed {
-                                    article_id: commit_or_range,
-                                    error: format!("Failed to extract patch: {}", e),
-                                    source: MessageSource::GitFetch,
-                                })
-                                .await;
-                        }
-                    }
+    /// Extract patch(es) for the row and emit PatchSubmitted events.
+    async fn ingest(&self, row: &FetchQueueRow) -> Result<()> {
+        let article_id = Self::article_id_for(row);
+        let mr_url = row.mr_url.clone();
+        let mr_title = row.mr_title.clone();
+
+        if row.commit_hash.contains("..") {
+            let shas = crate::git_ops::resolve_git_range(&self.repo_path, &row.commit_hash).await?;
+            let count = shas.len() as u32;
+            for (i, sha) in shas.iter().enumerate() {
+                let mut event = self
+                    .extract_patch(
+                        sha,
+                        &article_id,
+                        (i + 1) as u32,
+                        count,
+                        mr_url.as_ref(),
+                        mr_title.as_ref(),
+                        row.mr_number,
+                    )
+                    .await?;
+                if let Event::PatchSubmitted {
+                    ref mut message_id, ..
+                } = event
+                {
+                    *message_id = sha.clone();
                 }
+                self.main_tx
+                    .send(event)
+                    .await
+                    .map_err(|e| anyhow!("failed to send event: {}", e))?;
             }
+            info!("Submitted range {}", row.commit_hash);
+        } else {
+            let full_sha = self.resolve_sha(&row.commit_hash).await?;
+            let mut event = self
+                .extract_patch(
+                    &full_sha,
+                    &article_id,
+                    1,
+                    1,
+                    mr_url.as_ref(),
+                    mr_title.as_ref(),
+                    row.mr_number,
+                )
+                .await?;
+            if let Event::PatchSubmitted {
+                ref mut message_id, ..
+            } = event
+            {
+                *message_id = full_sha.clone();
+            }
+            self.main_tx
+                .send(event)
+                .await
+                .map_err(|e| anyhow!("failed to send event: {}", e))?;
+            info!("Submitted patch {}", row.commit_hash);
+        }
+        Ok(())
+    }
+
+    /// Decide whether to retry (with backoff) or terminally fail a fetch.
+    async fn handle_failure(&self, row: &FetchQueueRow, error: anyhow::Error) {
+        let now = now_secs();
+        let first = row.first_attempt_at.unwrap_or(now);
+        let permanent = error.downcast_ref::<PermanentFetchError>().is_some();
+        let msg = format!("{:#}", error);
+        if permanent {
+            error!(
+                "Fetch {} for {} failed permanently (not retrying): {}",
+                row.id, row.commit_hash, msg
+            );
+        } else if now - first >= RETRY_WINDOW_SECS {
+            error!(
+                "Fetch {} for {} exhausted its {}h retry window: {}",
+                row.id,
+                row.commit_hash,
+                RETRY_WINDOW_SECS / 3600,
+                msg
+            );
+        }
+        if permanent || now - first >= RETRY_WINDOW_SECS {
+            if let Err(e) = self.db.mark_fetch_failed(row.id, &msg).await {
+                error!("Failed to mark fetch {} failed: {}", row.id, e);
+            }
+            // Surface the terminal failure so the placeholder patchset moves out
+            // of 'Fetching' into 'Failed'.
+            let _ = self
+                .main_tx
+                .send(Event::IngestionFailed {
+                    article_id: Self::article_id_for(row),
+                    error: msg.clone(),
+                    source: MessageSource::GitFetch,
+                })
+                .await;
+        } else {
+            let backoff = backoff_secs(row.attempts);
+            warn!(
+                "Fetch {} for {} failed (attempt {}), retrying in {}s: {}",
+                row.id, row.commit_hash, row.attempts, backoff, msg
+            );
+            if let Err(e) = self
+                .db
+                .set_fetch_retry_at(row.id, now + backoff, &msg)
+                .await
+            {
+                error!("Failed to schedule retry for fetch {}: {}", row.id, e);
+            }
+        }
+    }
+
+    fn article_id_for(row: &FetchQueueRow) -> String {
+        match row.mr_number {
+            Some(number) => format!("mr-{}-{}", number, row.commit_hash),
+            None => row.commit_hash.clone(),
         }
     }
 
@@ -351,6 +423,9 @@ impl FetchAgent {
     }
 
     async fn ensure_remote(&self, name: &str, url: &str) -> Result<()> {
+        let global_lock = crate::git_ops::get_global_config_lock();
+        let _global_guard = global_lock.lock().await;
+
         // Inject GitLab token if available
         let authenticated_url = if let Some(token) = &self.gitlab_token {
             if url.contains("gitlab.com") && url.starts_with("https://") {
@@ -418,42 +493,139 @@ impl FetchAgent {
         Ok(())
     }
 
+    /// Fetch the given revisions from `remote`, tuned for a very large remote.
+    ///
+    /// Full object ids are fetched directly (`want <oid>`) in a single batched
+    /// call with no ref advertisement. Branch/tag names are resolved server-side
+    /// via a protocol-v2, prefix-filtered `ls-refs` (cheap even against a remote
+    /// with hundreds of thousands of refs) and fetched individually so one bad
+    /// name does not fail the whole batch.
     async fn fetch_commits(&self, remote: &str, commits: &[String]) -> Result<()> {
-        let mut cmd = Command::new("git");
-        cmd.current_dir(&self.repo_path)
-            .args(crate::git_ops::GIT_PROTOCOL_RESTRICTIONS)
-            .arg("fetch")
-            .arg(remote);
-
-        for commit in commits {
-            cmd.arg(commit);
+        let mut object_ids: Vec<&str> = Vec::new();
+        let mut ref_names: Vec<&str> = Vec::new();
+        for c in commits {
+            if looks_like_object_id(c) {
+                object_ids.push(c.as_str());
+            } else {
+                ref_names.push(c.as_str());
+            }
         }
 
-        let output = cmd.output().await?;
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Fetch failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
+        if !object_ids.is_empty() {
+            let mut cmd = self.fetch_base_cmd();
+            // Objects are resolvable by id regardless of refs, so skip tag
+            // following and don't serialize on FETCH_HEAD.
+            cmd.arg("--no-tags")
+                .arg("--no-write-fetch-head")
+                .arg(remote);
+            for oid in &object_ids {
+                cmd.arg(oid);
+            }
+            let output = cmd.output().await?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "fetch of {} object(s) failed: {}",
+                    object_ids.len(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
+        }
+
+        for name in ref_names {
+            let mut cmd = self.fetch_base_cmd();
+            // Keep default refspec/FETCH_HEAD behaviour so the name stays
+            // resolvable locally after the fetch.
+            cmd.arg(remote).arg(name);
+            let output = cmd.output().await?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "fetch of ref {} failed: {}",
+                    name,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
         }
         Ok(())
     }
 
-    async fn fetch_all(&self, remote: &str) -> Result<()> {
-        let output = Command::new("git")
-            .current_dir(&self.repo_path)
+    /// Base `git fetch` command shared by all fetches: no interactive prompt,
+    /// the standard protocol restrictions, and `kill_on_drop` so a cancelled
+    /// fetch is reaped. Callers append fetch flags, the remote, and revisions.
+    ///
+    /// Note: protocol v2 is deliberately NOT forced here. Protocol v1 sends
+    /// all remote refs upfront, giving the client rich negotiation data that
+    /// avoids pathological full-repo downloads for unreachable SHAs.
+    fn fetch_base_cmd(&self) -> Command {
+        let mut cmd = Command::new("git");
+        cmd.current_dir(&self.repo_path)
+            .args(["-c", "safe.bareRepository=all"])
+            .env("GIT_TERMINAL_PROMPT", "0")
             .args(crate::git_ops::GIT_PROTOCOL_RESTRICTIONS)
-            .args(["fetch", remote])
-            .output()
-            .await?;
+            .arg("fetch")
+            .kill_on_drop(true);
+        cmd
+    }
 
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Fetch all failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
+    /// Pre-fetch objects for a batch of rows in a single `git fetch` call.
+    /// Groups rows by remote URL and fetches all missing SHAs together so
+    /// the server can compute one optimal pack.
+    async fn batch_prefetch(&self, rows: &[FetchQueueRow]) {
+        // Group SHAs by remote URL.
+        let mut by_remote: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            let mut commits = if let Some((start, end)) = row.commit_hash.split_once("..") {
+                vec![start.to_string(), end.to_string()]
+            } else {
+                vec![row.commit_hash.clone()]
+            };
+            for sha in &row.supporting_commits {
+                if let Some((start, end)) = sha.split_once("..") {
+                    commits.push(start.to_string());
+                    commits.push(end.to_string());
+                } else {
+                    commits.push(sha.clone());
+                }
+            }
+            let url = row.repo_url.clone().unwrap_or_default();
+            by_remote.entry(url).or_default().extend(commits);
         }
-        Ok(())
+
+        for (url, commits) in &by_remote {
+            if url.is_empty() {
+                continue;
+            }
+            // Filter to only missing objects.
+            let mut missing = Vec::new();
+            for c in commits {
+                if !self.is_present(c).await {
+                    missing.push(c.clone());
+                }
+            }
+            if missing.is_empty() {
+                continue;
+            }
+
+            let remote_name = self.get_remote_name(url);
+            if let Err(e) = self.ensure_remote(&remote_name, url).await {
+                warn!("batch_prefetch: failed to ensure remote {}: {}", url, e);
+                continue;
+            }
+            info!(
+                "batch_prefetch: fetching {} SHAs from {} in one call",
+                missing.len(),
+                url
+            );
+            // Acquire the per-remote lock so we never run concurrent
+            // fetches against the same remote (which causes duplicate
+            // 11M-object downloads).
+            let lock = crate::git_ops::get_remote_lock(&remote_name);
+            let _guard = lock.lock().await;
+            if let Err(e) = self.fetch_commits(&remote_name, &missing).await {
+                warn!("batch_prefetch: batch fetch failed: {}", e);
+                // Individual process_row calls will retry on their own.
+            }
+        }
     }
 
     async fn is_present(&self, commit_or_range: &str) -> bool {
@@ -551,82 +723,62 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
-    // --- Standalone helpers for the durable fetch worker ---
-
-    /// First retry delay; subsequent delays double up to BACKOFF_CAP_SECS.
-    const BACKOFF_BASE_SECS: i64 = 30;
-    /// Maximum delay between retries.
-    const BACKOFF_CAP_SECS: i64 = 600;
-
-    /// Marker error for failures that can never succeed on retry (e.g. a commit
-    /// is missing and the row has no remote to fetch from). These bypass the
-    /// backoff retry window and fail the fetch immediately, mirroring the
-    /// fast-fail behaviour of the old in-memory FetchAgent.
-    #[derive(Debug)]
-    struct PermanentFetchError(String);
-
-    impl std::fmt::Display for PermanentFetchError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
+    async fn test_worker(repo_path: PathBuf) -> FetchWorker {
+        let settings = crate::settings::DatabaseSettings {
+            url: ":memory:".to_string(),
+            token: String::new(),
+        };
+        let db = Arc::new(Database::new(&settings).await.unwrap());
+        db.migrate().await.unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        FetchWorker::new(repo_path, db, tx, None)
     }
 
-    impl std::error::Error for PermanentFetchError {}
-
-    /// Derive the git commit or range to fetch from a placeholder message id.
-    ///
-    /// Handles the two placeholder id shapes produced by the API:
-    ///   - git-fetch:  "<sha>@sashiko.local"        -> "<sha>"
-    ///   - PR/MR:      "mr-<number>-<base>..<head>"  -> "<base>..<head>"
-    pub fn commit_hash_from_placeholder(msgid: &str) -> String {
-        // "mr-<number>-<rest>" -> "<rest>"; anything else passes through.
-        let s = msgid
-            .strip_prefix("mr-")
-            .and_then(|rest| rest.find('-').map(|dash| &rest[dash + 1..]))
-            .unwrap_or(msgid);
-        // Strip any "@sashiko.local" suffix from git-fetch placeholder ids.
-        s.split('@').next().unwrap_or(s).to_string()
+    #[test]
+    fn test_commit_hash_from_placeholder() {
+        assert_eq!(
+            commit_hash_from_placeholder("abc123@sashiko.local"),
+            "abc123"
+        );
+        assert_eq!(
+            commit_hash_from_placeholder("mr-42-base..head"),
+            "base..head"
+        );
+        assert_eq!(
+            commit_hash_from_placeholder("mr-42-base..head@sashiko.local"),
+            "base..head"
+        );
+        assert_eq!(commit_hash_from_placeholder("plainsha"), "plainsha");
     }
 
-    /// Current unix time in seconds.
-    fn now_secs() -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
+    #[test]
+    fn test_backoff_secs_is_exponential_and_capped() {
+        assert_eq!(backoff_secs(1), 30);
+        assert_eq!(backoff_secs(2), 60);
+        assert_eq!(backoff_secs(3), 120);
+        assert_eq!(backoff_secs(4), 240);
+        assert_eq!(backoff_secs(5), 480);
+        assert_eq!(backoff_secs(6), 600);
+        assert_eq!(backoff_secs(100), 600);
     }
 
-    /// Exponential backoff (in seconds) for a given attempt count. `attempts` is the
-    /// number of attempts already made (>= 1 after the first claim): 1 -> 30s,
-    /// 2 -> 60s, 3 -> 120s, ... capped at BACKOFF_CAP_SECS.
-    fn backoff_secs(attempts: i64) -> i64 {
-        let exp = attempts.saturating_sub(1).clamp(0, 20) as u32;
-        BACKOFF_BASE_SECS
-            .saturating_mul(2_i64.saturating_pow(exp))
-            .min(BACKOFF_CAP_SECS)
+    #[test]
+    fn test_looks_like_object_id() {
+        assert!(looks_like_object_id(&"a".repeat(40)));
+        assert!(looks_like_object_id(&"0".repeat(64)));
+        assert!(looks_like_object_id(
+            "8a21aa5149b3f34f48a277d596d1ffe512b32a41"
+        ));
+        assert!(!looks_like_object_id("main"));
+        assert!(!looks_like_object_id("v6.10"));
+        assert!(!looks_like_object_id("refs/heads/main"));
+        assert!(!looks_like_object_id(&"a".repeat(39)));
+        assert!(!looks_like_object_id("zzzz"));
     }
-
-    /// Whether a revision string is a full git object id (sha1 = 40 hex chars, or
-    /// sha256 = 64). Only full object ids can be requested directly via `want`
-    /// without a ref lookup; branch/tag names must be resolved by the server.
-    fn looks_like_object_id(rev: &str) -> bool {
-        matches!(rev.len(), 40 | 64) && rev.bytes().all(|b| b.is_ascii_hexdigit())
-    }
-
-    /// Durable, restart-safe git fetch worker.
-    ///
-    /// Replaces the previous in-memory `FetchAgent` channel. Fetch requests live in
-    /// the `fetch_queue` table; this worker claims them under a lease, performs the
-    /// git fetch and patch extraction, and either completes them, schedules a
-    /// backoff retry, or (after RETRY_WINDOW_SECS) fails them terminally. Because
-    /// all state lives in the database, requests survive restarts and crashed
-    /// workers are recovered by the ghost sweep.
 
     #[tokio::test]
-    async fn test_fetch_agent_lifecycle() {
-        let (tx, _rx) = mpsc::channel(1);
-        let repo_path = PathBuf::from("/tmp");
-        let (_agent, _sender) = FetchAgent::new(repo_path, tx, None);
+    async fn test_fetch_worker_construction() {
+        let _worker = test_worker(PathBuf::from("/tmp")).await;
     }
 
     #[tokio::test]
@@ -666,8 +818,7 @@ mod tests {
             .output()
             .await?;
 
-        let (tx, _rx) = mpsc::channel(1);
-        let (agent, _) = FetchAgent::new(repo_path.clone(), tx, None);
+        let agent = test_worker(repo_path.clone()).await;
 
         let output = Command::new("git")
             .current_dir(&repo_path)
@@ -738,8 +889,7 @@ mod tests {
             .output()
             .await?;
 
-        let (tx, _rx) = mpsc::channel(1);
-        let (agent, _) = FetchAgent::new(repo_path.clone(), tx, None);
+        let agent = test_worker(repo_path.clone()).await;
 
         let output = Command::new("git")
             .current_dir(&repo_path)
@@ -768,41 +918,80 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_commit_hash_from_placeholder() {
-        assert_eq!(
-            commit_hash_from_placeholder("abc123@sashiko.local"),
-            "abc123"
-        );
-        assert_eq!(
-            commit_hash_from_placeholder("mr-42-base..head"),
-            "base..head"
-        );
-        assert_eq!(commit_hash_from_placeholder("plainsha"), "plainsha");
-    }
+    #[tokio::test]
+    async fn test_ensure_present_checks_supporting_commits() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let repo_path = temp_dir.path().to_path_buf();
 
-    #[test]
-    fn test_backoff_secs_is_exponential_and_capped() {
-        assert_eq!(backoff_secs(1), 30);
-        assert_eq!(backoff_secs(2), 60);
-        assert_eq!(backoff_secs(3), 120);
-        assert_eq!(backoff_secs(4), 240);
-        assert_eq!(backoff_secs(5), 480);
-        assert_eq!(backoff_secs(6), 600);
-        assert_eq!(backoff_secs(100), 600);
-    }
+        Command::new("git")
+            .current_dir(&repo_path)
+            .arg("init")
+            .output()
+            .await?;
+        Command::new("git")
+            .current_dir(&repo_path)
+            .args(["config", "user.name", "Test User"])
+            .output()
+            .await?;
+        Command::new("git")
+            .current_dir(&repo_path)
+            .args(["config", "user.email", "test@example.com"])
+            .output()
+            .await?;
 
-    #[test]
-    fn test_looks_like_object_id() {
-        assert!(looks_like_object_id(&"a".repeat(40)));
-        assert!(looks_like_object_id(&"0".repeat(64)));
-        assert!(looks_like_object_id(
-            "8a21aa5149b3f34f48a277d596d1ffe512b32a41"
-        ));
-        assert!(!looks_like_object_id("main"));
-        assert!(!looks_like_object_id("v6.10"));
-        assert!(!looks_like_object_id("refs/heads/main"));
-        assert!(!looks_like_object_id(&"a".repeat(39)));
-        assert!(!looks_like_object_id("zzzz"));
+        let file_path = repo_path.join("file.txt");
+        let mut file = File::create(&file_path)?;
+        writeln!(file, "content")?;
+        Command::new("git")
+            .current_dir(&repo_path)
+            .args(["add", "."])
+            .output()
+            .await?;
+        Command::new("git")
+            .current_dir(&repo_path)
+            .args(["commit", "-m", "Commit 1"])
+            .output()
+            .await?;
+
+        let output = Command::new("git")
+            .current_dir(&repo_path)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .await?;
+        let commit1 = String::from_utf8(output.stdout)?.trim().to_string();
+
+        let agent = test_worker(repo_path.clone()).await;
+
+        let row = FetchQueueRow {
+            id: 1,
+            patchset_id: None,
+            cover_letter_message_id: None,
+            repo_url: None,
+            commit_hash: commit1.clone(),
+            mr_url: None,
+            mr_title: None,
+            mr_number: None,
+            status: crate::db::FetchStatus::Pending,
+            attempts: 0,
+            first_attempt_at: None,
+            next_retry_at: None,
+            locked_at: None,
+            last_error: None,
+            priority: 500,
+            created_at: 0,
+            supporting_commits: vec!["missing_sha_1234567890".to_string()],
+        };
+
+        // ensure_present must fail because supporting_commits contains a missing SHA
+        assert!(agent.ensure_present(&row).await.is_err());
+
+        // When supporting_commits is present locally, ensure_present must succeed
+        let row_valid = FetchQueueRow {
+            supporting_commits: vec![commit1.clone()],
+            ..row
+        };
+        assert!(agent.ensure_present(&row_valid).await.is_ok());
+
+        Ok(())
     }
 }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -551,6 +551,77 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
+    // --- Standalone helpers for the durable fetch worker ---
+
+    /// First retry delay; subsequent delays double up to BACKOFF_CAP_SECS.
+    const BACKOFF_BASE_SECS: i64 = 30;
+    /// Maximum delay between retries.
+    const BACKOFF_CAP_SECS: i64 = 600;
+
+    /// Marker error for failures that can never succeed on retry (e.g. a commit
+    /// is missing and the row has no remote to fetch from). These bypass the
+    /// backoff retry window and fail the fetch immediately, mirroring the
+    /// fast-fail behaviour of the old in-memory FetchAgent.
+    #[derive(Debug)]
+    struct PermanentFetchError(String);
+
+    impl std::fmt::Display for PermanentFetchError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for PermanentFetchError {}
+
+    /// Derive the git commit or range to fetch from a placeholder message id.
+    ///
+    /// Handles the two placeholder id shapes produced by the API:
+    ///   - git-fetch:  "<sha>@sashiko.local"        -> "<sha>"
+    ///   - PR/MR:      "mr-<number>-<base>..<head>"  -> "<base>..<head>"
+    pub fn commit_hash_from_placeholder(msgid: &str) -> String {
+        // "mr-<number>-<rest>" -> "<rest>"; anything else passes through.
+        let s = msgid
+            .strip_prefix("mr-")
+            .and_then(|rest| rest.find('-').map(|dash| &rest[dash + 1..]))
+            .unwrap_or(msgid);
+        // Strip any "@sashiko.local" suffix from git-fetch placeholder ids.
+        s.split('@').next().unwrap_or(s).to_string()
+    }
+
+    /// Current unix time in seconds.
+    fn now_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    /// Exponential backoff (in seconds) for a given attempt count. `attempts` is the
+    /// number of attempts already made (>= 1 after the first claim): 1 -> 30s,
+    /// 2 -> 60s, 3 -> 120s, ... capped at BACKOFF_CAP_SECS.
+    fn backoff_secs(attempts: i64) -> i64 {
+        let exp = attempts.saturating_sub(1).clamp(0, 20) as u32;
+        BACKOFF_BASE_SECS
+            .saturating_mul(2_i64.saturating_pow(exp))
+            .min(BACKOFF_CAP_SECS)
+    }
+
+    /// Whether a revision string is a full git object id (sha1 = 40 hex chars, or
+    /// sha256 = 64). Only full object ids can be requested directly via `want`
+    /// without a ref lookup; branch/tag names must be resolved by the server.
+    fn looks_like_object_id(rev: &str) -> bool {
+        matches!(rev.len(), 40 | 64) && rev.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+
+    /// Durable, restart-safe git fetch worker.
+    ///
+    /// Replaces the previous in-memory `FetchAgent` channel. Fetch requests live in
+    /// the `fetch_queue` table; this worker claims them under a lease, performs the
+    /// git fetch and patch extraction, and either completes them, schedules a
+    /// backoff retry, or (after RETRY_WINDOW_SECS) fails them terminally. Because
+    /// all state lives in the database, requests survive restarts and crashed
+    /// workers are recovered by the ghost sweep.
+
     #[tokio::test]
     async fn test_fetch_agent_lifecycle() {
         let (tx, _rx) = mpsc::channel(1);
@@ -695,5 +766,43 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_commit_hash_from_placeholder() {
+        assert_eq!(
+            commit_hash_from_placeholder("abc123@sashiko.local"),
+            "abc123"
+        );
+        assert_eq!(
+            commit_hash_from_placeholder("mr-42-base..head"),
+            "base..head"
+        );
+        assert_eq!(commit_hash_from_placeholder("plainsha"), "plainsha");
+    }
+
+    #[test]
+    fn test_backoff_secs_is_exponential_and_capped() {
+        assert_eq!(backoff_secs(1), 30);
+        assert_eq!(backoff_secs(2), 60);
+        assert_eq!(backoff_secs(3), 120);
+        assert_eq!(backoff_secs(4), 240);
+        assert_eq!(backoff_secs(5), 480);
+        assert_eq!(backoff_secs(6), 600);
+        assert_eq!(backoff_secs(100), 600);
+    }
+
+    #[test]
+    fn test_looks_like_object_id() {
+        assert!(looks_like_object_id(&"a".repeat(40)));
+        assert!(looks_like_object_id(&"0".repeat(64)));
+        assert!(looks_like_object_id(
+            "8a21aa5149b3f34f48a277d596d1ffe512b32a41"
+        ));
+        assert!(!looks_like_object_id("main"));
+        assert!(!looks_like_object_id("v6.10"));
+        assert!(!looks_like_object_id("refs/heads/main"));
+        assert!(!looks_like_object_id(&"a".repeat(39)));
+        assert!(!looks_like_object_id("zzzz"));
     }
 }

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -487,7 +487,7 @@ impl Drop for GitWorktree {
     }
 }
 
-fn get_remote_lock(name: &str) -> Arc<AsyncMutex<()>> {
+pub fn get_remote_lock(name: &str) -> Arc<AsyncMutex<()>> {
     static LOCKS: OnceLock<Mutex<HashMap<String, Arc<AsyncMutex<()>>>>> = OnceLock::new();
     let map_mutex = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
     let mut map = map_mutex.lock().unwrap();
@@ -496,7 +496,7 @@ fn get_remote_lock(name: &str) -> Arc<AsyncMutex<()>> {
         .clone()
 }
 
-fn get_global_config_lock() -> Arc<AsyncMutex<()>> {
+pub fn get_global_config_lock() -> Arc<AsyncMutex<()>> {
     static GLOBAL_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
     GLOBAL_LOCK
         .get_or_init(|| Arc::new(AsyncMutex::new(())))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod local_review;
 pub mod nntp;
 pub mod patch;
 pub mod patchwork;
+pub mod pipelines;
 pub mod prompt_bundle;
 pub mod reviewer;
 pub mod settings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod patch;
 pub mod patchwork;
 pub mod pipelines;
 pub mod prompt_bundle;
+pub mod review_kind;
 pub mod reviewer;
 pub mod settings;
 pub mod toolbox;

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -14,6 +14,7 @@
 
 use crate::{
     git_ops::{GitWorktree, extract_patch_metadata, get_commit_hash, resolve_git_range},
+    review_kind::ReviewKind,
     settings::{AiSettings, Settings},
     toolbox::ToolBox,
     worker::{
@@ -47,6 +48,8 @@ pub struct WorkerOptions {
     pub stages: Option<Vec<u8>>,
     pub scratch_clone: bool,
     pub current_tree: bool,
+    /// Alternate review pipeline selector. `None` = default patch review.
+    pub review_context: Option<ReviewKind>,
 }
 
 impl Default for WorkerOptions {
@@ -66,6 +69,7 @@ impl Default for WorkerOptions {
             stages: None,
             scratch_clone: false,
             current_tree: false,
+            review_context: None,
         }
     }
 }
@@ -486,21 +490,6 @@ async fn review_single_patch(
             baseline_sha,
         );
 
-        let mut worker = Worker::new(
-            provider,
-            std::sync::Arc::new(tools),
-            prompts,
-            WorkerConfig {
-                max_input_tokens: ai.max_input_tokens,
-                max_interactions: ai.max_interactions,
-                temperature: ai.temperature,
-                custom_prompt: options.custom_prompt.clone(),
-                series_range,
-                baseline_sha: Some(baseline_sha.to_string()),
-                stages: options.stages.clone(),
-            },
-        );
-
         let p_index = p.index;
         let progress_cb = progress.map(|cb| {
             move |event| match event {
@@ -555,15 +544,52 @@ async fn review_single_patch(
             "baseline": baseline_sha
         });
 
-        match worker
-            .run(
-                patchset_val,
-                progress_cb
-                    .as_ref()
-                    .map(|f| f as &(dyn Fn(_) + Send + Sync)),
-            )
-            .await
-        {
+        let progress_dyn = progress_cb
+            .as_ref()
+            .map(|f| f as &(dyn Fn(crate::worker::WorkerProgressEvent) + Send + Sync));
+        let run_result = if let Some(review_kind) = &options.review_context {
+            // Alternate review pipeline (e.g. cherry-pick / conflict resolution).
+            let env = crate::pipelines::PipelineEnv {
+                provider,
+                tools: std::sync::Arc::new(tools),
+                prompts: &prompts,
+                temperature: ai.temperature,
+                max_interactions: ai.max_interactions,
+                context_tag: Some(format!("[ps:{} p:{}] ", patchset_id, p.index)),
+                stages: None,
+                series_range: None,
+            };
+            match review_kind {
+                ReviewKind::CherryPick { .. } => {
+                    let resolution_sha = patch_shas.get(&p.index).cloned().unwrap_or_default();
+                    let pipeline =
+                        crate::pipelines::cherry_pick_review::CherryPickReviewPipeline::from_review_kind(
+                            review_kind,
+                            resolution_sha,
+                        );
+                    crate::pipelines::execute_pipeline(&pipeline, &env, patchset_val, progress_dyn)
+                        .await
+                }
+            }
+        } else {
+            let mut worker = Worker::new(
+                provider,
+                std::sync::Arc::new(tools),
+                prompts,
+                WorkerConfig {
+                    max_input_tokens: ai.max_input_tokens,
+                    max_interactions: ai.max_interactions,
+                    temperature: ai.temperature,
+                    custom_prompt: options.custom_prompt.clone(),
+                    series_range,
+                    baseline_sha: Some(baseline_sha.to_string()),
+                    stages: options.stages.clone(),
+                },
+            );
+            worker.run(patchset_val, progress_dyn).await
+        };
+
+        match run_result {
             Ok(result) => {
                 info!("AI review completed for patch {}.", p.index);
                 emit(

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         baseline,
                         skip_subjects,
                         only_subjects,
+                        submitted_at,
                     } => {
                         let messages = sashiko::ingestor::split_mbox(raw.as_bytes());
                         let count = messages.len();
@@ -591,7 +592,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             group: effective_group,
                                             article_id: submission_id.clone(),
                                             source,
-                                            metadata: Some(metadata),
+                                            metadata: {
+                                                let mut m = metadata;
+                                                if submitted_at.is_some() {
+                                                    m.received_date = submitted_at;
+                                                }
+                                                Some(m)
+                                            },
                                             patch: patch_opt,
                                             baseline: baseline_clone,
                                             failed_error: None,
@@ -1993,7 +2000,10 @@ async fn process_parsed_article(
                 metadata.message_id.as_str(),
                 &subject,
                 &author,
-                metadata.date,
+                // Use server-side timestamp (received_date) when available,
+                // falling back to the email's Date: header. This prevents
+                // stale mbox timestamps from skewing queue ordering.
+                metadata.received_date.unwrap_or(metadata.date),
                 total_parts,
                 PARSER_VERSION,
                 &metadata.to,

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     stages: stages.clone(),
                     scratch_clone: false,
                     current_tree: false,
+                    review_context: None,
                 })
                 .await
                 .unwrap_or_else(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         settings.review.stages = Some(stages.clone());
         info!("Selected stages via --stages flag: {:?}", stages);
     }
-
+    let mut compiled_rules = Vec::new();
+    for rule in &settings.review.priority_rules {
+        match rule.compile() {
+            Ok(r) => compiled_rules.push(r),
+            Err(e) => {
+                error!(
+                    "Invalid priority rule regex '{}': {}. Skipping rule.",
+                    rule.regex, e
+                );
+            }
+        }
+    }
+    let compiled_rules = Arc::new(compiled_rules);
     // Initialize Database
     let db = Arc::new(Database::new(&settings.database).await?);
     db.migrate().await?;
@@ -688,6 +700,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // DB Worker (Transactional Batching)
     let worker_db = db.clone();
     let mapping = settings.subsystems.mapping.clone();
+    let db_rules = compiled_rules.clone();
     let _db_worker_handle = tokio::spawn(async move {
         info!("DB Worker started");
 
@@ -706,7 +719,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             for article in buffer.drain(..) {
-                match process_parsed_article(&worker_db, article, &policy, &mapping).await {
+                match process_parsed_article(&worker_db, article, &policy, &mapping, &db_rules)
+                    .await
+                {
                     ProcessStatus::Ingested => total_ingested += 1,
                     ProcessStatus::Error => total_errors += 1,
                 }
@@ -1659,6 +1674,7 @@ async fn process_parsed_article(
     article: ParsedArticle,
     policy: &sashiko::email_policy::EmailPolicyConfig,
     subsystem_mapping: &[sashiko::settings::SubsystemMapping],
+    priority_rules: &[sashiko::settings::CompiledPriorityRule],
 ) -> ProcessStatus {
     let ParsedArticle {
         group,
@@ -1993,8 +2009,10 @@ async fn process_parsed_article(
             None
         };
 
+        let priority = sashiko::db::Database::calculate_priority(&subject, priority_rules);
+
         match worker_db
-            .create_patchset(
+            .create_patchset_with_priority(
                 thread_id,
                 cover_letter_id,
                 metadata.message_id.as_str(),
@@ -2014,6 +2032,7 @@ async fn process_parsed_article(
                 strict_author,
                 skip_filters.as_ref(),
                 only_filters.as_ref(),
+                priority,
             )
             .await
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,17 +391,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (raw_tx, mut raw_rx) = mpsc::channel::<Event>(1000);
     let (parsed_tx, mut parsed_rx) = mpsc::channel::<ParsedArticle>(1000);
 
-    // Initialize FetchAgent
+    // Initialize the durable FetchWorker (DB-backed queue).
     let repo_path = std::path::PathBuf::from(&settings.git.repository_path);
-    let (fetch_agent, fetch_tx) = sashiko::fetcher::FetchAgent::new(
+    let fetch_worker = sashiko::fetcher::FetchWorker::new(
         repo_path,
+        db.clone(),
         raw_tx.clone(),
         settings.forge.api_token.clone(),
     );
 
-    // Spawn FetchAgent
+    // Recover fetches orphaned before the durable queue existed or by a crash:
+    // re-enqueue any patchset stuck in 'Fetching' with no active queue row.
+    match db.get_stuck_fetch_placeholders().await {
+        Ok(stuck) => {
+            if !stuck.is_empty() {
+                info!(
+                    "Backfilling {} orphaned fetch(es) into fetch_queue",
+                    stuck.len()
+                );
+            }
+            for p in stuck {
+                let Some(cover) = p.cover_letter_message_id.as_deref() else {
+                    continue;
+                };
+                let commit = sashiko::fetcher::commit_hash_from_placeholder(cover);
+                if let Err(e) = db
+                    .enqueue_fetch(
+                        Some(p.patchset_id),
+                        Some(cover),
+                        p.repo_url.as_deref(),
+                        &commit,
+                        p.mr_url.as_deref(),
+                        p.mr_title.as_deref(),
+                        p.mr_number,
+                        p.priority as i32,
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to backfill fetch for patchset {}: {}",
+                        p.patchset_id, e
+                    );
+                }
+            }
+        }
+        Err(e) => error!("Failed to query stuck fetch placeholders: {}", e),
+    }
+
+    // Spawn the FetchWorker.
     tokio::spawn(async move {
-        fetch_agent.run().await;
+        fetch_worker.run().await;
     });
 
     // Parser Dispatcher
@@ -784,7 +823,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_settings = Arc::new(settings.clone());
     let api_db = db.clone();
     let api_tx = raw_tx.clone();
-    let api_fetch_tx = fetch_tx.clone();
     let allow_all_submit = cli.enable_unsafe_all_submit;
     let smtp_enabled = settings.smtp.is_some();
     let dry_run = settings.smtp.as_ref().map(|s| s.dry_run).unwrap_or(false);
@@ -793,7 +831,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             api_settings,
             api_db,
             api_tx,
-            api_fetch_tx,
             allow_all_submit,
             smtp_enabled,
             dry_run,

--- a/src/pipelines/cherry_pick_review/mod.rs
+++ b/src/pipelines/cherry_pick_review/mod.rs
@@ -21,6 +21,11 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod pipeline;
+pub mod synthesis;
+
+pub use pipeline::CherryPickReviewPipeline;
+
 /// Stage 1 (analysis): semantic-intent preservation of the resolution.
 pub const SEMANTIC_INTENT: &str = include_str!("prompts/semantic_intent.md");
 /// Stage 2 (analysis): detection of changes dropped during resolution.
@@ -66,14 +71,16 @@ pub struct CherryPickContext {
     pub original_diff: Option<String>,
 }
 
-/// Filter raw cherry-pick findings down to the ones worth surfacing.
+/// Filter cherry-pick findings: keep only high/critical
+/// resolution-introduced findings for the inline review.
 ///
-/// Rules (by `severity` and `origin`):
-/// - DROP all `low` severity.
-/// - DROP everything `base_preexisting` (already in the target branch).
-/// - DROP `original_patch_preexisting` unless `critical`.
-/// - KEEP `resolution_introduced` at medium+ severity.
+/// Rules (V1 parity with `filter_conflict_findings`):
+/// - KEEP only `origin == "resolution_introduced"` AND
+///   `severity in ["high", "critical"]`.
+/// - DROP everything else regardless of origin or severity.
 ///
+/// Missing `severity` defaults to `"low"` (dropped).
+/// Missing `origin` defaults to `"resolution_introduced"` (kept if sev ok).
 /// Non-array input yields an empty array.
 pub fn filter_cherry_pick_findings(findings: &serde_json::Value) -> serde_json::Value {
     let arr = match findings.as_array() {
@@ -95,35 +102,17 @@ pub fn filter_cherry_pick_findings(findings: &serde_json::Value) -> serde_json::
                 .unwrap_or("resolution_introduced")
                 .to_lowercase();
 
-            // Drop all low severity.
-            if severity == "low" {
+            let keep =
+                origin == "resolution_introduced" && (severity == "high" || severity == "critical");
+            if !keep {
                 tracing::info!(
-                    "Filtering out low-severity finding: {}",
-                    f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
-                );
-                return false;
-            }
-
-            // Drop all findings pre-existing in the target base branch.
-            if origin == "base_preexisting" {
-                tracing::info!(
-                    "Filtering out base-preexisting finding: {}",
-                    f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
-                );
-                return false;
-            }
-
-            // Drop findings pre-existing in the original patch unless critical.
-            if origin == "original_patch_preexisting" && severity != "critical" {
-                tracing::info!(
-                    "Filtering out original-patch-preexisting ({}) finding: {}",
+                    "Filtering out non-actionable finding (origin={}, severity={}): {}",
+                    origin,
                     severity,
                     f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
                 );
-                return false;
             }
-
-            true
+            keep
         })
         .cloned()
         .collect();
@@ -145,17 +134,18 @@ mod tests {
     }
 
     #[test]
-    fn keeps_resolution_introduced_medium_plus() {
+    fn keeps_resolution_introduced_high_critical() {
         let findings = json!([
-            {"description": "keep-me", "severity": "high", "origin": "resolution_introduced"},
-            {"description": "keep-me-2", "severity": "medium", "origin": "resolution_introduced"},
+            {"description": "keep-high", "severity": "high", "origin": "resolution_introduced"},
+            {"description": "keep-crit", "severity": "critical", "origin": "resolution_introduced"},
+            {"description": "drop-med", "severity": "medium", "origin": "resolution_introduced"},
         ]);
         let out = filter_cherry_pick_findings(&findings);
-        assert_eq!(descriptions(&out), vec!["keep-me", "keep-me-2"]);
+        assert_eq!(descriptions(&out), vec!["keep-high", "keep-crit"]);
     }
 
     #[test]
-    fn drops_low_severity_regardless_of_origin() {
+    fn drops_low_severity() {
         let findings = json!([
             {"description": "low", "severity": "low", "origin": "resolution_introduced"},
         ]);
@@ -183,14 +173,18 @@ mod tests {
     }
 
     #[test]
-    fn drops_original_preexisting_unless_critical() {
+    fn drops_original_preexisting_even_when_critical() {
         let findings = json!([
             {"description": "orig-high", "severity": "high", "origin": "original_patch_preexisting"},
             {"description": "orig-crit", "severity": "critical", "origin": "original_patch_preexisting"},
         ]);
+        // V1 parity: only resolution_introduced kept
         assert_eq!(
-            descriptions(&filter_cherry_pick_findings(&findings)),
-            vec!["orig-crit"]
+            filter_cherry_pick_findings(&findings)
+                .as_array()
+                .unwrap()
+                .len(),
+            0
         );
     }
 

--- a/src/pipelines/cherry_pick_review/mod.rs
+++ b/src/pipelines/cherry_pick_review/mod.rs
@@ -1,0 +1,213 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cherry-pick review: context type and finding filter.
+//!
+//! Ported from the original merge-conflict-resolution hack (`d95dac6`), adapted
+//! to the principled pipeline framework. The persisted dispatch payload lives in
+//! `crate::review_kind::ReviewKind::CherryPick`; this module holds the richer
+//! runtime context hydrated from git during the pipeline's `build_context`.
+
+use serde::{Deserialize, Serialize};
+
+/// Hydrated context for a cherry-pick / merge-conflict resolution review.
+///
+/// Semantics of the three commits involved:
+/// - `original_*`: the upstream patch being ported.
+/// - `base_*`: the target branch HEAD the patch was applied ONTO. Bugs already
+///   present here are NOT resolution-introduced.
+/// - `resolution_*`: what the automated agent produced. Only defects introduced
+///   here by the merge/resolution itself are in scope.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct CherryPickContext {
+    /// SHA of the automated resolution commit under review.
+    pub resolution_sha: String,
+    /// SHA of the original upstream patch being ported.
+    pub original_sha: String,
+    /// SHA of the target base the patch was applied onto.
+    pub base_sha: String,
+    /// Subject line of the resolution commit.
+    #[serde(default)]
+    pub resolution_subject: Option<String>,
+    /// Subject line of the original patch.
+    #[serde(default)]
+    pub original_subject: Option<String>,
+    /// Subject line of the base commit.
+    #[serde(default)]
+    pub base_subject: Option<String>,
+    /// Full `git show`/diff of the original patch, for direct comparison against
+    /// the resolution diff.
+    #[serde(default)]
+    pub original_diff: Option<String>,
+}
+
+/// Filter raw cherry-pick findings down to the ones worth surfacing.
+///
+/// Rules (by `severity` and `origin`):
+/// - DROP all `low` severity.
+/// - DROP everything `base_preexisting` (already in the target branch).
+/// - DROP `original_patch_preexisting` unless `critical`.
+/// - KEEP `resolution_introduced` at medium+ severity.
+///
+/// Non-array input yields an empty array.
+pub fn filter_cherry_pick_findings(findings: &serde_json::Value) -> serde_json::Value {
+    let arr = match findings.as_array() {
+        Some(a) => a,
+        None => return serde_json::json!([]),
+    };
+
+    let filtered: Vec<serde_json::Value> = arr
+        .iter()
+        .filter(|f| {
+            let severity = f
+                .get("severity")
+                .and_then(|v| v.as_str())
+                .unwrap_or("low")
+                .to_lowercase();
+            let origin = f
+                .get("origin")
+                .and_then(|v| v.as_str())
+                .unwrap_or("resolution_introduced")
+                .to_lowercase();
+
+            // Drop all low severity.
+            if severity == "low" {
+                tracing::info!(
+                    "Filtering out low-severity finding: {}",
+                    f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
+                );
+                return false;
+            }
+
+            // Drop all findings pre-existing in the target base branch.
+            if origin == "base_preexisting" {
+                tracing::info!(
+                    "Filtering out base-preexisting finding: {}",
+                    f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
+                );
+                return false;
+            }
+
+            // Drop findings pre-existing in the original patch unless critical.
+            if origin == "original_patch_preexisting" && severity != "critical" {
+                tracing::info!(
+                    "Filtering out original-patch-preexisting ({}) finding: {}",
+                    severity,
+                    f.get("description").and_then(|v| v.as_str()).unwrap_or("?")
+                );
+                return false;
+            }
+
+            true
+        })
+        .cloned()
+        .collect();
+
+    serde_json::json!(filtered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn descriptions(v: &serde_json::Value) -> Vec<String> {
+        v.as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["description"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn keeps_resolution_introduced_medium_plus() {
+        let findings = json!([
+            {"description": "keep-me", "severity": "high", "origin": "resolution_introduced"},
+            {"description": "keep-me-2", "severity": "medium", "origin": "resolution_introduced"},
+        ]);
+        let out = filter_cherry_pick_findings(&findings);
+        assert_eq!(descriptions(&out), vec!["keep-me", "keep-me-2"]);
+    }
+
+    #[test]
+    fn drops_low_severity_regardless_of_origin() {
+        let findings = json!([
+            {"description": "low", "severity": "low", "origin": "resolution_introduced"},
+        ]);
+        assert_eq!(
+            filter_cherry_pick_findings(&findings)
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn drops_base_preexisting_even_when_critical() {
+        let findings = json!([
+            {"description": "base", "severity": "critical", "origin": "base_preexisting"},
+        ]);
+        assert_eq!(
+            filter_cherry_pick_findings(&findings)
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn drops_original_preexisting_unless_critical() {
+        let findings = json!([
+            {"description": "orig-high", "severity": "high", "origin": "original_patch_preexisting"},
+            {"description": "orig-crit", "severity": "critical", "origin": "original_patch_preexisting"},
+        ]);
+        assert_eq!(
+            descriptions(&filter_cherry_pick_findings(&findings)),
+            vec!["orig-crit"]
+        );
+    }
+
+    #[test]
+    fn defaults_missing_origin_to_resolution_introduced() {
+        let findings = json!([
+            {"description": "no-origin", "severity": "high"},
+        ]);
+        assert_eq!(
+            descriptions(&filter_cherry_pick_findings(&findings)),
+            vec!["no-origin"]
+        );
+    }
+
+    #[test]
+    fn non_array_yields_empty() {
+        assert_eq!(filter_cherry_pick_findings(&json!({"x": 1})), json!([]));
+    }
+
+    #[test]
+    fn context_round_trips_through_json() {
+        let ctx = CherryPickContext {
+            resolution_sha: "r".into(),
+            original_sha: "o".into(),
+            base_sha: "b".into(),
+            resolution_subject: Some("rs".into()),
+            original_subject: None,
+            base_subject: None,
+            original_diff: None,
+        };
+        let s = serde_json::to_string(&ctx).unwrap();
+        assert_eq!(serde_json::from_str::<CherryPickContext>(&s).unwrap(), ctx);
+    }
+}

--- a/src/pipelines/cherry_pick_review/mod.rs
+++ b/src/pipelines/cherry_pick_review/mod.rs
@@ -21,6 +21,20 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Stage 1 (analysis): semantic-intent preservation of the resolution.
+pub const SEMANTIC_INTENT: &str = include_str!("prompts/semantic_intent.md");
+/// Stage 2 (analysis): detection of changes dropped during resolution.
+pub const DROPPED_CHANGES: &str = include_str!("prompts/dropped_changes.md");
+/// Stage 3 (analysis): structural merge-correctness verification.
+pub const MERGE_CORRECTNESS: &str = include_str!("prompts/merge_correctness.md");
+/// Origin classification: label each finding resolution_introduced /
+/// original_patch_preexisting / base_preexisting before filtering.
+pub const ORIGIN_CLASSIFICATION: &str = include_str!("prompts/origin_classification.md");
+/// Stage 10 (synthesis): verification and severity estimation.
+pub const VERIFICATION: &str = include_str!("prompts/verification.md");
+/// Stage 12 (synthesis): final cherry-pick review report.
+pub const CONFLICT_REPORT: &str = include_str!("prompts/conflict_report.md");
+
 /// Hydrated context for a cherry-pick / merge-conflict resolution review.
 ///
 /// Semantics of the three commits involved:

--- a/src/pipelines/cherry_pick_review/pipeline.rs
+++ b/src/pipelines/cherry_pick_review/pipeline.rs
@@ -1,0 +1,488 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The cherry-pick (merge-conflict resolution) review pipeline.
+//!
+//! Expresses the original hack (commit 66fb0a5) as a principled [`Pipeline`]:
+//! cherry-specific analysis stages 1-3 + shared analysis 4-7, then the shared
+//! synthesis tail (dedup 8, resolution 9, verification 10), an origin
+//! classification stage (11), a cherry-specific finding filter, and a final
+//! conflict report (12). The three-commit context is hydrated from git at
+//! review time; the database only stores the minimal `ReviewKind::CherryPick`.
+
+use anyhow::Result;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::pipelines::{
+    Capture, Cx, Pipeline, PipelineContext, PipelineState, StagePrompt, StageSpec,
+};
+use crate::review_kind::ReviewKind;
+
+use super::synthesis::{self, ANALYSIS_FORMAT_GUIDANCE};
+use super::{
+    CONFLICT_REPORT, DROPPED_CHANGES, MERGE_CORRECTNESS, ORIGIN_CLASSIFICATION, SEMANTIC_INTENT,
+    VERIFICATION, filter_cherry_pick_findings,
+};
+
+/// A cherry-pick / merge-conflict resolution review pipeline.
+pub struct CherryPickReviewPipeline {
+    /// SHA of the original patch being ported (commit 1).
+    pub original_sha: String,
+    /// SHA of the target base branch the patch was applied onto (commit 2).
+    pub base_sha: Option<String>,
+    /// SHA of the resolution commit under review (commit 3).
+    pub resolution_sha: String,
+}
+
+impl CherryPickReviewPipeline {
+    /// Build the pipeline from the persisted review context and resolution SHA.
+    pub fn from_review_kind(kind: &ReviewKind, resolution_sha: String) -> Self {
+        let ReviewKind::CherryPick {
+            original_sha,
+            base_sha,
+        } = kind;
+        Self {
+            original_sha: original_sha.clone(),
+            base_sha: base_sha.clone(),
+            resolution_sha,
+        }
+    }
+}
+
+fn override_stage(number: u8, text: &str, capture: Capture) -> StageSpec {
+    StageSpec::new(
+        number,
+        StagePrompt::Override {
+            content: text.to_string(),
+            clean: text.to_string(),
+        },
+        capture,
+    )
+}
+
+#[async_trait::async_trait]
+impl Pipeline for CherryPickReviewPipeline {
+    fn name(&self) -> &'static str {
+        "cherry-pick"
+    }
+
+    async fn run(&self, cx: &mut Cx<'_>) -> Result<()> {
+        // Assemble the shared system context (git hydration + dynamic context).
+        let ctx = self.build_shared_context(cx).await?;
+
+        // The Planning phase decides which of stages 4-7 to include. It reuses
+        // the exact system context the stages will see.
+        let selected = plan_stages(
+            cx.env.provider.as_ref(),
+            cx.env.stages.clone(),
+            &ctx.system_with_log,
+        )
+        .await;
+        cx.set_context(ctx);
+
+        run_analysis(cx, &selected).await?;
+        if cx.state.concerns.is_empty() {
+            return Ok(());
+        }
+        run_synthesis(cx).await
+    }
+}
+
+impl CherryPickReviewPipeline {
+    /// Hydrate the three-commit context from git and assemble the shared system
+    /// context (with/without review log, plus the clean/templated variants used
+    /// for logging).
+    async fn build_shared_context(&self, cx: &Cx<'_>) -> Result<PipelineContext> {
+        let env = cx.env;
+
+        let (static_context, clean_static_context) = env.prompts.build_context(None).await?;
+        let worktree = env.tools.get_worktree_path();
+
+        // Hydrate the three-commit context from git at review time.
+        let original_subject = git_subject(worktree, &self.original_sha).await;
+        let base_subject = match self.base_sha.as_deref() {
+            Some(sha) => git_subject(worktree, sha).await,
+            None => None,
+        };
+        let resolution_subject = match cx.patchset.get("subject").and_then(|v| v.as_str()) {
+            Some(s) => Some(s.to_string()),
+            None => git_subject(worktree, &self.resolution_sha).await,
+        };
+        let original_diff = git_show(worktree, &self.original_sha).await;
+        let resolution_diff = extract_resolution_diff(&cx.patchset);
+
+        let git_metadata = build_git_metadata(
+            &self.original_sha,
+            self.base_sha.as_deref(),
+            &self.resolution_sha,
+            original_subject.as_deref(),
+            base_subject.as_deref(),
+            resolution_subject.as_deref(),
+            original_diff.as_deref(),
+        );
+
+        // Mirror Worker::run's dynamic-context assembly (with/without review log).
+        let mut dynamic = dynamic_base(&git_metadata, "\n\nTarget Commit:\n", &resolution_diff);
+        let mut dynamic_no_log =
+            dynamic_base(&git_metadata, "\n\nTarget Commit Diff:\n", &resolution_diff);
+        let mut clean_dynamic = dynamic.clone();
+        let mut clean_dynamic_no_log = dynamic_no_log.clone();
+
+        if let Ok(prefetched) =
+            crate::worker::prefetch::prefetch_context(worktree, &resolution_diff).await
+            && !prefetched.is_empty()
+        {
+            append_prefetch(&mut dynamic, &prefetched);
+            append_prefetch(&mut dynamic_no_log, &prefetched);
+            append_prefetch(&mut clean_dynamic, "{{prefetched_context}}");
+            append_prefetch(&mut clean_dynamic_no_log, "{{prefetched_context}}");
+        }
+
+        Ok(PipelineContext {
+            system_with_log: format!("{}{}", static_context, dynamic),
+            system_without_log: format!("{}{}", static_context, dynamic_no_log),
+            clean_with_log: format!("{}{}", clean_static_context, clean_dynamic),
+            clean_without_log: format!("{}{}", clean_static_context, clean_dynamic_no_log),
+        })
+    }
+}
+
+/// Analysis stage with an override prompt and the shared analysis format guidance.
+fn analysis_override(number: u8, text: &str) -> StageSpec {
+    override_stage(number, text, Capture::MergeConcerns)
+        .with_format_guidance(ANALYSIS_FORMAT_GUIDANCE)
+}
+
+/// Assemble the dynamic-context body: git metadata, a target header, and the
+/// resolution diff.
+fn dynamic_base(git_metadata: &str, target_header: &str, resolution_diff: &str) -> String {
+    let mut s = String::new();
+    s.push_str(git_metadata);
+    s.push_str(target_header);
+    s.push_str(resolution_diff);
+    s
+}
+
+/// Append the pre-fetched-context block. `body` is the real prefetched content,
+/// or the `{{prefetched_context}}` placeholder for the clean/templated variant.
+fn append_prefetch(s: &mut String, body: &str) {
+    const HDR: &str = include_str!("prompts/prefetched_context_header.md");
+    s.push_str(HDR);
+    s.push_str(body);
+    s.push_str("\n</pre_fetched_context>\n");
+}
+
+/// Build the Planning-phase AI request from the shared system context.
+fn planning_request(shared_ctx: &str) -> crate::ai::AiRequest {
+    let planning_prompt = include_str!("prompts/planning.md");
+    crate::ai::AiRequest {
+        system: None,
+        messages: vec![crate::ai::AiMessage {
+            role: crate::ai::AiRole::User,
+            content: Some(format!("{}\n\n{}", shared_ctx, planning_prompt)),
+            thought: None,
+            thought_signature: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }],
+        tools: None,
+        temperature: Some(0.0),
+        response_format: Some(crate::ai::AiResponseFormat::Json {
+            schema: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "relevant_stages": {
+                        "type": "array",
+                        "items": { "type": "integer" }
+                    }
+                },
+                "required": ["relevant_stages"]
+            })),
+        }),
+        context_tag: None,
+    }
+}
+
+/// Run the Planning phase (json_request with retry) to decide which of stages
+/// 4-7 to include. Skips when stages were set explicitly. Planning stays an
+/// UNLOGGED side request (not folded into history). Returns `None` to mean
+/// "run all stages".
+async fn plan_stages(
+    provider: &dyn crate::ai::AiProvider,
+    explicit: Option<Vec<u8>>,
+    shared_ctx: &str,
+) -> Option<Vec<u8>> {
+    if let Some(stages) = explicit {
+        return Some(stages);
+    }
+
+    let val = crate::pipelines::json_request(provider, planning_request(shared_ctx), |v| {
+        v.get("relevant_stages")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| "missing 'relevant_stages' array".to_string())
+            .map(|_| ())
+    })
+    .await;
+
+    if let Some(val) = val
+        && let Some(arr) = val["relevant_stages"].as_array()
+    {
+        let mut stages = vec![1u8, 2, 3];
+        for v in arr {
+            if let Some(n) = v.as_u64()
+                && (4..=7).contains(&n)
+            {
+                stages.push(n as u8);
+            }
+        }
+        tracing::info!("Planning phase selected stages: {:?}", stages);
+        Some(stages)
+    } else {
+        // If planning fails, run all stages.
+        None
+    }
+}
+
+/// Run the analysis stages: cherry-specific 1-3 plus any planning-selected 4-7,
+/// all in parallel.
+async fn run_analysis(cx: &mut Cx<'_>, selected: &Option<Vec<u8>>) -> Result<()> {
+    let include_stage = |n: u8| -> bool {
+        match selected {
+            Some(stages) => stages.contains(&n),
+            None => true,
+        }
+    };
+    let mut analysis = vec![
+        analysis_override(1, SEMANTIC_INTENT),
+        analysis_override(2, DROPPED_CHANGES),
+        analysis_override(3, MERGE_CORRECTNESS).with_guides(3),
+    ];
+    for n in 4..=7 {
+        if include_stage(n) {
+            analysis.push(
+                StageSpec::new(n, StagePrompt::Builtin, Capture::MergeConcerns)
+                    .with_format_guidance(ANALYSIS_FORMAT_GUIDANCE),
+            );
+        }
+    }
+    cx.parallel(analysis).await
+}
+
+/// Run the synthesis tail: dedup (8), resolution (9), verification (10), origin
+/// classification (10), the cherry-pick finding filter, and the final report
+/// (11). Each step short-circuits when nothing remains to act on.
+async fn run_synthesis(cx: &mut Cx<'_>) -> Result<()> {
+    // Stage 8: dedup.
+    cx.stage(
+        StageSpec::new(8, StagePrompt::Builtin, Capture::ReplaceConcerns)
+            .with_template(synthesis::stage8_builder()),
+    )
+    .await?;
+    if cx.state.concerns.is_empty() {
+        return Ok(());
+    }
+
+    // Stage 9: conflict resolution.
+    cx.stage(
+        StageSpec::new(9, StagePrompt::Builtin, Capture::ReplaceConcerns)
+            .with_template(synthesis::stage9_builder()),
+    )
+    .await?;
+    if cx.state.concerns.is_empty() {
+        return Ok(());
+    }
+
+    // Stage 10: verification.
+    cx.stage(
+        override_stage(10, VERIFICATION, Capture::Findings)
+            .with_template(synthesis::stage10_builder())
+            .with_guides(10),
+    )
+    .await?;
+    if findings_empty(&cx.state) {
+        return Ok(());
+    }
+
+    // Stage 10: origin classification.
+    cx.stage(
+        override_stage(10, ORIGIN_CLASSIFICATION, Capture::Findings)
+            .with_template(synthesis::origin_builder()),
+    )
+    .await?;
+
+    // Cherry-pick finding filter.
+    if let Some(f) = cx.state.findings.take() {
+        // Preserve the classified findings for DB output; the filter only
+        // controls Stage 11 and the early exit.
+        cx.state.classified_findings = Some(f.clone());
+        let filtered = filter_cherry_pick_findings(&f);
+        // Set a distinct review_inline when the filter drops all findings.
+        if filtered.as_array().is_none_or(|a| a.is_empty()) {
+            cx.state.review_inline =
+                Some("No issues found after conflict review filtering.".to_string());
+        }
+        cx.state.findings = Some(filtered);
+    }
+    if findings_empty(&cx.state) {
+        return Ok(());
+    }
+
+    // Stage 11: conflict report.
+    cx.stage(
+        override_stage(11, CONFLICT_REPORT, Capture::Inline)
+            .with_template(synthesis::stage11_builder())
+            .with_guides(11),
+    )
+    .await
+}
+
+/// True when there are no findings to act on.
+fn findings_empty(state: &PipelineState) -> bool {
+    state
+        .findings
+        .as_ref()
+        .and_then(|v| v.as_array())
+        .is_none_or(|a| a.is_empty())
+}
+
+fn extract_resolution_diff(patchset: &Value) -> String {
+    patchset
+        .get("patches")
+        .and_then(|p| p.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|p| p.get("diff").and_then(|d| d.as_str()))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+async fn git_output(worktree: &Path, args: &[&str]) -> Option<String> {
+    let output = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(args)
+        .output()
+        .await
+        .ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        None
+    }
+}
+
+async fn git_subject(worktree: &Path, sha: &str) -> Option<String> {
+    git_output(worktree, &["show", "-s", "--format=%s", sha])
+        .await
+        .map(|s| s.trim().to_string())
+}
+
+async fn git_show(worktree: &Path, sha: &str) -> Option<String> {
+    git_output(worktree, &["show", sha]).await
+}
+
+fn build_git_metadata(
+    original_sha: &str,
+    base_sha: Option<&str>,
+    resolution_sha: &str,
+    original_subject: Option<&str>,
+    base_subject: Option<&str>,
+    resolution_subject: Option<&str>,
+    original_diff: Option<&str>,
+) -> String {
+    let unknown = "(unknown)";
+    let orig_subj = original_subject.unwrap_or(unknown);
+    let base_subj = base_subject.unwrap_or(unknown);
+    let res_subj = resolution_subject.unwrap_or(unknown);
+    let base_sha = base_sha.unwrap_or(unknown);
+
+    let mut m = include_str!("prompts/merge_conflict_review_framing.md")
+        .replace("{{original_sha}}", original_sha)
+        .replace("{{original_subject}}", orig_subj)
+        .replace("{{base_sha}}", base_sha)
+        .replace("{{base_subject}}", base_subj)
+        .replace("{{resolution_sha}}", resolution_sha)
+        .replace("{{resolution_subject}}", res_subj);
+
+    if let Some(diff) = original_diff {
+        let diff = diff.trim();
+        if !diff.is_empty() {
+            m.push_str(
+                "\nFor direct comparison, the ORIGINAL PATCH (commit 1) diff follows. \
+                 Compare it against the resolution diff to spot dropped hunks, altered \
+                 logic, or merge artifacts:\n",
+            );
+            m.push_str("<original_patch_diff>\n");
+            m.push_str(diff);
+            m.push_str("\n</original_patch_diff>\n");
+        }
+    }
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipelines::PipelineState;
+    use crate::pipelines::cherry_pick_review::synthesis;
+
+    #[test]
+    fn git_metadata_contains_three_commits() {
+        let md = build_git_metadata(
+            "aaa111",
+            Some("bbb222"),
+            "ccc333",
+            Some("orig subject"),
+            Some("base subject"),
+            Some("res subject"),
+            Some("diff --git a/x b/x"),
+        );
+        assert!(md.contains("aaa111"));
+        assert!(md.contains("bbb222"));
+        assert!(md.contains("ccc333"));
+        assert!(md.contains("orig subject"));
+        assert!(md.contains("<original_patch_diff>"));
+        assert!(md.contains("MERGE-CONFLICT RESOLUTION REVIEW"));
+    }
+
+    #[test]
+    fn from_review_kind_extracts_shas() {
+        let kind = ReviewKind::CherryPick {
+            original_sha: "orig".to_string(),
+            base_sha: Some("base".to_string()),
+        };
+        let p = CherryPickReviewPipeline::from_review_kind(&kind, "res".to_string());
+        assert_eq!(p.original_sha, "orig");
+        assert_eq!(p.base_sha.as_deref(), Some("base"));
+        assert_eq!(p.resolution_sha, "res");
+    }
+
+    #[test]
+    fn stage8_builder_injects_state() {
+        let state = PipelineState {
+            concerns: vec![serde_json::json!({"type": "TestConcern"})],
+            ..Default::default()
+        };
+        let build = synthesis::stage8_builder();
+        let (user, clean) = build("# Stage 8 instruction", &state);
+        assert!(user.contains("# Stage 8 instruction"));
+        assert!(user.contains("Consolidated Concerns:"));
+        assert!(user.contains("TestConcern"));
+        assert_eq!(user, clean);
+    }
+}

--- a/src/pipelines/cherry_pick_review/prompts/analysis_format_guidance.md
+++ b/src/pipelines/cherry_pick_review/prompts/analysis_format_guidance.md
@@ -1,0 +1,56 @@
+TodoWrite compatibility: vendored prompts may ask you to add tasks or suspected bugs to TodoWrite. Do not call or mention TodoWrite. Treat those instructions as an internal checklist only. If that checklist identifies a concrete suspected bug, carry it forward as a JSON concern with file, function_or_symbol, line when known, triggering condition, and evidence. Do not output generic checklist progress as a concern.
+
+Once you have gathered sufficient information, return ONLY a JSON object with "concerns" and "dismissed_concerns" arrays.
+If you find no concerns and no dismissed concerns, return `{"concerns": [], "dismissed_concerns": []}`.
+If you find concerns, each must be an object with:
+- "type": A short category string.
+- "description": A clear description of the problem.
+- "reasoning": A step-by-step explanation.
+- "preexisting": A boolean value: `true` if this bug/vulnerability already existed in the codebase before these patches were applied, or `false` if the issue was newly introduced by the reviewed patchset.
+- "locations": An array of objects, each containing "file", "function_or_symbol", "line_range" (e.g., "120-125"), and "why_this_location_matters". Use `null` for "file", "function_or_symbol", or "line_range" when an issue is non-local or the exact value is not known. Do not invent line numbers; use `line_range: null` when the exact lines are not known and explain the triggering condition in "reasoning".
+
+Use the "dismissed_concerns" array ONLY for candidate concerns that you considered plausible, investigated, and disproved with concrete evidence. This is especially important when you first suspect a concern and then follow the evidence chain proving that it does NOT apply.
+If you find dismissed_concerns, each must use the same item schema as concerns except that dismissed_concerns do not need the "preexisting" field:
+- "type": A short category string.
+- "description": The candidate concern that was investigated and disproved.
+- "reasoning": A step-by-step explanation of the evidence proving the candidate concern does not apply.
+- "locations": An array of objects, each containing "file", "function_or_symbol", "line_range" (e.g., "145-150"), and "why_this_location_matters". Use `null` for unknown values. Do not invent line numbers.
+
+CRITICAL REVIEW DIRECTIVE: Do NOT dismiss concerns just because you assume the surrounding system or caller handles it perfectly. Do not be overly charitable to the existing code. If there is a missing initialization, an unhandled edge case, or a brittle logic flow, report it as a concern immediately. Assume the worst-case scenario where external inputs and caller states are malformed.
+
+Example:
+```json
+{
+  "concerns": [
+    {
+      "type": "Issue Category",
+      "description": "What is wrong.",
+      "reasoning": "Why it is wrong.",
+      "preexisting": false,
+      "locations": [
+        {
+          "file": "path/to/file.c",
+          "function_or_symbol": "function_name",
+          "line_range": "120-125",
+          "why_this_location_matters": "This is where the newly allocated resource is dropped on the error path."
+        }
+      ]
+    }
+  ],
+  "dismissed_concerns": [
+    {
+      "type": "Issue Category",
+      "description": "Possible missing cleanup when foo_init() fails after bar_alloc().",
+      "reasoning": "The concrete code path or ordering that proves this candidate concern does not apply.",
+      "locations": [
+        {
+          "file": "path/to/file.c",
+          "function_or_symbol": "function_name",
+          "line_range": "145-150",
+          "why_this_location_matters": "This is where the cleanup path proves the candidate leak does not apply."
+        }
+      ]
+    }
+  ]
+}
+```

--- a/src/pipelines/cherry_pick_review/prompts/conflict_report.md
+++ b/src/pipelines/cherry_pick_review/prompts/conflict_report.md
@@ -1,0 +1,12 @@
+# Stage 12. Conflict review report
+
+You are generating the final report from a merge-conflict resolution review.
+
+The findings you receive have already been verified, classified by severity, classified by origin, and filtered. Your job is to present them clearly.
+
+For each finding, produce a clear summary that includes:
+- What the issue is (specific code, specific function, specific file)
+- Why it matters (what breaks, what is lost, what is duplicated)
+- How it was likely introduced (which part of the merge resolution caused it)
+
+Return ONLY a JSON object with a findings array. Each finding must preserve all fields from the input.

--- a/src/pipelines/cherry_pick_review/prompts/dropped_changes.md
+++ b/src/pipelines/cherry_pick_review/prompts/dropped_changes.md
@@ -1,0 +1,11 @@
+# Stage 2. Dropped changes detection
+
+You are auditing a merge-conflict resolution for COMPLETENESS. This commit was created by an automated agent to resolve a conflict when applying a kernel patch to a branch that has diverged.
+
+Your task is to detect if any meaningful code changes were DROPPED or LOST during the conflict resolution:
+1. Compare the resolution diff against what the original patch intended to add, modify, or remove. Use tools to inspect the commit message and diff carefully.
+2. Check if any new functions, struct fields, enum variants, macro definitions, or includes from the original patch are MISSING in the resolved version.
+3. Check if any existing downstream code was ACCIDENTALLY REMOVED by the resolution.
+4. Look for TODO, FIXME, or XXX markers that suggest the resolution agent gave up on part of the merge.
+5. Check if any ifdef/ifndef/endif guards were incorrectly resolved (e.g., code that should be conditional is now unconditional, or vice versa).
+6. Verify that all callers/callees that the original patch updated are also updated in the resolution. A common merge error is updating a function signature but missing one of its call sites.

--- a/src/pipelines/cherry_pick_review/prompts/merge_conflict_review_framing.md
+++ b/src/pipelines/cherry_pick_review/prompts/merge_conflict_review_framing.md
@@ -1,0 +1,20 @@
+
+
+=== MERGE-CONFLICT RESOLUTION REVIEW ===
+An automated agent cherry-picked/forward-ported a patch onto a different branch and resolved the resulting conflicts. THREE commits are involved; only defects INTRODUCED BY THE RESOLUTION are in scope.
+
+1. ORIGINAL PATCH (the change being ported):
+   SHA:     {{original_sha}}
+   Subject: {{original_subject}}
+   ^ Bugs that already existed in this patch are NOT in scope.
+
+2. TARGET BASE (the branch HEAD it was applied ONTO):
+   SHA:     {{base_sha}}
+   Subject: {{base_subject}}
+   ^ Bugs that already existed in the base branch are NOT in scope.
+
+3. RESOLUTION COMMIT (what you are reviewing):
+   SHA:     {{resolution_sha}}
+   Subject: {{resolution_subject}}
+   ^ = (original patch applied) + (conflict resolution). Report ONLY bugs that exist HERE but did NOT exist in the original patch (1) or target base (2).
+=========================================

--- a/src/pipelines/cherry_pick_review/prompts/merge_correctness.md
+++ b/src/pipelines/cherry_pick_review/prompts/merge_correctness.md
@@ -1,0 +1,14 @@
+# Stage 3. Merge correctness verification
+
+You are a static analysis engine checking the STRUCTURAL CORRECTNESS of a merge-conflict resolution in C code. The resolution was created by an automated agent.
+
+Check for these specific merge artifacts:
+1. DUPLICATE INCLUDES: Did taking both sides of a conflict result in the same header being included twice?
+2. DUPLICATE DEFINITIONS: Are there duplicate function definitions, struct member declarations, enum values, or macro definitions?
+3. CONFLICTING MACROS: Are there define directives with different values for the same macro name?
+4. MISMATCHED SIGNATURES: Does a function declaration (in a header) disagree with its definition (in a .c file) after resolution?
+5. BROKEN CONTROL FLOW: Are there if/else blocks with missing braces, goto labels that were removed but are still referenced, or switch cases that fall through incorrectly?
+6. VARIABLE ISSUES: Are variables declared twice due to merged code? Are variables used before initialization because the resolution reordered statements?
+7. INITIALIZER ERRORS: Missing or extra commas in enum, struct, or array initializers — a very common merge artifact.
+8. PREPROCESSOR NESTING: Are ifdef/ifndef/endif blocks properly nested after the merge? Check that every ifdef has a matching endif.
+9. COMPILATION GUARDS: Did the resolution create code that references symbols, types, or functions that do not exist in the target branch?

--- a/src/pipelines/cherry_pick_review/prompts/origin_classification.md
+++ b/src/pipelines/cherry_pick_review/prompts/origin_classification.md
@@ -1,0 +1,12 @@
+# Stage 11. Origin Classification
+
+You are classifying the origin of each finding from a merge-conflict resolution review.
+
+For each finding, determine its origin:
+- resolution_introduced: The merge/resolution CREATED this issue. It did not exist in the original patch, and it did not exist in the target base branch; combining them introduced it.
+- original_patch_preexisting: This issue already existed in the ORIGINAL PATCH being ported (commit 1). The conflict resolution did not cause it; it was already present in that patch.
+- base_preexisting: This issue already existed in the TARGET BASE branch (commit 2) before the resolution was applied. The resolution did not cause it.
+
+IMPORTANT: Use tools to check the code BEFORE the resolution commit to determine origin. Compare the state at the parent commit with the resolution commit. If the problematic code existed identically before the resolution, it is preexisting.
+
+Return ONLY a JSON object with a 'findings' array. Each finding must preserve ALL fields from the input and ADD an 'origin' field with one of the three values above.

--- a/src/pipelines/cherry_pick_review/prompts/planning.md
+++ b/src/pipelines/cherry_pick_review/prompts/planning.md
@@ -1,0 +1,12 @@
+Analyze the provided patch and determine which of the following review stages are relevant and should be executed:
+- Stage 4: Resource management
+- Stage 5: Locking and synchronization
+- Stage 6: Security audit
+- Stage 7: Hardware engineer's review
+
+CRITICAL: Always err on the side of running more stages. If you are not absolutely sure, include the stage. If the patch is a trivial typo fix, you may omit some stages. Stages 1, 2, and 3 are always run and should not be included in your answer.
+
+You MUST respond with ONLY a JSON object, no other text. Example:
+```json
+{"relevant_stages": [4, 5, 6, 7]}
+```

--- a/src/pipelines/cherry_pick_review/prompts/prefetched_context_header.md
+++ b/src/pipelines/cherry_pick_review/prompts/prefetched_context_header.md
@@ -1,0 +1,6 @@
+
+
+<pre_fetched_context>
+The following context was automatically pre-fetched based on the modified lines in the patch. It contains the full source code of the functions and structs modified by the diff AFTER applying the target patch.
+If it's not sufficient, you MUST use available tools to explore the source code. Don't make assumptions without actually looking into the relevant code.
+

--- a/src/pipelines/cherry_pick_review/prompts/semantic_intent.md
+++ b/src/pipelines/cherry_pick_review/prompts/semantic_intent.md
@@ -1,0 +1,17 @@
+# Stage 1. Semantic intent analysis
+
+You are reviewing a merge-conflict resolution commit. This commit was created by an automated agent to resolve a conflict that occurred when cherry-picking or rebasing a kernel patch onto a different branch.
+
+Your task is to analyze whether the resolution preserves the SEMANTIC INTENT of BOTH sides of the conflict:
+- The ORIGINAL PATCH's intent: what the patch being ported set out to do (new feature, bugfix, refactor)
+- The TARGET BASE's state: what the branch it was applied onto already had (possibly different implementations of similar features, different configurations, or divergent code paths)
+
+Look for these specific problems:
+1. Logic that was silently dropped from either side during resolution
+2. Conditions that were inverted or altered (e.g., an if-check that changed meaning)
+3. Return values or error codes that changed meaning in the resolved version
+4. Error handling paths that were broken by the merge (e.g., goto labels removed but still referenced)
+5. Behavioral changes that NEITHER the original patch NOR the target base intended — artifacts of the merge itself
+6. Function signatures or struct definitions that are inconsistent after resolution
+
+Focus on SEMANTIC correctness, not syntactic differences. A resolution that changes whitespace or reorders includes is fine. A resolution that silently drops a NULL check is not.

--- a/src/pipelines/cherry_pick_review/prompts/verification.md
+++ b/src/pipelines/cherry_pick_review/prompts/verification.md
@@ -1,0 +1,15 @@
+# Stage 10. Verification and severity estimation
+
+You are the lead reviewer validating consolidated concerns from a merge-conflict resolution review.
+You will be given a list of deduplicated concerns after conflict resolution.
+
+1. Validate each concern by proving the provided reasoning against the actual code. Use tools to gather additional evidence if needed. Report all valid concerns as findings. Discard all false positives.
+2. CRITICAL RULE: To discard a concern as a false positive, you MUST find concrete proof that explicitly invalidates the concern's reasoning. If you cannot find definitive proof, the concern must be reported as a finding.
+3. Assign a severity to each remaining valid finding: low, medium, high, or critical.
+   - critical: Will cause a kernel crash, data corruption, or security vulnerability in common code paths.
+   - high: Will cause incorrect behavior, resource leaks, or build failures in reachable code paths.
+   - medium: Could cause problems under specific conditions, or represents a logic error that may not be immediately triggered.
+   - low: Style issues, minor inefficiencies, or cosmetic problems that do not affect correctness.
+4. SPECIFICITY REQUIREMENT: Every finding MUST cite the exact function name(s), file path(s), and triggering conditions. Do not produce vague findings.
+5. Carry forward the locations from the validated concern into each finding. If you gather better evidence, replace vague locations with precise ones.
+6. Do NOT classify the origin of findings (pre-existing vs introduced). That is handled by a separate stage.

--- a/src/pipelines/cherry_pick_review/synthesis.rs
+++ b/src/pipelines/cherry_pick_review/synthesis.rs
@@ -1,0 +1,185 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verbatim-ported synthesis-stage prompt builders for the cherry-pick pipeline.
+//!
+//! Synthesis stages 8-11 (+ origin classification) each build a bespoke user
+//! prompt that injects the accumulated concerns/findings and carries a per-stage
+//! output schema. These templates are copied VERBATIM from the original hack
+//! (commit 66fb0a5) so the pipeline reproduces its behaviour exactly.
+//!
+//! The `clean` prompt is set equal to the user prompt: it only affects logging
+//! (synthesis stages use a fixed system context, not accumulated clean history),
+//! so this does not change model behaviour.
+
+use crate::pipelines::{PipelineState, StagePromptBuilder};
+
+/// Concerns/dismissed-concerns JSON schema guidance appended to analysis stages
+/// 1-7 (copied verbatim from `Worker::execute_stage`).
+pub const ANALYSIS_FORMAT_GUIDANCE: &str = include_str!("prompts/analysis_format_guidance.md");
+
+fn concerns_json(state: &PipelineState) -> String {
+    serde_json::to_string_pretty(&state.concerns).unwrap_or_default()
+}
+
+fn dismissed_json(state: &PipelineState) -> String {
+    serde_json::to_string_pretty(&state.dismissed_concerns).unwrap_or_default()
+}
+
+fn findings_json(state: &PipelineState) -> String {
+    match &state.findings {
+        Some(v) => serde_json::to_string_pretty(v).unwrap_or_default(),
+        None => "[]".to_string(),
+    }
+}
+
+pub fn stage8_builder() -> StagePromptBuilder {
+    Box::new(|stage_prompt: &str, state: &PipelineState| {
+        let aggregated_concerns_json = concerns_json(state);
+        let aggregated_dismissed_concerns_json = dismissed_json(state);
+        let user_prompt = format!(
+            r#"{}
+
+Consolidated Concerns:
+{}
+
+Consolidated Dismissed Concerns:
+{}
+
+Return ONLY a JSON object with 'concerns' and 'dismissed_concerns' arrays.
+Each object in the 'concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "preexisting", "locations".
+Each object in the 'dismissed_concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "locations".
+Preserve the most precise location details from the input. Do not invent line numbers; use null when exact values are unknown.
+
+Example Output:
+```json
+{{
+  "concerns": [
+    {{
+      "type": "Memory Leak",
+      "description": "Memory leak in function X",
+      "reasoning": "1. X is called.\n2. Y is allocated but not freed on error path.",
+      "preexisting": false,
+      "locations": [
+        {{
+          "file": "path/to/file.c",
+          "function_or_symbol": "function_name",
+          "line": 123,
+          "code_snippet": "problematic_code();",
+          "why_this_location_matters": "This is where the newly allocated resource is dropped on the error path."
+        }}
+      ]
+    }}
+  ],
+  "dismissed_concerns": [
+    {{
+      "type": "Resource Management",
+      "description": "Possible missing cleanup when foo_init() fails after bar_alloc().",
+      "reasoning": "The concrete code path or ordering that proves this candidate concern does not apply.",
+      "locations": [
+        {{
+          "file": "path/to/file.c",
+          "function_or_symbol": "function_name",
+          "line": 125,
+          "code_snippet": "safe_code_path();",
+          "why_this_location_matters": "This is where the cleanup path proves the candidate leak does not apply."
+        }}
+      ]
+    }}
+  ]
+}}
+```"#,
+            stage_prompt, aggregated_concerns_json, aggregated_dismissed_concerns_json
+        );
+        (user_prompt.clone(), user_prompt)
+    })
+}
+
+pub fn stage9_builder() -> StagePromptBuilder {
+    Box::new(|stage_prompt: &str, state: &PipelineState| {
+        let deduplicated_concerns_json = concerns_json(state);
+        let deduplicated_dismissed_concerns_json = dismissed_json(state);
+        let user_prompt = format!(
+            r#"{}
+
+Consolidated Concerns:
+{}
+
+Consolidated Dismissed Concerns:
+{}
+
+Return ONLY a JSON object with a 'concerns' array containing the remaining concerns after resolving conflicts. Each object in the 'concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "preexisting", "locations".
+Preserve the most precise locations from the retained concerns. Do not invent line numbers; use null when exact values are unknown.
+
+Example Output:
+```json
+{{
+  "concerns": [
+    {{
+      "type": "Memory Leak",
+      "description": "Memory leak in function X",
+      "reasoning": "1. X is called.\n2. Y is allocated but not freed on error path.",
+      "preexisting": false,
+      "locations": [
+        {{
+          "file": "path/to/file.c",
+          "function_or_symbol": "function_name",
+          "line": 123,
+          "code_snippet": "problematic_code();",
+          "why_this_location_matters": "This is where the newly allocated resource is dropped on the error path."
+        }}
+      ]
+    }}
+  ]
+}}
+```"#,
+            stage_prompt, deduplicated_concerns_json, deduplicated_dismissed_concerns_json
+        );
+        (user_prompt.clone(), user_prompt)
+    })
+}
+
+pub fn stage10_builder() -> StagePromptBuilder {
+    Box::new(|stage_prompt: &str, state: &PipelineState| {
+        let full_series_context = "Not applicable (single patch or last patch in series).";
+        let conflict_resolved_concerns_json = concerns_json(state);
+        let user_prompt = format!(
+            "{}\n\nCRITICAL REVIEW DIRECTIVE: To dismiss a concern as a false positive, you must find concrete evidence in the code that proves the concern is invalid (e.g., verifying the caller handles the edge case). If you cannot find concrete proof of safety, you must retain the concern.\n\nFull Series Context:\n{}\n\nConsolidated Concerns:\n{}\n\nReturn ONLY a JSON object with a 'findings' array. Each object in the 'findings' array MUST use exactly the following keys: \"problem\" (a string containing the vulnerability description), \"severity\" (a string: Low, Medium, High, or Critical), \"severity_explanation\" (a string detailing the reasoning and proof), \"preexisting\" (a boolean: true if the problem already existed in the codebase before these patches were applied, or false if it was newly introduced by the reviewed patchset), \"locations\" (an array of objects with file, function_or_symbol, line, code_snippet, and why_this_location_matters). Carry forward the locations from the validated concern; if you gather better evidence, replace vague locations with the most precise verified locations. Do not invent line numbers; use null when exact values are unknown.\n\nExample Output:\n```json\n{{\n  \"findings\": [\n    {{\n      \"problem\": \"Memory leak in function X when condition Y is met.\",\n      \"severity\": \"High\",\n      \"severity_explanation\": \"1. Condition Y is met.\\\n2. The buffer is allocated but not freed before return.\",\n      \"preexisting\": false,\n      \"locations\": [\n        {{\n          \"file\": \"path/to/file.c\",\n          \"function_or_symbol\": \"function_name\",\n          \"line\": 123,\n          \"code_snippet\": \"problematic_code();\",\n          \"why_this_location_matters\": \"This is where the newly allocated resource is dropped on the error path.\"\n        }}\n      ]\n    }}\n  ]\n}}\n```",
+            stage_prompt, full_series_context, conflict_resolved_concerns_json
+        );
+        (user_prompt.clone(), user_prompt)
+    })
+}
+
+pub fn origin_builder() -> StagePromptBuilder {
+    Box::new(|classification_prompt: &str, state: &PipelineState| {
+        let findings_str = findings_json(state);
+        let user_prompt = format!(
+            "{}\n\nFindings to classify:\n{}\n\nReturn ONLY a JSON object with a 'findings' array. Each finding must have all original fields plus an 'origin' field.",
+            classification_prompt, findings_str
+        );
+        (user_prompt.clone(), user_prompt)
+    })
+}
+
+pub fn stage11_builder() -> StagePromptBuilder {
+    Box::new(|stage_prompt: &str, state: &PipelineState| {
+        let findings_str = findings_json(state);
+        let user_prompt = format!(
+            "{}\n\nFindings:\n{}\n\nReturn raw text output, not JSON.",
+            stage_prompt, findings_str
+        );
+        (user_prompt.clone(), user_prompt)
+    })
+}

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -1,0 +1,566 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A general, composable review-pipeline framework.
+//!
+//! The default patch review (`crate::worker::Worker::run`) is deliberately left
+//! untouched. This module lets us express ALTERNATE review workflows (e.g.
+//! cherry-pick review) as an ordered list of [`Step`]s over the *same* stage
+//! machinery, built on the shared `SessionRunner` / `LlmSession` primitives
+//! described in `designs/DESIGN_MODULAR_LLM_SESSIONS.md`.
+//!
+//! Each stage is executed via [`crate::worker::run_review_stage`], which reuses
+//! the exact tool loop, validation, and recitation handling as the patch-review
+//! path, so behavior stays equivalent.
+
+use anyhow::Result;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+use crate::ai::AiProvider;
+use crate::toolbox::ToolBox;
+use crate::worker::stage::create_stage;
+use crate::worker::{PromptRegistry, WorkerProgressEvent, WorkerResult};
+
+/// Where a stage's instruction prompt comes from.
+pub enum StagePrompt {
+    /// Use the built-in per-stage prompt from `PromptRegistry::get_stage_prompt`.
+    Builtin,
+    /// Use an explicit `(content, clean)` override (e.g. cherry-pick stages 1-3).
+    Override {
+        /// Full instruction text sent to the model.
+        content: String,
+        /// Compact log form (may reference `@file` guidance instead of bodies).
+        clean: String,
+    },
+}
+
+/// How a stage's output is folded into the accumulated [`PipelineState`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Capture {
+    /// Merge `output["concerns"]` / `["dismissed_concerns"]` (analysis stages 1-7).
+    MergeConcerns,
+    /// Replace the concern set with `output["concerns"]` (dedup/resolution 8-9).
+    ReplaceConcerns,
+    /// Store `output["findings"]` as the final findings (stage 10).
+    Findings,
+    /// Store `output.as_str()` as the inline review text (stage 11).
+    Inline,
+}
+
+/// Builds the `(user_prompt, clean_user_prompt)` for a stage from its
+/// instruction text and the state accumulated so far. Used by synthesis stages
+/// that inject prior concerns/findings and carry a per-stage output schema.
+pub type StagePromptBuilder = Box<dyn Fn(&str, &PipelineState) -> (String, String) + Send + Sync>;
+
+/// A single stage to execute within a pipeline.
+pub struct StageSpec {
+    /// Stage number; selects validation + trait behavior via `create_stage`.
+    pub number: u8,
+    /// Where the instruction prompt comes from.
+    pub prompt: StagePrompt,
+    /// How to fold the stage output into [`PipelineState`].
+    pub capture: Capture,
+    /// Extra user-prompt guidance appended after the instruction (e.g. the
+    /// concerns JSON schema). Empty for stages that carry their own format rules.
+    pub format_guidance: String,
+    /// Optional dynamic builder for the user prompt from the instruction and the
+    /// accumulated state. When set, it takes precedence over `format_guidance`
+    /// (synthesis stages 8-12 use this to inject prior concerns/findings).
+    pub template: Option<StagePromptBuilder>,
+    /// For `StagePrompt::Override` stages, which stage's guide files (severity,
+    /// inline template, etc.) to append -- mirroring `get_stage_prompt`, which
+    /// `Override` bypasses. `None` appends nothing.
+    pub guide_stage: Option<u8>,
+}
+
+impl StageSpec {
+    /// Create a stage spec with no extra format guidance.
+    pub fn new(number: u8, prompt: StagePrompt, capture: Capture) -> Self {
+        Self {
+            number,
+            prompt,
+            capture,
+            format_guidance: String::new(),
+            template: None,
+            guide_stage: None,
+        }
+    }
+
+    /// Append extra format guidance to the user prompt.
+    pub fn with_format_guidance(mut self, guidance: impl Into<String>) -> Self {
+        self.format_guidance = guidance.into();
+        self
+    }
+
+    /// Set a dynamic prompt builder (takes precedence over `format_guidance`).
+    pub fn with_template(mut self, builder: StagePromptBuilder) -> Self {
+        self.template = Some(builder);
+        self
+    }
+
+    /// Append the guide files for stage `n` (as `get_stage_prompt` would) to an
+    /// `Override` prompt.
+    pub fn with_guides(mut self, n: u8) -> Self {
+        self.guide_stage = Some(n);
+        self
+    }
+}
+
+/// The system context a pipeline supplies to its stages, with and without the
+/// review log (mirrors `Worker::run`'s handling of `use_log_in_context`).
+#[derive(Default)]
+pub struct PipelineContext {
+    /// System prompt for stages that include the review log.
+    pub system_with_log: String,
+    /// System prompt for stages that exclude the review log.
+    pub system_without_log: String,
+    /// Compact log form of `system_with_log`.
+    pub clean_with_log: String,
+    /// Compact log form of `system_without_log`.
+    pub clean_without_log: String,
+}
+
+/// State accumulated across steps; assembled into the final [`WorkerResult`].
+#[derive(Default)]
+pub struct PipelineState {
+    /// Active concerns.
+    pub concerns: Vec<Value>,
+    /// Total concerns aggregated from parallel stages (before dedup).
+    pub total_concerns: usize,
+    /// Dismissed concerns.
+    pub dismissed_concerns: Vec<Value>,
+    /// Final findings (from a `Capture::Findings` stage), if any.
+    pub findings: Option<Value>,
+    /// Pre-filter classified findings (preserved for DB output).
+    /// V1 parity: the output `findings` field always contains the full
+    /// classified list; the Rust-side filter only affects which findings
+    /// go to the inline review (Stage 11).
+    pub classified_findings: Option<Value>,
+    /// Inline review text (from a `Capture::Inline` stage), if any.
+    pub review_inline: Option<String>,
+    /// Suggested fixes text, if any.
+    pub fixes: Option<String>,
+    /// Accumulated input tokens.
+    pub tokens_in: u32,
+    /// Accumulated output tokens.
+    pub tokens_out: u32,
+    /// Accumulated cached tokens.
+    pub tokens_cached: u32,
+    /// Accumulated conversation history across stages.
+    pub history: Vec<crate::ai::AiMessage>,
+}
+
+/// Ingredients required to execute a pipeline. Taken directly (mirroring the
+/// private `Worker` fields) so the executor never reaches into `Worker`.
+pub struct PipelineEnv<'a> {
+    /// The AI provider.
+    pub provider: Arc<dyn AiProvider>,
+    /// The tool box (worktree-scoped).
+    pub tools: Arc<ToolBox>,
+    /// The prompt registry (for built-in stage prompts + static context).
+    pub prompts: &'a PromptRegistry,
+    /// Sampling temperature.
+    pub temperature: f32,
+    /// Maximum turns per stage.
+    pub max_interactions: usize,
+    /// Optional context tag for logging.
+    pub context_tag: Option<String>,
+    /// Optional explicit stage list (V1 parity: WorkerConfig.stages).
+    pub stages: Option<Vec<u8>>,
+    /// Optional series range for Stage 10 context (V1 parity).
+    pub series_range: Option<String>,
+}
+
+/// A composable review workflow.
+///
+/// A pipeline is expressed imperatively: `run` orchestrates its stages through
+/// the [`Cx`] handle -- it builds the system context, runs stages, and branches
+/// on the accumulated [`PipelineState`] using ordinary control flow.
+#[async_trait::async_trait]
+pub trait Pipeline: Send + Sync {
+    /// Human-readable name (used in logs and the result context).
+    fn name(&self) -> &'static str;
+
+    /// Execute the workflow, driving stages through `cx`.
+    async fn run(&self, cx: &mut Cx<'_>) -> Result<()>;
+}
+
+/// Imperative driver handle passed to [`Pipeline::run`]. Bundles the execution
+/// environment, the pipeline-built system context, and the accumulated
+/// [`PipelineState`], and exposes the stage-running ops the executor used to
+/// apply for a static plan.
+pub struct Cx<'a> {
+    /// Execution environment (provider, tools, prompts, config).
+    pub env: &'a PipelineEnv<'a>,
+    /// The patchset under review.
+    pub patchset: Value,
+    /// State accumulated across stages.
+    pub state: PipelineState,
+    ctx: PipelineContext,
+    progress: Option<&'a (dyn Fn(WorkerProgressEvent) + Send + Sync)>,
+}
+
+impl Cx<'_> {
+    /// Set the shared system context. Call once from `run`, after building it.
+    pub fn set_context(&mut self, ctx: PipelineContext) {
+        self.ctx = ctx;
+    }
+
+    /// Run a single stage and fold its output into the state.
+    pub async fn stage(&mut self, spec: StageSpec) -> Result<()> {
+        let outcome = run_stage(&spec, self.env, &self.ctx, &self.state, self.progress).await?;
+        fold(&mut self.state, &spec, outcome);
+        Ok(())
+    }
+
+    /// Run several stages concurrently, folding each output into the state.
+    pub async fn parallel(&mut self, specs: Vec<StageSpec>) -> Result<()> {
+        let futures = specs
+            .iter()
+            .map(|spec| run_stage(spec, self.env, &self.ctx, &self.state, self.progress));
+        let outcomes = futures::future::try_join_all(futures).await?;
+        for (spec, outcome) in specs.iter().zip(outcomes) {
+            fold(&mut self.state, spec, outcome);
+        }
+        Ok(())
+    }
+}
+
+/// The raw result of running one stage.
+struct StageOutcome {
+    output: Value,
+    tokens_in: u32,
+    tokens_out: u32,
+    tokens_cached: u32,
+    history: Vec<crate::ai::AiMessage>,
+}
+
+/// Execute a pipeline end to end, returning a [`WorkerResult`] in the same shape
+/// as `Worker::run` so the review binary can consume it identically.
+pub async fn execute_pipeline(
+    pipeline: &dyn Pipeline,
+    env: &PipelineEnv<'_>,
+    patchset: Value,
+    progress: Option<&(dyn Fn(WorkerProgressEvent) + Send + Sync)>,
+) -> Result<WorkerResult> {
+    let mut cx = Cx {
+        env,
+        patchset,
+        state: PipelineState::default(),
+        ctx: PipelineContext::default(),
+        progress,
+    };
+    pipeline.run(&mut cx).await?;
+    let Cx { state, ctx, .. } = cx;
+
+    let final_output = json!({
+        "findings": state
+            .classified_findings
+            .clone()
+            .or_else(|| state.findings.clone())
+            .unwrap_or_else(|| Value::Array(state.concerns.clone())),
+        "dismissed_concerns": Value::Array(state.dismissed_concerns.clone()),
+        "review_inline": state.review_inline.clone().unwrap_or_else(|| {
+            // V1 compat: when the pipeline exits early (no findings),
+            // the inline review text defaults to 'No issues found.'
+            if state.findings.as_ref().and_then(|v| v.as_array()).is_none_or(|a| a.is_empty()) {
+                "No issues found.".to_string()
+            } else {
+                String::new()
+            }
+        }),
+        "fixes": state.fixes.clone().unwrap_or_default(),
+        "concerns_count": state.total_concerns,
+        "dismissed_concerns_count": state.dismissed_concerns.len(),
+    });
+
+    // Prepend the system prompt as a leading system message in the logged
+    // history so it is persisted to reviews[n].logs. The system prompt is sent
+    // to the model but was previously omitted from the review log (V1 parity).
+    let mut logged_history = state.history.clone();
+    if !logged_history.is_empty() {
+        logged_history.insert(
+            0,
+            crate::ai::AiMessage {
+                role: crate::ai::AiRole::System,
+                content: Some(ctx.clean_with_log.clone()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        );
+    }
+
+    Ok(WorkerResult {
+        output: Some(final_output),
+        error: None,
+        input_context: format!("Pipeline '{}' completed", pipeline.name()),
+        history: logged_history.clone(),
+        history_before_pruning: logged_history.clone(),
+        history_after_pruning: logged_history,
+        tokens_in: state.tokens_in,
+        tokens_out: state.tokens_out,
+        tokens_cached: state.tokens_cached,
+    })
+}
+
+async fn run_stage(
+    spec: &StageSpec,
+    env: &PipelineEnv<'_>,
+    ctx: &PipelineContext,
+    state: &PipelineState,
+    progress: Option<&(dyn Fn(WorkerProgressEvent) + Send + Sync)>,
+) -> Result<StageOutcome> {
+    let stage = create_stage(spec.number);
+
+    if let Some(progress_cb) = progress {
+        progress_cb(WorkerProgressEvent::StageStarted { stage: spec.number });
+    }
+
+    let system = if stage.use_log_in_context() {
+        ctx.system_with_log.clone()
+    } else {
+        ctx.system_without_log.clone()
+    };
+
+    let (content, clean) = match &spec.prompt {
+        StagePrompt::Builtin => env.prompts.get_stage_prompt(spec.number).await?,
+        StagePrompt::Override { content, clean } => {
+            let mut content = content.clone();
+            let mut clean = clean.clone();
+            if let Some(guide_stage) = spec.guide_stage {
+                env.prompts
+                    .append_stage_guides(guide_stage, &mut content, &mut clean)
+                    .await?;
+            }
+            (content, clean)
+        }
+    };
+    let (user_prompt, clean_user_prompt) = if let Some(build) = &spec.template {
+        build(&content, state)
+    } else if spec.format_guidance.is_empty() {
+        (content, clean)
+    } else {
+        (
+            format!("{}\n\n{}", content, spec.format_guidance),
+            format!("{}\n\n{}", clean, spec.format_guidance),
+        )
+    };
+
+    let result = crate::worker::run_review_stage(
+        env.provider.as_ref(),
+        env.tools.clone(),
+        env.temperature,
+        env.max_interactions,
+        env.context_tag.as_deref(),
+        stage,
+        system,
+        user_prompt,
+        clean_user_prompt,
+        progress,
+    )
+    .await?;
+
+    if let Some(progress_cb) = progress {
+        progress_cb(WorkerProgressEvent::StageFinished { stage: spec.number });
+    }
+
+    Ok(StageOutcome {
+        output: result.output,
+        tokens_in: result.usage.prompt_tokens as u32,
+        tokens_out: result.usage.completion_tokens as u32,
+        tokens_cached: result.usage.cached_tokens.unwrap_or(0) as u32,
+        history: result.history,
+    })
+}
+
+fn fold(state: &mut PipelineState, spec: &StageSpec, outcome: StageOutcome) {
+    state.tokens_in += outcome.tokens_in;
+    state.tokens_out += outcome.tokens_out;
+    state.tokens_cached += outcome.tokens_cached;
+    state.history.extend(outcome.history);
+
+    match spec.capture {
+        Capture::MergeConcerns => {
+            if let Some(arr) = outcome.output.get("concerns").and_then(|v| v.as_array()) {
+                for item in arr {
+                    if let Some(tagged) = tag_source(item.clone(), spec.number) {
+                        state.total_concerns += 1;
+                        state.concerns.push(tagged);
+                    }
+                }
+            }
+            if let Some(arr) = outcome
+                .output
+                .get("dismissed_concerns")
+                .and_then(|v| v.as_array())
+            {
+                for item in arr {
+                    if let Some(tagged) = tag_source(item.clone(), spec.number) {
+                        state.dismissed_concerns.push(tagged);
+                    }
+                }
+            }
+        }
+        Capture::ReplaceConcerns => {
+            if let Some(arr) = outcome.output.get("concerns").and_then(|v| v.as_array()) {
+                state.concerns = arr.clone();
+            }
+            if let Some(arr) = outcome
+                .output
+                .get("dismissed_concerns")
+                .and_then(|v| v.as_array())
+            {
+                state.dismissed_concerns = arr.clone();
+            }
+        }
+        Capture::Findings => {
+            state.findings = Some(
+                outcome
+                    .output
+                    .get("findings")
+                    .cloned()
+                    .unwrap_or(outcome.output),
+            );
+        }
+        Capture::Inline => {
+            if let Some(text) = outcome.output.as_str() {
+                state.review_inline = Some(text.to_string());
+            }
+        }
+    }
+}
+
+/// Inject `source_stage` into a concern (mirrors V1's
+/// `normalize_stage_item`).
+///
+/// Returns `None` for non-object, non-string items (numbers, nulls,
+/// booleans) — V1 parity: these are silently dropped.
+fn tag_source(item: Value, stage: u8) -> Option<Value> {
+    match item {
+        Value::Object(mut map) => {
+            map.insert("source_stage".to_string(), json!(stage));
+            Some(Value::Object(map))
+        }
+        Value::String(text) => Some(json!({
+            "source_stage": stage,
+            "type": "General",
+            "description": text,
+        })),
+        _ => None, // Drop non-object, non-string items (V1 parity)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NeverProvider;
+
+    #[async_trait::async_trait]
+    impl AiProvider for NeverProvider {
+        async fn generate_content(
+            &self,
+            _request: crate::ai::AiRequest,
+        ) -> anyhow::Result<crate::ai::AiResponse> {
+            panic!("provider must not be called for a step-only pipeline");
+        }
+        fn estimate_tokens(&self, _request: &crate::ai::AiRequest) -> usize {
+            0
+        }
+        fn get_capabilities(&self) -> crate::ai::ProviderCapabilities {
+            crate::ai::ProviderCapabilities {
+                model_name: "never".to_string(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    fn test_env<'a>(prompts: &'a PromptRegistry, dir: &'a std::path::Path) -> PipelineEnv<'a> {
+        PipelineEnv {
+            provider: Arc::new(NeverProvider),
+            tools: Arc::new(ToolBox::new(dir.to_path_buf(), None)),
+            prompts,
+            temperature: 0.0,
+            max_interactions: 3,
+            context_tag: None,
+            stages: None,
+            series_range: None,
+        }
+    }
+
+    struct MutatePipeline;
+
+    #[async_trait::async_trait]
+    impl Pipeline for MutatePipeline {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+        async fn run(&self, cx: &mut Cx<'_>) -> Result<()> {
+            cx.state
+                .concerns
+                .push(json!({"type": "X", "description": "d"}));
+            cx.state.total_concerns += 1;
+            cx.state.review_inline = Some("hello".to_string());
+            Ok(())
+        }
+    }
+
+    struct EarlyReturnPipeline;
+
+    #[async_trait::async_trait]
+    impl Pipeline for EarlyReturnPipeline {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+        async fn run(&self, cx: &mut Cx<'_>) -> Result<()> {
+            // Models an early exit: return before touching review_inline.
+            if cx.state.concerns.is_empty() {
+                return Ok(());
+            }
+            cx.state.review_inline = Some("should not run".to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn assembles_worker_result_without_calling_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prompts = PromptRegistry::new(tmp.path().to_path_buf());
+        let env = test_env(&prompts, tmp.path());
+
+        let result = execute_pipeline(&MutatePipeline, &env, json!({}), None)
+            .await
+            .unwrap();
+        let out = result.output.unwrap();
+        assert_eq!(out["concerns_count"], 1);
+        assert_eq!(out["review_inline"], "hello");
+        // findings falls back to the concern list when no Findings stage ran.
+        assert_eq!(out["findings"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn early_return_stops_the_pipeline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prompts = PromptRegistry::new(tmp.path().to_path_buf());
+        let env = test_env(&prompts, tmp.path());
+
+        let result = execute_pipeline(&EarlyReturnPipeline, &env, json!({}), None)
+            .await
+            .unwrap();
+        assert_eq!(result.output.unwrap()["review_inline"], "No issues found.");
+    }
+}

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -446,6 +446,78 @@ fn fold(state: &mut PipelineState, spec: &StageSpec, outcome: StageOutcome) {
     }
 }
 
+/// V1-parity: simple JSON request with one retry (mirrors Worker::json_request).
+///
+/// Sends a request to the provider, parses JSON from the response,
+/// validates it, and retries once on failure. Returns None if both
+/// attempts fail.
+pub(crate) async fn json_request(
+    provider: &dyn AiProvider,
+    request: crate::ai::AiRequest,
+    validate: impl Fn(&serde_json::Value) -> Result<(), String>,
+) -> Option<serde_json::Value> {
+    use crate::ai::{AiMessage, AiRole};
+
+    // First attempt
+    let resp = provider.generate_content(request.clone()).await.ok()?;
+    let text = resp.content.as_deref().unwrap_or("");
+    if let Some(val) = try_parse_json(text)
+        && validate(&val).is_ok()
+    {
+        return Some(val);
+    }
+
+    // Retry with correction
+    let mut retry_messages = request.messages.clone();
+    retry_messages.push(AiMessage {
+        role: AiRole::Assistant,
+        content: resp.content.clone(),
+        thought: None,
+        thought_signature: None,
+        tool_calls: None,
+        tool_call_id: None,
+    });
+    retry_messages.push(AiMessage {
+        role: AiRole::User,
+        content: Some(
+            "Your previous response was not valid JSON or did not match the required schema.              Please try again with ONLY a valid JSON object."
+                .to_string(),
+        ),
+        thought: None,
+        thought_signature: None,
+        tool_calls: None,
+        tool_call_id: None,
+    });
+    let retry_req = crate::ai::AiRequest {
+        messages: retry_messages,
+        ..request
+    };
+    let resp2 = provider.generate_content(retry_req).await.ok()?;
+    let text2 = resp2.content.as_deref().unwrap_or("");
+    if let Some(val) = try_parse_json(text2)
+        && validate(&val).is_ok()
+    {
+        return Some(val);
+    }
+    None
+}
+
+/// Try to parse JSON from text, stripping markdown code fences if present.
+fn try_parse_json(text: &str) -> Option<serde_json::Value> {
+    let trimmed = text.trim();
+    // Strip code fence
+    let cleaned = if trimmed.starts_with("```") {
+        let inner = trimmed
+            .strip_prefix("```json")
+            .or_else(|| trimmed.strip_prefix("```"))
+            .unwrap_or(trimmed);
+        inner.strip_suffix("```").unwrap_or(inner).trim()
+    } else {
+        trimmed
+    };
+    serde_json::from_str(cleaned).ok()
+}
+
 /// Inject `source_stage` into a concern (mirrors V1's
 /// `normalize_stage_item`).
 ///

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -24,6 +24,8 @@
 //! the exact tool loop, validation, and recitation handling as the patch-review
 //! path, so behavior stays equivalent.
 
+pub mod cherry_pick_review;
+
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::sync::Arc;

--- a/src/review_kind.rs
+++ b/src/review_kind.rs
@@ -1,0 +1,58 @@
+//! Per-patchset review dispatch kind.
+//!
+//! Persisted as JSON in the `patchsets.review_context` column. A `NULL` column
+//! (deserialized as `None`) selects the default patch-review pipeline, so
+//! patch-only deployments store nothing extra. A present value selects an
+//! alternate pipeline (currently only cherry-pick review).
+
+use serde::{Deserialize, Serialize};
+
+/// Selects which review pipeline processes a patchset.
+///
+/// Serialized to JSON, e.g. `{"type":"cherry-pick","original_sha":"..."}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ReviewKind {
+    /// Review of an automated cherry-pick / merge-conflict resolution commit.
+    #[serde(rename = "cherry-pick")]
+    CherryPick {
+        /// The original patch that was being ported.
+        original_sha: String,
+        /// The target base the patch was applied onto. Defaults to
+        /// `<resolution>~1` when absent.
+        #[serde(default)]
+        base_sha: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cherry_pick_round_trips_through_json() {
+        let k = ReviewKind::CherryPick {
+            original_sha: "abc123".to_string(),
+            base_sha: Some("def456".to_string()),
+        };
+        let json = serde_json::to_string(&k).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"cherry-pick","original_sha":"abc123","base_sha":"def456"}"#
+        );
+        assert_eq!(serde_json::from_str::<ReviewKind>(&json).unwrap(), k);
+    }
+
+    #[test]
+    fn base_sha_defaults_to_none_when_absent() {
+        let k: ReviewKind =
+            serde_json::from_str(r#"{"type":"cherry-pick","original_sha":"abc"}"#).unwrap();
+        assert_eq!(
+            k,
+            ReviewKind::CherryPick {
+                original_sha: "abc".to_string(),
+                base_sha: None
+            }
+        );
+    }
+}

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1610,6 +1610,19 @@ async fn run_review_tool(
         cmd.arg("--review-commit").arg(commit);
     }
 
+    // Forward the alternate-pipeline selector (e.g. cherry-pick review) if the
+    // patchset was submitted with one; absent selects the default pipeline.
+    match db.get_review_context(patchset_id).await {
+        Ok(Some(rc)) => {
+            cmd.arg("--review-context").arg(rc);
+        }
+        Ok(None) => {}
+        Err(e) => warn!(
+            "Failed to load review_context for patchset {}: {}",
+            patchset_id, e
+        ),
+    }
+
     if settings.ai.no_ai {
         cmd.arg("--no-ai");
     }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS patchsets (
     base_priority INTEGER DEFAULT 500,
     priority_cap INTEGER,
     priority INTEGER DEFAULT 500,
+    repo_url TEXT, -- fetch source URL, persisted for Fetching placeholder recovery
+    review_context TEXT, -- JSON-encoded ReviewKind selecting an alternate review pipeline; NULL = default patch review
     FOREIGN KEY(thread_id) REFERENCES threads(id),
     FOREIGN KEY(cover_letter_message_id) REFERENCES messages(message_id),
     FOREIGN KEY(baseline_id) REFERENCES baselines(id)
@@ -282,6 +284,46 @@ CREATE TABLE IF NOT EXISTS patchwork_outbox (
 );
 CREATE INDEX IF NOT EXISTS idx_patchwork_outbox_status ON patchwork_outbox(status);
 
-
 CREATE INDEX IF NOT EXISTS idx_reviews_patch_status ON reviews(patch_id, status);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_patchsets_slug ON patchsets(slug) WHERE slug IS NOT NULL;
+
+-- Durable queue for outstanding git fetches. Replaces the previous in-memory
+-- FetchAgent channel so that fetch requests survive restarts, request
+-- cancellation, and worker crashes. Modeled on patchwork_outbox: a row is
+-- claimed under a lease (locked_at), retried with backoff (next_retry_at), and
+-- reclaimed by a ghost sweep if its worker dies mid-flight.
+CREATE TABLE IF NOT EXISTS fetch_queue (
+    id INTEGER PRIMARY KEY,
+    patchset_id INTEGER,
+    cover_letter_message_id TEXT,
+    repo_url TEXT,
+    commit_hash TEXT NOT NULL,
+    mr_url TEXT,
+    mr_title TEXT,
+    mr_number INTEGER,
+    status TEXT NOT NULL DEFAULT 'Pending' CHECK(status IN ('Pending', 'Fetching', 'Failed')),
+    attempts INTEGER DEFAULT 0,
+    first_attempt_at INTEGER,
+    next_retry_at INTEGER,
+    locked_at INTEGER,
+    last_error TEXT,
+    priority INTEGER DEFAULT 500,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY(patchset_id) REFERENCES patchsets(id)
+);
+CREATE INDEX IF NOT EXISTS idx_fetch_queue_claim
+    ON fetch_queue(status, next_retry_at, priority, created_at);
+CREATE INDEX IF NOT EXISTS idx_fetch_queue_commit ON fetch_queue(commit_hash);
+
+-- Supporting commits for a fetch (e.g. a cherry-pick's original and base
+-- commits). These are ensured present locally so a review can hydrate its
+-- context from git, but are never ingested as patches. One row per commit so
+-- an arbitrary number can be stored.
+CREATE TABLE IF NOT EXISTS fetch_supporting_commits (
+    id INTEGER PRIMARY KEY,
+    fetch_id INTEGER NOT NULL,
+    commit_hash TEXT NOT NULL,
+    FOREIGN KEY(fetch_id) REFERENCES fetch_queue(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_fetch_supporting_fetch_id
+    ON fetch_supporting_commits(fetch_id);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -86,12 +86,16 @@ CREATE TABLE IF NOT EXISTS patchsets (
     embargo_until INTEGER,
     embargo_release_started_at INTEGER,
     slug TEXT, -- URL-friendly slug like "reponame-725" (repo-mrnum)
+    base_priority INTEGER DEFAULT 500,
+    priority_cap INTEGER,
+    priority INTEGER DEFAULT 500,
     FOREIGN KEY(thread_id) REFERENCES threads(id),
     FOREIGN KEY(cover_letter_message_id) REFERENCES messages(message_id),
     FOREIGN KEY(baseline_id) REFERENCES baselines(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_patchsets_status ON patchsets(status);
+CREATE INDEX IF NOT EXISTS idx_patchsets_status_priority_date ON patchsets(status, priority DESC, date ASC);
 
 
 CREATE TABLE IF NOT EXISTS patches (

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -406,6 +406,53 @@ pub struct CustomRemoteSettings {
     pub only_branches: Option<Vec<String>>,
 }
 
+/// Deserialize a `Vec<T>` that may arrive as a sequence (from TOML `[[...]]`)
+/// or as a map of numeric-string indices to values (from env vars via the
+/// `config` crate, e.g. `..._RULES__0__REGEX`). Mirrors
+/// `deserialize_custom_remotes` for the non-optional list case.
+fn deserialize_indexed_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    struct IndexedVecVisitor<T>(std::marker::PhantomData<T>);
+
+    impl<'de, T: serde::Deserialize<'de>> serde::de::Visitor<'de> for IndexedVecVisitor<T> {
+        type Value = Vec<T>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a sequence or a map of indices to values")
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: serde::de::SeqAccess<'de>,
+        {
+            let mut vec = Vec::new();
+            while let Some(elem) = seq.next_element()? {
+                vec.push(elem);
+            }
+            Ok(vec)
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            use std::collections::BTreeMap;
+            let mut btree = BTreeMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                let value = map.next_value::<T>()?;
+                let idx: usize = key.parse().map_err(serde::de::Error::custom)?;
+                btree.insert(idx, value);
+            }
+            Ok(btree.into_values().collect())
+        }
+    }
+
+    deserializer.deserialize_any(IndexedVecVisitor(std::marker::PhantomData))
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[allow(unused)]
@@ -414,8 +461,35 @@ pub struct GitSettings {
     pub custom_remotes: Option<Vec<CustomRemoteSettings>>,
 }
 
+pub const MIN_PRIORITY: i32 = 1;
+pub const MAX_PRIORITY: i32 = 999;
+pub const DEFAULT_PRIORITY: i32 = 500;
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
+#[allow(unused)]
+pub struct PriorityRule {
+    pub regex: String,
+    pub priority: i32,
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledPriorityRule {
+    pub regex: regex::Regex,
+    pub priority: i32,
+}
+
+impl PriorityRule {
+    pub fn compile(&self) -> Result<CompiledPriorityRule, regex::Error> {
+        let re = regex::Regex::new(&self.regex)?;
+        Ok(CompiledPriorityRule {
+            regex: re,
+            priority: self.priority.clamp(MIN_PRIORITY, MAX_PRIORITY),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
 pub struct ReviewSettings {
     pub concurrency: usize,
@@ -430,6 +504,8 @@ pub struct ReviewSettings {
     pub max_files_touched: usize,
     #[serde(default)]
     pub ignore_files: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_indexed_vec")]
+    pub priority_rules: Vec<PriorityRule>,
     #[serde(default = "default_email_policy_path")]
     pub email_policy_path: String,
     /// Maximum cumulative non-cached tokens (uncached input + output) across all turns in a
@@ -648,5 +724,93 @@ mod tests {
                 std::env::remove_var("XDG_CONFIG_HOME");
             }
         }
+    }
+
+    #[test]
+    fn test_priority_rules_deserialize_toml() {
+        let toml = r#"
+            concurrency = 4
+            worktree_dir = "/tmp/test"
+
+            [[priority_rules]]
+            regex = "^PRODKERNEL:"
+            priority = 750
+
+            [[priority_rules]]
+            regex = "security"
+            priority = 999
+        "#;
+
+        let settings: ReviewSettings = toml::from_str(toml).expect("parse review settings");
+        assert_eq!(settings.priority_rules.len(), 2);
+        assert_eq!(settings.priority_rules[0].regex, "^PRODKERNEL:");
+        assert_eq!(settings.priority_rules[0].priority, 750);
+        assert_eq!(settings.priority_rules[1].regex, "security");
+        assert_eq!(settings.priority_rules[1].priority, 999);
+
+        let compiled = settings.priority_rules[0].compile().expect("compile rule");
+        assert!(compiled.regex.is_match("PRODKERNEL: perf fix"));
+        assert!(!compiled.regex.is_match("staging: driver"));
+        assert_eq!(compiled.priority, 750);
+
+        // Verify clamping of out-of-range priority values
+        let clamped_high = PriorityRule {
+            regex: "test".to_string(),
+            priority: 5000,
+        }
+        .compile()
+        .expect("compile rule");
+        assert_eq!(clamped_high.priority, MAX_PRIORITY);
+
+        let clamped_low = PriorityRule {
+            regex: "test".to_string(),
+            priority: -100,
+        }
+        .compile()
+        .expect("compile rule");
+        assert_eq!(clamped_low.priority, MIN_PRIORITY);
+    }
+
+    #[test]
+    fn test_priority_rules_deserialize_env_map() {
+        let toml_base = r#"
+[review]
+concurrency = 2
+worktree_dir = "/tmp/test"
+"#;
+        let cfg = config::Config::builder()
+            .add_source(config::File::from_str(toml_base, config::FileFormat::Toml))
+            .set_override("review.priority_rules.0.regex", "(?i)^PRODKERNEL:")
+            .expect("set override")
+            .set_override("review.priority_rules.0.priority", 750)
+            .expect("set override")
+            .set_override("review.priority_rules.1.regex", "security")
+            .expect("set override")
+            .set_override("review.priority_rules.1.priority", 999)
+            .expect("set override")
+            .build()
+            .expect("build config");
+
+        #[derive(Debug, Deserialize)]
+        struct TestWrapper {
+            review: ReviewSettings,
+        }
+
+        let wrapper: TestWrapper = cfg.try_deserialize().expect("deserialize config");
+        assert_eq!(wrapper.review.priority_rules.len(), 2);
+        assert_eq!(wrapper.review.priority_rules[0].regex, "(?i)^PRODKERNEL:");
+        assert_eq!(wrapper.review.priority_rules[0].priority, 750);
+        assert_eq!(wrapper.review.priority_rules[1].regex, "security");
+        assert_eq!(wrapper.review.priority_rules[1].priority, 999);
+    }
+
+    #[test]
+    fn test_priority_rules_default_empty() {
+        let toml = r#"
+            concurrency = 2
+            worktree_dir = "/tmp/test"
+        "#;
+        let settings: ReviewSettings = toml::from_str(toml).expect("parse review settings");
+        assert!(settings.priority_rules.is_empty());
     }
 }

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -359,6 +359,46 @@ SPECIFICITY REQUIREMENT: Each inline comment MUST reference the exact function n
         Ok((content, clean))
     }
 
+    /// Append the same per-stage guide files that [`Self::get_stage_prompt`]
+    /// appends, for pipelines that supply their own instruction text via
+    /// `StagePrompt::Override` (which bypasses `get_stage_prompt`).
+    pub async fn append_stage_guides(
+        &self,
+        stage: u8,
+        content: &mut String,
+        clean: &mut String,
+    ) -> Result<()> {
+        let mut clean_files = Vec::new();
+        match stage {
+            3 => {
+                self.append_file(content, &mut clean_files, "callstack.md")
+                    .await?;
+                self.append_file(content, &mut clean_files, "technical-patterns.md")
+                    .await?;
+            }
+            5 => {
+                self.append_file(content, &mut clean_files, "subsystem/locking.md")
+                    .await?;
+            }
+            10 => {
+                self.append_file(content, &mut clean_files, "false-positive-guide.md")
+                    .await?;
+                self.append_file(content, &mut clean_files, "severity.md")
+                    .await?;
+            }
+            11 => {
+                self.append_file(content, &mut clean_files, "inline-template.md")
+                    .await?;
+            }
+            _ => {}
+        }
+        if !clean_files.is_empty() {
+            clean.push_str(&clean_files.join(", "));
+            clean.push_str("\n\n");
+        }
+        Ok(())
+    }
+
     async fn append_file(
         &self,
         buffer: &mut String,
@@ -1634,6 +1674,51 @@ Example:
             history: result.history,
         })
     }
+}
+
+/// Run a single review stage through the shared `SessionRunner` machinery.
+///
+/// Additive helper used by the general pipeline executor (`crate::pipelines`).
+/// It constructs the module-private `ReviewStageSession` exactly like
+/// `Worker::execute_stage`, so alternate pipelines reuse the identical tool
+/// loop, validation, and recitation handling. The default patch-review path
+/// (`Worker::run` / `Worker::execute_stage`) is untouched.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_review_stage(
+    provider: &dyn AiProvider,
+    tools: std::sync::Arc<ToolBox>,
+    temperature: f32,
+    max_interactions: usize,
+    context_tag: Option<&str>,
+    stage: Box<dyn ReviewStage>,
+    system_prompt: String,
+    user_prompt: String,
+    clean_user_prompt: String,
+    progress: Option<&(dyn Fn(WorkerProgressEvent) + Send + Sync)>,
+) -> Result<crate::ai::session::SessionResult<serde_json::Value>> {
+    let stage_num = stage.number();
+    let mut session = ReviewStageSession::new(
+        stage,
+        system_prompt,
+        user_prompt,
+        clean_user_prompt,
+        tools,
+        temperature,
+        context_tag,
+    );
+    let runner = SessionRunner::new(provider)
+        .with_max_validation_attempts(3)
+        .with_max_turns(max_interactions)
+        .with_turn_callback(move |turn, max_turns| {
+            if let Some(cb) = progress {
+                cb(WorkerProgressEvent::StageTurn {
+                    stage: stage_num,
+                    turn,
+                    max_turns,
+                });
+            }
+        });
+    runner.run(&mut session).await
 }
 
 struct StageExecutionResult {

--- a/tests/integration/server_tests.rs
+++ b/tests/integration/server_tests.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use sashiko::api::build_router;
 use sashiko::db::Database;
 use sashiko::events::Event;
-use sashiko::fetcher::FetchRequest;
 use sashiko::settings::{DatabaseSettings, Settings};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -83,14 +82,12 @@ async fn spawn_test_server(read_only: bool) -> TestServer {
     db.migrate().await.unwrap();
 
     let (event_tx, event_rx) = mpsc::channel::<Event>(100);
-    let (fetch_tx, _fetch_rx) = mpsc::channel::<FetchRequest>(100);
 
     let settings = Arc::new(test_settings(read_only));
     let app = build_router(
         settings,
         Arc::clone(&db),
         event_tx,
-        fetch_tx,
         /* allow_all_submit */ true,
         /* smtp_enabled */ false,
         /* dry_run */ true,


### PR DESCRIPTION
On top of #418 and #413 

Add a dedicated review pipeline for cherry-pick merge conflicts, enabling Sashiko to review the correctness of conflict resolutions.

This cherry-pick review pipeline is separate of the review sashiko does and should never affect it. It has being built on top of #413, with a simple interface to define the graph that defines the review.

Commits from 3f8bfb6563f53705c41e4d5585215e8a3906df7e to b091bcad9bf11edd6912e8704b8cd1eae110330c

Some details on the implementation.

- Data model: add review_context column and ReviewKind enum to distinguish patch reviews from cherry-pick reviews.
- Review context types: define CherryPickReviewContext with finding filter for cherry-pick-specific analysis.
- Stage prompts: add 10 prompt templates for cherry-pick review stages (semantic intent, dropped changes, merge correctness, origin classification, etc.).
- CherryPickReviewPipeline: implement the pipeline as a principled Pipeline over the shared stage machinery, running cherry-pick-specific analysis stages alongside shared analysis, dedup, synthesis, and verification.
- Dispatch: route reviews to the cherry-pick pipeline when review_context indicates a cherry-pick.
- Daemon integration: read and forward review context from the daemon into the worker.
- API submit variant: add a cherry-pick submit endpoint that accepts supporting commits and enqueues via enqueue_fetch_with_support()