### PR TITLE
prompts: verify cross-function resource cleanup

### DIFF
--- a/third_party/prompts/kernel/false-positive-guide.md
+++ b/third_party/prompts/kernel/false-positive-guide.md
@@ -166,6 +166,35 @@ the code behaves a certain way, you MUST verify against the actual implementatio
 - Understand subsystem ownership models
   - Output: quote subsystem convention or "no documented model"
 
+### 6.1. Cross-Function Cleanup Verification (MANDATORY)
+
+A resource is not leaked merely because the current function does not release
+it directly. Before retaining a leak concern, inspect every cleanup, unwind,
+destroy, unregister, or release helper reached by the candidate exit path.
+Open the helper body and follow its relevant callees far enough to determine
+what happens to the exact resource. Do not infer behavior from the helper's
+name alone.
+
+For a cleanup helper called conditionally, prove whether the condition is true
+for the path under review. Track the same object, field, reference, descriptor,
+or registration from acquisition through the helper. Account for nested
+cleanup helpers, managed-resource APIs, ownership transfer, and subsystem
+unregister functions that release resources internally.
+
+Retain the concern when concrete code shows that:
+
+- the condition can bypass cleanup on the failing path;
+- the helper releases a different resource or only performs partial cleanup;
+- ownership was never transferred to the component expected to release it; or
+- the relevant helper implementation is unavailable, making the release an
+  unverified assumption rather than proven cleanup.
+
+**Output Verification**:
+- Acquisition: [resource and location]
+- Cleanup call and condition: [helper, location, and evaluated condition]
+- Release or ownership transfer: [exact statement and location, or "not found"]
+- Verdict: [cleanup proven / leak proven / insufficient source context]
+
 ### 7. Order Changes
 **Don't report** order changes unless you can prove:
 - A race condition is introduced


### PR DESCRIPTION
Fixes #124

## Summary

Require Sashiko to inspect cleanup helper implementations before reporting a cross-function resource leak.

## Root cause

The resource-management prompts required ownership tracking across function boundaries, but the final false-positive verification did not explicitly require opening cleanup, unwind, destroy, unregister, or release helpers. A call site could therefore appear to leak a resource even when a conditional helper released it internally.

## Changes

- inspect cleanup helper bodies and relevant callees rather than inferring behavior from names
- evaluate the condition guarding a cleanup call on the exact candidate path
- track the same object, field, reference, descriptor, or registration from acquisition to release
- account for nested helpers, managed resources, ownership transfer, and subsystem unregister behavior
- retain real findings when cleanup is bypassed, partial, applies to another resource, or cannot be verified
- require an auditable acquisition-to-release verdict

## Validation

- confirmed the guide is always loaded during Stage 10 false-positive verification
- `cargo fmt --all -- --check`
- `git diff --check`
- exact one-file cumulative diff
- signed-off commit verified

No model-backed regression or paid API call was used.