### PR TITLE
utils: avoid panics when truncating UTF-8 text

### DIFF
--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -37,6 +37,7 @@ use crate::ai::{
     AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ClassifyAiError,
     ProviderCapabilities, ToolCall,
 };
+use crate::utils::utf8_prefix;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClaudeCliError {
@@ -144,9 +145,7 @@ impl AiProvider for ClaudeCliProvider {
             ))
             .into());
         }
-        let outer: Value = serde_json::from_str(&raw).map_err(|e| {
-            ClaudeCliError::Parse(format!("{}\nRaw: {}", e, &raw[..raw.len().min(200)]))
-        })?;
+        let outer = parse_cli_output(&raw)?;
 
         if outer["is_error"].as_bool().unwrap_or(false) {
             return Err(ClaudeCliError::Cli(
@@ -183,6 +182,11 @@ impl AiProvider for ClaudeCliProvider {
             context_window_size: context_window_for_model(&self.model),
         }
     }
+}
+
+fn parse_cli_output(raw: &str) -> Result<Value, ClaudeCliError> {
+    serde_json::from_str(raw)
+        .map_err(|e| ClaudeCliError::Parse(format!("{}\nRaw: {}", e, utf8_prefix(raw, 200))))
 }
 
 /// Pick the context window to advertise for a given model name. The value is
@@ -442,6 +446,16 @@ mod tests {
     use super::*;
     use crate::ai::{AiMessage, AiRequest, AiResponseFormat, AiRole, AiTool};
     use serde_json::json;
+
+    #[test]
+    fn test_parse_error_preview_handles_multibyte_cutoff() {
+        let raw = format!("{}🙂not-json", "a".repeat(199));
+
+        let error = parse_cli_output(&raw).unwrap_err();
+
+        assert!(matches!(&error, ClaudeCliError::Parse(_)));
+        assert!(error.to_string().contains(&"a".repeat(199)));
+    }
 
     fn make_request(messages: Vec<AiMessage>) -> AiRequest {
         AiRequest {

--- a/src/bin/sashiko-cli.rs
+++ b/src/bin/sashiko-cli.rs
@@ -18,6 +18,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use reqwest::Client;
 use sashiko::api::{PatchsetsResponse, SubmitRequest, SubmitResponse};
 use sashiko::settings::Settings;
+use sashiko::utils::utf8_prefix;
 use serde_json::{Value, from_str};
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
@@ -561,11 +562,7 @@ async fn handle_list(
                     print_colored(status_color, &format!("{:<18}", status_str));
 
                     let subject = item.subject.unwrap_or_else(|| "(no subject)".to_string());
-                    let subject_display = if subject.len() > 48 {
-                        format!("{}...", &subject[..45])
-                    } else {
-                        subject
-                    };
+                    let subject_display = format_subject(&subject);
 
                     let date_display = if let Some(ts) = item.date {
                         format_timestamp(ts)
@@ -592,6 +589,14 @@ async fn handle_list(
     }
 
     Ok(())
+}
+
+fn format_subject(subject: &str) -> String {
+    if subject.len() > 48 {
+        format!("{}...", utf8_prefix(subject, 45))
+    } else {
+        subject.to_string()
+    }
 }
 
 fn review_has_issues(review: &Value) -> bool {
@@ -1993,6 +1998,13 @@ fn format_timestamp(ts: i64) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_format_subject_handles_multibyte_cutoff() {
+        let subject = format!("{}🙂rest", "a".repeat(44));
+
+        assert_eq!(format_subject(&subject), format!("{}...", "a".repeat(44)));
+    }
 
     #[test]
     fn test_count_severities_mixed() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,19 @@ use std::sync::OnceLock;
 static KEY_REGEX: OnceLock<Regex> = OnceLock::new();
 static URL_CRED_REGEX: OnceLock<Regex> = OnceLock::new();
 
+/// Returns the longest prefix of `input` that is valid UTF-8 and no longer
+/// than `max_bytes` bytes.
+///
+/// This is useful when text must fit a byte-limited preview. Direct string
+/// slicing can panic when the byte limit falls inside a multi-byte character.
+pub fn utf8_prefix(input: &str, max_bytes: usize) -> &str {
+    let mut end = input.len().min(max_bytes);
+    while !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    &input[..end]
+}
+
 /// Redacts sensitive information from a string.
 ///
 /// Specifically targets:
@@ -87,6 +100,15 @@ pub fn clean_json_string(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_utf8_prefix_preserves_character_boundaries() {
+        assert_eq!(utf8_prefix("plain text", 5), "plain");
+        assert_eq!(utf8_prefix("abc🙂def", 7), "abc🙂");
+        assert_eq!(utf8_prefix("abc🙂def", 6), "abc");
+        assert_eq!(utf8_prefix("🙂", 0), "");
+        assert_eq!(utf8_prefix("short", 100), "short");
+    }
 
     #[test]
     fn test_redact_gemini_key() {


### PR DESCRIPTION
## Summary

- add a shared UTF-8-safe byte-limited prefix helper
- prevent non-ASCII patch subjects from panicking the list command
- keep malformed Claude CLI output diagnostics from panicking at the preview cutoff

## Root cause

Rust strings must be sliced at UTF-8 character boundaries. The two affected paths sliced user- or provider-controlled text at fixed byte offsets, so a multi-byte character crossing either cutoff caused a panic.

The helper preserves the existing byte limits and backs up only when necessary to return a valid character boundary. ASCII behavior is unchanged.

## Tests

- regression coverage for a patch subject crossing the 45-byte cutoff
- regression coverage for malformed provider output crossing the 200-byte cutoff
- helper coverage for ASCII, exact Unicode boundaries, split Unicode boundaries, zero, and oversized limits
- `cargo fmt --all -- --check`
- `git diff --check`

The local focused Cargo build is blocked before Sashiko compiles because `aws-lc-sys` rejects the available GCC 9.4 toolchain. GitHub Actions is therefore the authoritative compile, Clippy, and test validation for this draft.