### PR TITLE
toolbox: fix panic reading a file that is empty at the revision

### DIFF
--- a/src/toolbox/git_read_files.rs
+++ b/src/toolbox/git_read_files.rs
@@ -163,8 +163,11 @@ impl GitReadFilesTool {
         let lines: Vec<&str> = content.lines().collect();
         let total_lines = lines.len();
 
-        let start_line = start_line.map(|s| s.clamp(1, total_lines));
-        let end_line = end_line.map(|e| e.clamp(1, total_lines));
+        // total_lines is 0 for an empty file, and clamp() panics when its
+        // lower bound exceeds its upper one. The bounds below already handle
+        // the empty case; this pre-clamp only has to avoid tripping over it.
+        let start_line = start_line.map(|s| s.clamp(1, total_lines.max(1)));
+        let end_line = end_line.map(|e| e.clamp(1, total_lines.max(1)));
 
         let (start, end) = match (start_line, end_line) {
             (Some(s), Some(e)) => (s.max(1) - 1, e.min(total_lines)),

--- a/src/toolbox/tools_test.rs
+++ b/src/toolbox/tools_test.rs
@@ -489,4 +489,47 @@ mod tests {
             "git_show returned_items metadata does not match actual lines returned (accounting for warning line)!"
         );
     }
+
+    #[test]
+    fn test_git_read_files_empty_file_with_range() {
+        // Regression: reading a file that is empty at the revision with an
+        // explicit line range must not panic. total_lines is 0 for such a
+        // file, and the bounds clamp used to invert (lower 1 > upper 0).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().to_path_buf();
+
+        let run_git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .current_dir(&repo_path)
+                .args(args)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        };
+
+        run_git(&["init"]);
+        run_git(&["config", "user.name", "Test User"]);
+        run_git(&["config", "user.email", "test@example.com"]);
+        std::fs::write(repo_path.join("empty.txt"), "").unwrap();
+        run_git(&["add", "empty.txt"]);
+        run_git(&["commit", "-m", "Add empty file"]);
+
+        let toolbox = ToolBox::new(repo_path, None);
+        let rt = Runtime::new().unwrap();
+
+        let args = json!({
+            "revision": "HEAD",
+            "files": [
+                { "path": "empty.txt", "start_line": 1, "end_line": 5 }
+            ]
+        });
+        let result = rt.block_on(toolbox.call("git_read_files", args)).unwrap();
+        let results = result["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+
+        let res = &results[0];
+        assert!(res.get("error").is_none(), "unexpected error: {res:?}");
+        assert_eq!(res["content"].as_str().unwrap(), "");
+        assert_eq!(res["total_lines"].as_u64().unwrap(), 0);
+    }
 }


### PR DESCRIPTION
`git_read_files` clamps `start_line` and `end_line` to `[1, total_lines]` before working out the slice bounds. When the file is empty at the requested revision `total_lines` is 0, so the clamp's lower bound is above its upper bound and it panics:

    assertion failed: min <= max, core/src/cmp.rs:1082

This raises the clamp's upper bound to `total_lines.max(1)`, so its lower bound (`1`) can never exceed its upper bound and the clamp cannot panic. Nothing changes for a non-empty file, where `total_lines.max(1)` equals `total_lines`. For an empty file the code after the clamp already handles it: the `match` caps `end` at `total_lines`, the next two lines bring `start` and `end` into range, and the `start >= total_lines` guard returns an empty result instead of slicing.

Removing the two pre-clamp lines would also avoid the panic, but it changes what an out-of-range `start_line` returns (the last line today, an empty result without them), so I kept the smaller change.

The second commit adds a regression test: it reads a file that is empty at the revision with a line range set and checks the tool returns empty content rather than panicking. Without the fix the test aborts on the same assertion.
