### PR TITLE
Add a review_each_push setting to the forge config that lets each push

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -6,6 +6,7 @@ description = ""
 
 [forge]
 enabled = false
+# review_each_push = true
 # provider = "github"
 # api_token = "your-api-token"
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -446,6 +446,7 @@ async fn submit_patch(
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
             {
@@ -500,6 +501,7 @@ async fn submit_patch(
                 .create_fetching_patchset(
                     &clean_msgid,
                     &format!("Fetching thread {}...", clean_msgid),
+                    None,
                     None,
                     None,
                     None,
@@ -1196,8 +1198,19 @@ async fn forge_webhook(
 
     let slug = metadata.pr_url.as_ref().map(|url| {
         let repo = crate::forge::extract_repo_name_from_url(url);
-        format!("{}-{}", repo, metadata.pr_number)
+        if state.settings.forge.review_each_push {
+            let short_head = &metadata.head_sha[..metadata.head_sha.len().min(12)];
+            format!("{}-{}-{}", repo, metadata.pr_number, short_head)
+        } else {
+            format!("{}-{}", repo, metadata.pr_number)
+        }
     });
+
+    let thread_key = if state.settings.forge.review_each_push {
+        Some(format!("mr-{}@sashiko.local", metadata.pr_number))
+    } else {
+        None
+    };
 
     state
         .db
@@ -1210,6 +1223,7 @@ async fn forge_webhook(
             Some(subject),
             Some(metadata.pr_number),
             slug.as_deref(),
+            thread_key.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/src/db.rs
+++ b/src/db.rs
@@ -3711,6 +3711,7 @@ impl Database {
         mr_title: Option<&str>,
         mr_number: Option<i64>,
         slug: Option<&str>,
+        thread_key: Option<&str>,
     ) -> Result<i64> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
@@ -3753,8 +3754,33 @@ impl Database {
             }
         }
 
-        // 2. Ensure a placeholder thread and message exist to satisfy Foreign Key constraints
-        let thread_id = self.ensure_thread_for_message(&root_msg_id, now).await?;
+        // 2. Ensure a placeholder thread and message exist to satisfy Foreign Key constraints.
+        // The thread is anchored on thread_key (per-PR) when grouping pushes, but the
+        // patchset cover_letter_message_id FK still references the per-push root_msg_id,
+        // so that message row must exist under the resolved thread.
+        let thread_anchor = thread_key.unwrap_or(root_msg_id.as_str());
+        let thread_id = self.ensure_thread_for_message(thread_anchor, now).await?;
+
+        if self
+            .get_thread_id_for_message(&root_msg_id)
+            .await?
+            .is_none()
+        {
+            self.create_message(
+                &root_msg_id,
+                thread_id,
+                None,
+                "unknown",
+                "(placeholder)",
+                now,
+                "",
+                "",
+                "",
+                None,
+                None,
+            )
+            .await?;
+        }
 
         // 3. Create the fetching patchset
         let mut rows = self.conn

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -53,6 +53,8 @@ pub struct ForgeSettings {
     pub provider: Option<String>,
     pub webhook_secret: Option<String>,
     pub api_token: Option<String>,
+    #[serde(default)]
+    pub review_each_push: bool,
 }
 
 fn default_true() -> bool {
@@ -486,6 +488,7 @@ fn default_forge() -> ForgeSettings {
         provider: None,
         webhook_secret: None,
         api_token: None,
+        review_each_push: false,
     }
 }
 


### PR DESCRIPTION
to a pull request be reviewed independently, instead of one review per PR. It defaults to false via serde, so existing deployments keep their current behavior.

When enabled:
  - The patchset slug includes the short head SHA (reponame-pr-headsha) so each push maps to its own patchset and its own review.
  - All pushes for a pull request are anchored under one shared thread, keeping the per-PR grouping while each push keeps its own patchset.

Ensure the per-push cover message row exists under the resolved thread so the patchset foreign key is satisfied when a shared thread key is used. Without the flag, the slug, thread, and message behavior are unchanged.