### PR TITLE
Fix cached prompt token accounting

### DIFF
--- a/designs/DESIGN_OPENAI_COMPAT_PROVIDER.md
+++ b/designs/DESIGN_OPENAI_COMPAT_PROVIDER.md
@@ -167,7 +167,7 @@ pub enum OpenAiCompatError {
 | `usage.prompt_tokens` | `prompt_tokens` |
 | `usage.completion_tokens` | `completion_tokens` |
 | `usage.total_tokens` | `total_tokens` |
-| (no cached tokens in standard OpenAI) | `cached_tokens: None` |
+| `usage.prompt_tokens_details.cached_tokens` | `cached_tokens` — a breakdown of `prompt_tokens`, which passes through unchanged. A missing or malformed `prompt_tokens_details` is dropped rather than failing the response; zero, or a count larger than `prompt_tokens`, yields `None`. |
 
 #### `impl AiProvider for OpenAiCompatClient`
 

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -153,8 +153,11 @@ impl AiProvider for CachingAiProvider {
                     fmt_thousands(total)
                 );
                 if let Some(ref mut usage) = resp.usage {
-                    usage.cached_tokens =
-                        Some(usage.cached_tokens.unwrap_or(0) + usage.prompt_tokens);
+                    // The hit serves the whole prompt from this cache, so all
+                    // of it counts as cached.  cached_tokens is a breakdown
+                    // of prompt_tokens rather than an addend.  The count
+                    // recorded with the response covers this same prompt.
+                    usage.cached_tokens = Some(usage.prompt_tokens);
                 }
                 return Ok(resp);
             }

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -292,12 +292,21 @@ fn parse_usage(outer: &Value) -> Option<AiUsage> {
     }
     let input = u["input_tokens"].as_u64().unwrap_or(0) as usize;
     let output = u["output_tokens"].as_u64().unwrap_or(0) as usize;
-    let cached = u["cache_read_input_tokens"].as_u64().unwrap_or(0) as usize;
+    let cache_read = u["cache_read_input_tokens"].as_u64().unwrap_or(0) as usize;
+    let cache_write = u["cache_creation_input_tokens"].as_u64().unwrap_or(0) as usize;
+    // input_tokens arrives without the cached prefix, so the two cache
+    // counts fold back in here.  cached_tokens is a breakdown of
+    // prompt_tokens, and a consumer subtracts it to get uncached input.
+    let total_input = input + cache_read + cache_write;
     Some(AiUsage {
-        prompt_tokens: input,
+        prompt_tokens: total_input,
         completion_tokens: output,
-        total_tokens: input + output,
-        cached_tokens: Some(cached),
+        total_tokens: total_input + output,
+        cached_tokens: if cache_read > 0 {
+            Some(cache_read)
+        } else {
+            None
+        },
     })
 }
 
@@ -535,5 +544,40 @@ mod tests {
 
         let prompt = build_prompt(&req);
         assert!(!prompt.contains("RESPONSE FORMAT"));
+    }
+
+    #[test]
+    fn test_parse_usage_folds_cache_counts_into_prompt_tokens() {
+        let outer = serde_json::json!({
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 19500,
+                "cache_creation_input_tokens": 1000,
+            }
+        });
+
+        let usage = parse_usage(&outer).unwrap();
+
+        // Uncached input is prompt_tokens less the cached breakdown, so it
+        // covers the fresh input and the prefix the model had to write.
+        assert_eq!(usage.prompt_tokens, 21000);
+        assert_eq!(usage.cached_tokens, Some(19500));
+        assert_eq!(usage.total_tokens, 21020);
+    }
+
+    #[test]
+    fn test_parse_usage_without_a_cache_read_reports_no_cached_tokens() {
+        let outer = serde_json::json!({
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 20,
+            }
+        });
+
+        let usage = parse_usage(&outer).unwrap();
+
+        assert_eq!(usage.prompt_tokens, 500);
+        assert_eq!(usage.cached_tokens, None);
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -321,7 +321,11 @@ pub struct AiUsage {
     pub completion_tokens: usize,
     /// Total tokens used (prompt + completion).
     pub total_tokens: usize,
-    /// Optional number of tokens served from cache.
+    /// Number of tokens served from cache.  A breakdown of `prompt_tokens`
+    /// rather than an addend: a consumer subtracts it to get uncached input.
+    /// A provider whose API reports the cached prefix outside its prompt
+    /// total folds it in before filling these fields.  None when the
+    /// provider reports no cache hit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cached_tokens: Option<usize>,
 }

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -22,7 +22,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 
@@ -84,6 +84,7 @@ pub struct OpenAiFunction {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OpenAiResponse {
     pub choices: Vec<OpenAiChoice>,
+    #[serde(default)]
     pub usage: OpenAiUsage,
 }
 
@@ -94,11 +95,43 @@ pub struct OpenAiChoice {
     pub finish_reason: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Every field defaults, and the object itself defaults on the response.
+/// A compatible endpoint reports whichever counts it keeps, and some
+/// report none at all.  The counts are accounting, and losing them costs
+/// less than losing a completion that arrived intact.
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct OpenAiUsage {
+    #[serde(default)]
     pub prompt_tokens: u32,
+    #[serde(default)]
     pub completion_tokens: u32,
+    #[serde(default)]
     pub total_tokens: u32,
+    /// Absent on the many compatible endpoints that do not report cache
+    /// hits.  A value that does not fit the documented shape is dropped
+    /// rather than failing the response.
+    #[serde(
+        default,
+        deserialize_with = "lenient_prompt_tokens_details",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct OpenAiPromptTokensDetails {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u32>,
+}
+
+fn lenient_prompt_tokens_details<'de, D>(
+    deserializer: D,
+) -> Result<Option<OpenAiPromptTokensDetails>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(serde_json::from_value(value).unwrap_or_default())
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -493,11 +526,28 @@ fn translate_ai_response(resp: OpenAiResponse) -> Result<AiResponse> {
         );
     }
 
+    // prompt_tokens already counts the cached prefix, so cached_tokens is a
+    // breakdown of it rather than an addend the way Anthropic reports it.
+    // A larger count means the endpoint reports the prefix alongside the
+    // prompt instead.  Clamping to prompt_tokens leaves the two equal, so a
+    // consumer subtracting for uncached input still gets zero and the token
+    // budget still never trips.  Drop the count instead.
+    let cached = resp
+        .usage
+        .prompt_tokens_details
+        .and_then(|d| d.cached_tokens)
+        .filter(|&c| c <= resp.usage.prompt_tokens)
+        .unwrap_or(0);
+
     let usage = Some(AiUsage {
         prompt_tokens: resp.usage.prompt_tokens as usize,
         completion_tokens: resp.usage.completion_tokens as usize,
         total_tokens: resp.usage.total_tokens as usize,
-        cached_tokens: None,
+        cached_tokens: if cached > 0 {
+            Some(cached as usize)
+        } else {
+            None
+        },
     });
 
     Ok(AiResponse {
@@ -990,6 +1040,7 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
             },
         };
 
@@ -1003,6 +1054,156 @@ mod tests {
         assert_eq!(usage.completion_tokens, 20);
         assert_eq!(usage.total_tokens, 30);
         assert_eq!(usage.cached_tokens, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_cached_tokens() -> Result<()> {
+        let openai_resp = OpenAiResponse {
+            choices: vec![OpenAiChoice {
+                index: 0,
+                message: OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: Some("Hello!".to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: "stop".to_string(),
+            }],
+            usage: OpenAiUsage {
+                prompt_tokens: 2048,
+                completion_tokens: 20,
+                total_tokens: 2068,
+                prompt_tokens_details: Some(OpenAiPromptTokensDetails {
+                    cached_tokens: Some(1920),
+                }),
+            },
+        };
+
+        let usage = translate_ai_response(openai_resp)?.usage.unwrap();
+
+        // prompt_tokens stays whole: the cached count is a breakdown of it,
+        // so uncached input is the difference.
+        assert_eq!(usage.prompt_tokens, 2048);
+        assert_eq!(usage.cached_tokens, Some(1920));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_zero_cached_tokens_is_none() -> Result<()> {
+        let openai_resp = OpenAiResponse {
+            choices: vec![OpenAiChoice {
+                index: 0,
+                message: OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: Some("Hello!".to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: "stop".to_string(),
+            }],
+            usage: OpenAiUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+                prompt_tokens_details: Some(OpenAiPromptTokensDetails {
+                    cached_tokens: Some(0),
+                }),
+            },
+        };
+
+        let usage = translate_ai_response(openai_resp)?.usage.unwrap();
+        assert_eq!(usage.cached_tokens, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_usage_deserializes_without_prompt_tokens_details() -> Result<()> {
+        let usage: OpenAiUsage = serde_json::from_str(
+            r#"{"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}"#,
+        )?;
+        assert!(usage.prompt_tokens_details.is_none());
+
+        let usage: OpenAiUsage = serde_json::from_str(
+            r#"{"prompt_tokens": 2048, "completion_tokens": 20, "total_tokens": 2068,
+                "prompt_tokens_details": {"cached_tokens": 1920, "audio_tokens": 0}}"#,
+        )?;
+        assert_eq!(
+            usage.prompt_tokens_details.and_then(|d| d.cached_tokens),
+            Some(1920)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_usage_tolerates_malformed_prompt_tokens_details() -> Result<()> {
+        for details in [r#"{"cached_tokens": 1920.5}"#, r#""1920""#, "[]", "null"] {
+            let body = format!(
+                r#"{{"prompt_tokens": 2048, "completion_tokens": 20,
+                     "total_tokens": 2068, "prompt_tokens_details": {details}}}"#
+            );
+            let usage: OpenAiUsage = serde_json::from_str(&body)?;
+            let cached = usage.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            assert_eq!(cached, None, "{details}");
+            assert_eq!(usage.prompt_tokens, 2048);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_deserializes_with_usage_missing_or_partial() -> Result<()> {
+        let resp: OpenAiResponse = serde_json::from_str(
+            r#"{"choices": [{"index": 0, "finish_reason": "stop",
+                 "message": {"role": "assistant", "content": "Hello!"}}]}"#,
+        )?;
+        assert_eq!(resp.choices[0].message.content.as_deref(), Some("Hello!"));
+        assert_eq!(resp.usage.prompt_tokens, 0);
+        assert_eq!(resp.usage.total_tokens, 0);
+
+        let resp: OpenAiResponse = serde_json::from_str(
+            r#"{"choices": [{"index": 0, "finish_reason": "stop",
+                 "message": {"role": "assistant", "content": "Hello!"}}],
+                 "usage": {"prompt_tokens": 10}}"#,
+        )?;
+        assert_eq!(resp.usage.prompt_tokens, 10);
+        assert_eq!(resp.usage.completion_tokens, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_translate_response_drops_cached_over_prompt_tokens() -> Result<()> {
+        let openai_resp = OpenAiResponse {
+            choices: vec![OpenAiChoice {
+                index: 0,
+                message: OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: Some("Hello!".to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: "stop".to_string(),
+            }],
+            usage: OpenAiUsage {
+                prompt_tokens: 2048,
+                completion_tokens: 20,
+                total_tokens: 2068,
+                prompt_tokens_details: Some(OpenAiPromptTokensDetails {
+                    cached_tokens: Some(3000),
+                }),
+            },
+        };
+
+        // An endpoint reporting the prefix alongside prompt_tokens offers no
+        // usable breakdown, so the whole prompt stays uncached input.
+        let usage = translate_ai_response(openai_resp)?.usage.unwrap();
+        assert_eq!(usage.cached_tokens, None);
+        assert_eq!(usage.prompt_tokens, 2048);
 
         Ok(())
     }
@@ -1031,6 +1232,7 @@ mod tests {
                 prompt_tokens: 15,
                 completion_tokens: 25,
                 total_tokens: 40,
+                prompt_tokens_details: None,
             },
         };
 
@@ -1056,6 +1258,7 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 0,
                 total_tokens: 10,
+                prompt_tokens_details: None,
             },
         };
 

--- a/static/index.html
+++ b/static/index.html
@@ -2181,9 +2181,6 @@
                     <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path></svg>
                 </a>`;
 
-                let totalTokens = 0;
-                reviews.forEach(r => totalTokens += (r.tokens_in || 0) + (r.tokens_out || 0) + (r.tokens_cached || 0));
-
                 const borderStyle = '';
 
                 let statusHtml = '';
@@ -2837,7 +2834,6 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
             if (!res.ok) throw new Error('Review not found');
             const data = await res.json();
 
-            const totalTokens = (data.tokens_in || 0) + (data.tokens_out || 0) + (data.tokens_cached || 0);
             let logs = [];
             if (Array.isArray(data.logs)) {
                 logs = data.logs;
@@ -3228,7 +3224,9 @@ ${escapeHtml((data.body || '(no body)').replace(/\n+$/, ''), true, false)}${data
                     return !['pending', 'inreview'].includes(s) && !s.includes('failedtoapply');
                 });
 
-                const totalTokensIn = tokenReviews.reduce((acc, r) => acc + (r.tokens_in || 0), 0);
+                // tokens_in counts the cached prefix, so subtract it here to
+                // keep the two cards from reporting the same tokens twice.
+                const totalTokensIn = tokenReviews.reduce((acc, r) => acc + Math.max(0, (r.tokens_in || 0) - (r.tokens_cached || 0)), 0);
                 const totalTokensOut = tokenReviews.reduce((acc, r) => acc + (r.tokens_out || 0), 0);
                 const totalTokensCached = tokenReviews.reduce((acc, r) => acc + (r.tokens_cached || 0), 0);
                 


### PR DESCRIPTION
The OpenAI-compatible path now carries real review traffic, so its
accounting has to match what the Claude path has always reported.
`AiUsage.cached_tokens` did not say whether it counted within
`prompt_tokens` or beside it, and each provider answered differently.
claude.rs folds the cached prefix into `prompt_tokens`. claude-cli
reports it alongside. openai.rs does not report it at all. A consumer
that subtracts `cached_tokens` to derive uncached input is right on one
provider and wrong on the other two.

The contract now sits on the `AiUsage` field itself. `cached_tokens`
is a breakdown of `prompt_tokens` rather than an addend, so a provider
added later meets it on the type rather than in a per-provider
comment. The two providers that disagreed with it, and the response
cache hit path, are corrected to match.

The stats page subtraction comes last for a reason. It is correct only
once every provider counts the prefix within `tokens_in`, and it is
what stops the two Token Usage cards from reporting the same tokens
twice. It also exposes data vintage. Those cards average the last
thousand reviews, so a row claude-cli recorded before this series
reads as zero input until the window turns over. An operator sees that
on a deployment that has just taken the series, and it is not a
regression.
