### PR TITLE
docs: document OrcaRouter as an OpenAI-compatible provider

### DIFF
--- a/Settings.toml
+++ b/Settings.toml
@@ -101,6 +101,12 @@ temperature = 1.0
 # max_input_tokens = 128000
 # max_interactions = 100
 
+# To use OrcaRouter (OpenAI-compatible gateway), also export OPENAI_API_KEY with the API key in the environment
+# provider = "openai-compatible"
+# model = "openai/gpt-4o-mini"
+# max_input_tokens = 128000
+# max_interactions = 100
+
 [ai.claude]
 prompt_caching = true
 # thinking = "enabled"    # Enable extended thinking (or "adaptive" for Sonnet 4.6+)
@@ -111,6 +117,7 @@ prompt_caching = true
 
 # [ai.openai_compat]        # Enable openrouter url
 # base_url = "https://openrouter.ai/api/v1"
+# base_url = "https://api.orcarouter.ai/v1"  # Enable for OrcaRouter
 
 # [ai.vertex]
 # project_id = "my-gcp-project"  # Or set ANTHROPIC_VERTEX_PROJECT_ID env var

--- a/docs/examples/Settings.orcarouter.toml
+++ b/docs/examples/Settings.orcarouter.toml
@@ -1,0 +1,9 @@
+[ai]
+# Can be "openai" or "openai-compatible"
+provider = "openai-compatible"
+model = "openai/gpt-4o-mini"
+
+[ai.openai_compat]
+base_url = "https://api.orcarouter.ai/v1"
+context_window_size = 128000
+max_tokens = 16384

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -325,3 +325,21 @@ base_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"
 context_window_size = 128000
 max_tokens = 16384
 ```
+
+**OrcaRouter example:**
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway to
+models from OpenAI, Anthropic, Google, and other providers behind a single
+endpoint and API key. Point `base_url` at `https://api.orcarouter.ai/v1` and
+use a namespaced model id such as `openai/gpt-4o-mini`:
+
+```toml
+[ai]
+provider = "openai-compatible"
+model = "openai/gpt-4o-mini"
+
+[ai.openai_compat]
+base_url = "https://api.orcarouter.ai/v1"
+context_window_size = 128000
+max_tokens = 16384
+```


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) to the OpenAI-compatible provider documentation, the same way the existing OpenRouter and z.ai examples are shown, so the config reference stays consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Changes

- `docs/llm-providers.md`: add an **OrcaRouter example** block to the "OpenAI-Compatible Providers" section (mirrors the existing z.ai example).
- `Settings.toml`: add a commented OrcaRouter config example next to the existing OpenRouter one.
- `docs/examples/Settings.orcarouter.toml`: new per-provider starter config.

## Usage

```toml
[ai]
provider = "openai-compatible"
model = "openai/gpt-4o-mini"

[ai.openai_compat]
base_url = "https://api.orcarouter.ai/v1"
context_window_size = 128000
max_tokens = 16384
```

Set `OPENAI_API_KEY` (or `LLM_API_KEY`) to your OrcaRouter key. The `https://api.orcarouter.ai/v1` shorthand is recognized by `normalize_base_url` and expanded to `/chat/completions`. Verified live against `https://api.orcarouter.ai/v1/chat/completions` with `openai/gpt-4o-mini` (HTTP 200).
