### PR TITLE
docs: Correct the openai provider values and add OpenAI examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ Core AI settings that apply to all providers.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `provider` | string | -- | LLM provider: `gemini`, `claude`, `claude-cli`, `codex-cli`, `copilot-cli`, `bedrock`, `vertex`, `kiro-cli`, `openai-compat`. |
+| `provider` | string | -- | LLM provider: `gemini`, `claude`, `claude-cli`, `codex-cli`, `copilot-cli`, `bedrock`, `vertex`, `kiro-cli`, `openai`, `openai-compatible`. |
 | `model` | string | -- | Model identifier (provider-specific). |
 | `max_input_tokens` | integer | `150000` | Maximum input tokens per request. |
 | `max_interactions` | integer | `100` | Maximum tool-call rounds per review turn. |
@@ -111,7 +111,7 @@ Settings for the Gemini provider (`provider = "gemini"`).
 
 #### `[ai.openai_compat]`
 
-Settings for OpenAI-compatible providers (`provider = "openai-compat"`).
+Settings for the OpenAI providers (`provider = "openai"` or `provider = "openai-compatible"`).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,9 +115,9 @@ Settings for the OpenAI providers (`provider = "openai"` or `provider = "openai-
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `base_url` | string | -- | API endpoint URL. |
-| `context_window_size` | integer | -- | Context window size (optional). |
-| `max_tokens` | integer | -- | Max output tokens (optional). |
+| `base_url` | string | model-derived | API endpoint URL. Derived from the model name, `https://api.openai.com/v1/chat/completions` for anything unrecognized. |
+| `context_window_size` | integer | model-derived | Context window size. `128000` for most models. |
+| `max_tokens` | integer | `4096` | Max output tokens per response. With `provider = "openai"` it is sent as `max_completion_tokens`, which bounds reasoning tokens as well as the reply. |
 
 #### `[ai.kiro_cli]`
 

--- a/docs/examples/Settings.gpt-5-codex.toml
+++ b/docs/examples/Settings.gpt-5-codex.toml
@@ -1,0 +1,5 @@
+# Codex CLI backend using OpenAI's coding-optimized gpt-5-codex model.
+# Requires the `codex` CLI installed, on $PATH, and authenticated.
+[ai]
+provider = "codex-cli"
+model = "gpt-5-codex"

--- a/docs/examples/Settings.openai-api.toml
+++ b/docs/examples/Settings.openai-api.toml
@@ -1,0 +1,19 @@
+# Direct OpenAI API backend: HTTP calls to https://api.openai.com/v1/chat/completions,
+# no codex CLI. Billed per token against an API key rather than a Codex
+# subscription.
+#
+# The key comes from the environment; there is no TOML field for it:
+#   export OPENAI_API_KEY=sk-...     # LLM_API_KEY is also accepted
+[ai]
+provider = "openai"        # official API path; sends max_completion_tokens
+model = "gpt-5.6-sol"      # the "gpt-5.6" alias resolves here; "gpt-5.6-terra" is cheaper
+
+# The openai provider reads this table too. base_url and context_window_size
+# are optional; set max_tokens as well. It is sent as max_completion_tokens,
+# which on a reasoning model covers reasoning tokens as well as the reply, and
+# it falls back to 4096 when this table is absent. That leaves a reasoning
+# model little room for a reply once it has spent part of the budget thinking.
+[ai.openai_compat]
+max_tokens = 65536             # output cap, sent as max_completion_tokens
+# base_url = "https://api.openai.com/v1/chat/completions"  # auto-derived from model; set only to override
+# context_window_size = 128000   # generic fallback for gpt-5.x; raise to the model's real window

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -240,6 +240,10 @@ subscription -- no per-token charge, no API key.
 cp docs/examples/Settings.codex-cli.toml Settings.toml
 ```
 
+For OpenAI's coding-optimized model, use
+`docs/examples/Settings.gpt-5-codex.toml` instead (same backend,
+`model = "gpt-5-codex"`).
+
 **What you get:**
 
 - Runs `codex exec --json --sandbox read-only` as a stateless backend
@@ -377,3 +381,8 @@ base_url = "https://api.orcarouter.ai/v1"
 context_window_size = 128000
 max_tokens = 16384
 ```
+
+For OpenAI's own API with an API key (rather than a self-hosted
+compatible endpoint), use `docs/examples/Settings.openai-api.toml`:
+set `provider = "openai"`, `model = "gpt-5.6-sol"`, and export
+`OPENAI_API_KEY`.


### PR DESCRIPTION
docs/configuration.md names `openai-compat` as the provider value for the
OpenAI path, in the `[ai]` provider list and again above the
`[ai.openai_compat]` table. `create_provider_from_ai()` matches `openai` and
`openai-compatible`. `openai-compat` falls through to the catch-all and aborts
the run with "Unsupported AI provider", so a reader who follows the reference
cannot start the tool at all. Both accepted values are named now. The table
name itself does not change; it is the TOML key both providers read, not a
provider value.

That same table recorded no defaults for `base_url`, `context_window_size`, or
`max_tokens`, and `max_tokens` is the one a reader cannot guess. With
`provider = "openai"` it is sent as `max_completion_tokens`, which bounds
reasoning tokens as well as the reply, and it falls back to 4096 when the table
is absent. A reasoning model such as gpt-5.6 can spend most of that budget
before it writes any of the reply. All three defaults are filled in so the
fallbacks are readable without the source.

docs/examples/ carried no starting config for either OpenAI setup.
Settings.codex-cli.toml names gpt-4o, so running the codex CLI against the
coding-optimized gpt-5-codex meant editing that file by hand. Nothing targeted
api.openai.com at all: Settings.openai-compat.toml points at a self-hosted
endpoint, and Settings.orcarouter.toml at a third-party gateway.
Settings.gpt-5-codex.toml and Settings.openai-api.toml close both gaps, and
docs/llm-providers.md points at each one from the section it belongs to.

Documentation only. No code changes.
