### PR TITLE
reviewer: Correct how a review's outcome is reported

### DIFF
--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1416,14 +1416,17 @@ impl Reviewer {
                                                     "Failed to queue email for patch {}/{} (ID: {}): {}",
                                                     patchset_id, index, patch_id, e
                                                 );
-                                                db_success = false;
                                             }
                                         }
                                     }
                                 }
                                 if !db_success {
+                                    let _ = ctx.db.update_patch_status(patch_id, "Failed").await;
                                     return Ok(PatchResult::ReviewFailed);
                                 }
+                                // Failing the patchset over a notification
+                                // would strand it: get_pending_patchsets()
+                                // selects only Pending rows.
                                 let _ = ctx.db.update_patch_status(patch_id, "Reviewed").await;
                                 return Ok(PatchResult::Success);
                             } else if ctx.settings.ai.no_ai {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -345,6 +345,7 @@ impl Reviewer {
                 .unwrap_or(&review.patch_message_id);
             Self::queue_notifications(
                 ctx,
+                patchset.id,
                 review.patch_id,
                 &review.patch_message_id,
                 ps_msg_id,
@@ -562,7 +563,10 @@ impl Reviewer {
 
                 // Opt-out logic
                 if skip_regexes.iter().any(|re| re.is_match(_subj)) {
-                    info!("Skipping patch {} (subject matches skip filter)", patch_id);
+                    info!(
+                        "Skipping patch {}/{} (subject matches skip filter)",
+                        patchset_id, index
+                    );
                     should_skip = true;
                 }
 
@@ -572,8 +576,8 @@ impl Reviewer {
                     && !only_regexes.iter().any(|re| re.is_match(_subj))
                 {
                     info!(
-                        "Skipping patch {} (subject does not match any only filter)",
-                        patch_id
+                        "Skipping patch {}/{} (subject does not match any only filter)",
+                        patchset_id, index
                     );
                     should_skip = true;
                 }
@@ -596,8 +600,8 @@ impl Reviewer {
                         || patch_files_count > ctx.settings.review.max_files_touched
                     {
                         info!(
-                            "Skipping patch {} (exceeds size limits: {} lines, {} files)",
-                            patch_id, patch_lines_changed, patch_files_count
+                            "Skipping patch {}/{} (exceeds size limits: {} lines, {} files)",
+                            patchset_id, index, patch_lines_changed, patch_files_count
                         );
                         should_skip = true;
                     }
@@ -1376,8 +1380,8 @@ impl Reviewer {
                                         let mut skip_notify = false;
                                         if let Some(until) = embargo_until.filter(|&u| u > now) {
                                             info!(
-                                                "Review completed but embargoed until {} for patch {}",
-                                                until, patch_id
+                                                "Review completed but embargoed until {} for patch {}/{}",
+                                                until, patchset_id, index
                                             );
                                             skip_notify = true;
                                         }
@@ -1397,6 +1401,7 @@ impl Reviewer {
 
                                             if let Err(e) = Self::queue_notifications(
                                                 ctx,
+                                                patchset_id,
                                                 patch_id,
                                                 patch_msg_id,
                                                 patchset_msg_id,
@@ -1408,17 +1413,18 @@ impl Reviewer {
                                             .await
                                             {
                                                 error!(
-                                                    "Failed to queue email for patch {}: {}",
-                                                    patch_id, e
+                                                    "Failed to queue email for patch {}/{} (ID: {}): {}",
+                                                    patchset_id, index, patch_id, e
                                                 );
                                                 db_success = false;
                                             }
                                         }
                                     }
                                 }
-                                if db_success {
-                                    let _ = ctx.db.update_patch_status(patch_id, "Reviewed").await;
+                                if !db_success {
+                                    return Ok(PatchResult::ReviewFailed);
                                 }
+                                let _ = ctx.db.update_patch_status(patch_id, "Reviewed").await;
                                 return Ok(PatchResult::Success);
                             } else if ctx.settings.ai.no_ai {
                                 info!(
@@ -2119,6 +2125,7 @@ impl Reviewer {
     #[allow(clippy::too_many_arguments)]
     async fn queue_notifications(
         ctx: &ReviewContext,
+        patchset_id: i64,
         patch_id: i64,
         patch_message_id: &str,
         patchset_message_id: &str,
@@ -2330,7 +2337,10 @@ impl Reviewer {
             }
 
             if !sent_positive_review {
-                info!("No issues found for patch {}, skipping email.", patch_id);
+                info!(
+                    "No issues found for patch {}/{} (ID: {}), skipping email.",
+                    patchset_id, index, patch_id
+                );
                 ctx.db
                     .insert_email_outbox(
                         patch_id,
@@ -2349,7 +2359,10 @@ impl Reviewer {
 
         match action {
             EmailAction::Mute => {
-                info!("Email policy muted email for patch {}", patch_id);
+                info!(
+                    "Email policy muted email for patch {}/{} (ID: {})",
+                    patchset_id, index, patch_id
+                );
                 ctx.db
                     .insert_email_outbox(
                         patch_id,
@@ -2475,7 +2488,10 @@ impl Reviewer {
                     )
                     .await?;
 
-                info!("Queued email for patch {}", patch_id);
+                info!(
+                    "Queued email for patch {}/{} (ID: {})",
+                    patchset_id, index, patch_id
+                );
             }
         }
         Ok(())
@@ -3331,6 +3347,7 @@ echo '{"patchset_id": 1, "patches": [{"index": 1, "status": "applied"}]}'
 
         Reviewer::queue_notifications(
             &ctx,
+            ps_id,
             p_id_1,
             "msg_id_p1",
             "msg_id_1",
@@ -3397,6 +3414,7 @@ inline review content\n\n-- \nSashiko AI review · https://sashiko.dev/#/patchse
 
         Reviewer::queue_notifications(
             &ctx,
+            ps_id,
             p_id_2,
             "msg_id_p2",
             "msg_id_1",
@@ -3450,6 +3468,7 @@ inline review content 2\n\n-- \nSashiko AI review · https://sashiko.dev/#/patch
 
         Reviewer::queue_notifications(
             &ctx,
+            ps_id,
             p_id_3,
             "msg_id_p3",
             "msg_id_1",
@@ -3554,6 +3573,7 @@ inline review content 3\n\n-- \nSashiko AI review · https://sashiko.dev/#/patch
 
         Reviewer::queue_notifications(
             &ctx,
+            ps_id,
             p_id_1,
             "msg_id_p1",
             "msg_id_1",
@@ -3598,6 +3618,7 @@ inline review content 3\n\n-- \nSashiko AI review · https://sashiko.dev/#/patch
 
         Reviewer::queue_notifications(
             &ctx,
+            ps_id,
             p_id_2,
             "msg_id_p2",
             "msg_id_1",


### PR DESCRIPTION
Two reporting defects in the reviewer, both in how a review's
outcome reaches the user.

The notification and filter logs identified a patch by its database
row id. A reader watching a review of patchset 34 saw "Email policy
muted email for patch 35" with no way to correlate the two. Every
other surface that names a review uses the patchset id: the
per-request tracing tag, the sashiko-cli show lookup, and the
review-start log. Those logs now use the patchset_id/index form as
well.

The patch row is the second case. When complete_review() cannot
store the outcome, the row kept whatever status it carried while the
review was running. sashiko list then showed the patch as still in
flight. It now reads Failed.

One behavioral change deserves a look during review. A notification
that fails to queue no longer holds the patch row back. Such a patch
reads Reviewed even though no email was ever queued. The review
itself succeeded by then. Failing the patchset instead would strand
it, because get_pending_patchsets() selects only Pending rows. The
cost is that a dropped notification now shows up only in the error
log. No outbox row exists for the send retry to find.
