### PR TITLE
prompts: require proof for missing kernel symbols

### DIFF
--- a/third_party/prompts/kernel/false-positive-guide.md
+++ b/third_party/prompts/kernel/false-positive-guide.md
@@ -63,6 +63,35 @@ Do not confuse **mandatory kernel API error-handling** with "defensive programmi
   - The function naming/documentation doesn't clearly indicate usage constraints
   - Similar kernel APIs validate the same preconditions
 
+### 2.1 Symbol Existence and Linkage Claims
+**Before reporting** that a newly referenced function, macro, type, or global is
+undefined or does not exist:
+
+1. Search for the exact identifier across the full review worktree, not only
+   the files touched by the patch. Read the complete `git_grep` summary and all
+   relevant matches before drawing a conclusion.
+2. Inspect matching declarations, definitions, and exports. A declaration in a
+   header or a definition outside the patched subsystem disproves a claim that
+   the symbol does not exist.
+3. Distinguish three different failures: a missing include or declaration at
+   the call site, a definition excluded by Kconfig or Makefile conditions, and
+   a definition that is unavailable across a module boundary. Do not turn one
+   into a generic "undefined symbol" claim.
+4. For a configuration-dependent finding, name the exact configuration and
+   build/link path that excludes the required definition while compiling the
+   new reference.
+
+If the source search is unavailable, fails, or is incomplete, that is not
+evidence that the identifier is absent. Do not report nonexistence as fact
+without a successful whole-tree search and the concrete declaration/build
+analysis above.
+
+*Output Verification:*
+- Exact identifier searched: [ identifier ]
+- Declaration/definition/export matches: [ locations or "none in complete search" ]
+- Relevant include, Kconfig, Makefile, and module boundary: [ evidence ]
+- Proven failure mode: [ compile, link, module load, or "no failure proven" ]
+
 ### 3. Unverifiable Assumptions
 **Assume the author is wrong** and require proof they are correct
 - Untrusted sources (network/user) always need concrete proof of correctness


### PR DESCRIPTION
Fixes #439

## Summary

Require concrete source and build evidence before a kernel review reports that a referenced symbol does not exist.

## Root cause

The `git_grep` summary added for #357 makes whole-tree matches visible, but #439 shows that presentation alone is not sufficient: the reviewer still claimed two mbcache functions were absent despite clear declarations, definitions, exports, and callers in the supplied results.

This adds a narrow verification boundary to the existing kernel false-positive guide:

- search the exact identifier across the complete review worktree
- inspect declarations, definitions, and exports before asserting absence
- distinguish a genuinely missing symbol from a missing include, Kconfig/Makefile exclusion, or module-linkage problem
- require the exact configuration and build/link path for configuration-dependent findings
- treat an unavailable, failed, or incomplete search as insufficient evidence rather than proof of absence

The output checklist makes the evidence auditable without globally suppressing real undefined-symbol findings.

## Scope

Only `third_party/prompts/kernel/false-positive-guide.md` changes. The grep tool, review pipeline, prompt bundle code, tests, and `REVISION` file are unchanged. No LLM-backed regression test is added.

## Validation

- manually checked the positive and negative reasoning boundaries against the #357 and #439 examples
- `cargo fmt --all -- --check` passes
- `git diff --check` passes
- the cumulative diff contains exactly one prompt file
