### PR TITLE
worker: restore four behaviours lost in the workflow migration

### DIFF
--- a/src/worker/kernel_workflow.rs
+++ b/src/worker/kernel_workflow.rs
@@ -261,10 +261,23 @@ Follow the formatting rules strictly. Do not use markdown headers or ALL CAPS sh
 SPECIFICITY REQUIREMENT: Each inline comment MUST reference the exact function name, file, line number when known, and specific triggering condition. Prefer the finding's `locations` field when present. Do not produce vague summaries like 'potential issue in error handling'. State precisely what goes wrong, where, and under what circumstances. Do not invent line numbers; if the exact line is unavailable, anchor the comment to the nearest verified function or symbol and explain the triggering condition."#;
 
 const STAGE_JSON_SCHEMA_EXAMPLE: &str = r#"
-Return ONLY a JSON object with 'concerns' and 'dismissed_concerns' arrays.
+TodoWrite compatibility: vendored prompts may ask you to add tasks or suspected bugs to TodoWrite. Do not call or mention TodoWrite. Treat those instructions as an internal checklist only. If that checklist identifies a concrete suspected bug, carry it forward as a JSON concern with file, function_or_symbol, line when known, triggering condition, and evidence. Do not output generic checklist progress as a concern.
+
+Once you have gathered sufficient information, return ONLY a JSON object with 'concerns' and 'dismissed_concerns' arrays.
+If you find no concerns and no dismissed concerns, return {"concerns": [], "dismissed_concerns": []}.
 Each object in the 'concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "preexisting", "locations".
-Each object in the 'dismissed_concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "locations".
+- "type": A short category string.
+- "description": A clear description of the problem.
+- "reasoning": A step-by-step explanation.
+- "preexisting": true if this bug already existed in the codebase before these patches were applied, false if the issue was newly introduced by the reviewed patchset.
+- "locations": An array of objects, each containing "file", "function_or_symbol", "line", "code_snippet" and "why_this_location_matters".
+Each object in the 'dismissed_concerns' array MUST use exactly the following keys: "type", "description", "reasoning", "locations". They mean the same as above, except that "description" is the candidate concern that was investigated and disproved, and "reasoning" is the evidence proving it does not apply.
+
+Use the 'dismissed_concerns' array ONLY for candidate concerns that you considered plausible, investigated, and disproved with concrete evidence. This is especially important when you first suspect a concern and then follow the evidence chain proving that it does NOT apply.
+
 SPECIFICITY REQUIREMENT: When reporting a concern or dismissed_concern, cite exact function name(s), file path(s), and line number(s) when known. Do not invent line numbers; use null when exact values are unknown.
+
+CRITICAL REVIEW DIRECTIVE: Do NOT dismiss concerns just because you assume the surrounding system or caller handles it perfectly. Do not be overly charitable to the existing code. If there is a missing initialization, an unhandled edge case, or a brittle logic flow, report it as a concern immediately. Assume the worst-case scenario where external inputs and caller states are malformed.
 
 Example Output:
 ```json
@@ -938,6 +951,27 @@ mod tests {
             assert!(
                 !stage_uses_commit_log(stage),
                 "stage {stage} reviews the diff hunks alone"
+            );
+        }
+    }
+
+    #[test]
+    fn test_analysis_stages_keep_the_guidance_the_schema_alone_does_not_carry() {
+        // The vendored guides still tell the model to use TodoWrite, which no
+        // longer exists, and stage 10 keeps an anti-charity directive of its
+        // own. Both belong to stages 1 to 7 as well.
+        for required in [
+            "Do not call or mention TodoWrite",
+            "Do not be overly charitable to the existing code",
+            "If you find no concerns and no dismissed concerns",
+            "investigated, and disproved with concrete evidence",
+            "\"preexisting\": true if this bug already existed",
+            "\"reasoning\": A step-by-step explanation.",
+            "the candidate concern that was investigated and disproved",
+        ] {
+            assert!(
+                STAGE_JSON_SCHEMA_EXAMPLE.contains(required),
+                "stage 1-7 guidance lost: {required}"
             );
         }
     }

--- a/src/worker/kernel_workflow.rs
+++ b/src/worker/kernel_workflow.rs
@@ -491,12 +491,17 @@ You MUST respond with ONLY a JSON object, no other text. Example:
         .build()
 }
 
+/// Stages 3 to 6 review the diff hunks alone. Every other stage also needs the
+/// commit message, so it gets the git show output with the changelog injected.
+fn stage_uses_commit_log(stage_num: u8) -> bool {
+    !(3..=6).contains(&stage_num)
+}
+
 fn analysis_stage(
     stage_num: u8,
     name: &'static str,
     instruction: &'static str,
     guides: &[&'static str],
-    use_log: bool,
     max_turns: usize,
     temperature: f32,
 ) -> Box<dyn ExecutableStage<KernelReviewState>> {
@@ -510,7 +515,7 @@ fn analysis_stage(
 
     Box::new(
         Stage::builder(name)
-            .system_prompt(kernel_system_prompt(use_log))
+            .system_prompt(kernel_system_prompt(stage_uses_commit_log(stage_num)))
             .user_prompt(user_template)
             .output_format(
                 OutputFormat::json()
@@ -564,7 +569,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_1",
                 STAGE_1_INSTRUCTION,
                 &[],
-                true,
                 max_turns,
                 temperature,
             )),
@@ -573,7 +577,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_2",
                 STAGE_2_INSTRUCTION,
                 &[],
-                true,
                 max_turns,
                 temperature,
             )),
@@ -582,7 +585,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_3",
                 STAGE_3_INSTRUCTION,
                 &["callstack.md", "technical-patterns.md"],
-                false,
                 max_turns,
                 temperature,
             )),
@@ -591,7 +593,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_4",
                 STAGE_4_INSTRUCTION,
                 &[],
-                false,
                 max_turns,
                 temperature,
             )),
@@ -600,7 +601,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_5",
                 STAGE_5_INSTRUCTION,
                 &["subsystem/locking.md"],
-                false,
                 max_turns,
                 temperature,
             )),
@@ -609,7 +609,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_6",
                 STAGE_6_INSTRUCTION,
                 &[],
-                false,
                 max_turns,
                 temperature,
             )),
@@ -618,7 +617,6 @@ pub fn resolve_analysis_stages_with_options(
                 "stage_7",
                 STAGE_7_INSTRUCTION,
                 &[],
-                false,
                 max_turns,
                 temperature,
             )),
@@ -926,6 +924,23 @@ pub fn build_kernel_review_workflow_with_options(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_only_stages_3_to_6_review_the_diff_alone() {
+        // Matches ReviewStage::use_log_in_context, which the workflow replaced.
+        for stage in [1, 2, 7] {
+            assert!(
+                stage_uses_commit_log(stage),
+                "stage {stage} needs the commit message"
+            );
+        }
+        for stage in [3, 4, 5, 6] {
+            assert!(
+                !stage_uses_commit_log(stage),
+                "stage {stage} reviews the diff hunks alone"
+            );
+        }
+    }
 
     #[test]
     fn test_build_workflow_graph_structure() {

--- a/src/worker/kernel_workflow.rs
+++ b/src/worker/kernel_workflow.rs
@@ -131,6 +131,7 @@ If tool output is truncated ('truncated': true), page only if directly relevant 
 
 <global_review_guidelines>
 The following documents contain the official technical patterns, architectural rules, and subsystem-specific guidelines that you MUST adhere to during your review. Use these as the absolute source of truth for identifying anti-patterns and violations.
+@includes
 </global_review_guidelines>
 
 === Active Git Metadata ===

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -667,7 +667,6 @@ impl Worker {
             context_tag: self.context_tag.clone(),
         };
 
-        let manual_stages = self.stages.clone();
         let event_cb = move |event: WorkflowEvent| {
             if let Some(progress_cb) = progress {
                 match event {
@@ -680,17 +679,13 @@ impl Worker {
                             progress_cb(WorkerProgressEvent::StageStarted { stage: num });
                         }
                     }
+                    WorkflowEvent::ParallelResolved { stage_names } => {
+                        progress_cb(WorkerProgressEvent::ReviewStarted {
+                            planned_stages: planned_stages_from(&stage_names),
+                        });
+                    }
                     WorkflowEvent::StageFinished { stage_name, .. } => {
-                        if stage_name == "stage_planning" {
-                            let planned = if let Some(ref manual) = manual_stages {
-                                manual.clone()
-                            } else {
-                                vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-                            };
-                            progress_cb(WorkerProgressEvent::ReviewStarted {
-                                planned_stages: planned,
-                            });
-                        } else if let Some(num) = parse_stage_number(stage_name) {
+                        if let Some(num) = parse_stage_number(stage_name) {
                             progress_cb(WorkerProgressEvent::StageFinished { stage: num });
                         }
                     }
@@ -750,6 +745,20 @@ impl Worker {
             tokens_cached: outcome.tokens_cached,
         })
     }
+}
+
+/// The stages a review will run: the analysis stages the fan-out resolved, then
+/// the four that always follow them. Nothing resolved means nothing planned,
+/// not a bare tail.
+fn planned_stages_from(stage_names: &[&'static str]) -> Vec<u8> {
+    let mut planned: Vec<u8> = stage_names
+        .iter()
+        .filter_map(|n| parse_stage_number(n))
+        .collect();
+    if !planned.is_empty() {
+        planned.extend([8, 9, 10, 11]);
+    }
+    planned
 }
 
 fn parse_stage_number(name: &str) -> Option<u8> {
@@ -1151,6 +1160,16 @@ mod tests {
     use super::*;
     use crate::ai::AiRole;
     use crate::worker::stage::create_stage;
+
+    #[test]
+    fn test_planned_stages_follow_the_resolved_fan_out() {
+        assert_eq!(
+            planned_stages_from(&["stage_1", "stage_2", "stage_5"]),
+            vec![1, 2, 5, 8, 9, 10, 11]
+        );
+        assert_eq!(planned_stages_from(&[]), Vec::<u8>::new());
+        assert_eq!(planned_stages_from(&["stage_planning"]), Vec::<u8>::new());
+    }
 
     #[test]
     fn test_append_stage_dismissed_concerns_preserves_category_type() {

--- a/src/workflow/engine.rs
+++ b/src/workflow/engine.rs
@@ -81,6 +81,11 @@ impl WorkflowEngine {
                     outcome.history.extend(planner_outcome.history);
 
                     let dynamic_stages = resolver(state);
+                    if let Some(cb) = event_cb {
+                        cb(WorkflowEvent::ParallelResolved {
+                            stage_names: dynamic_stages.iter().map(|s| s.name()).collect(),
+                        });
+                    }
                     if !dynamic_stages.is_empty() {
                         execute_parallel_batch(
                             &dynamic_stages,
@@ -384,12 +389,20 @@ mod tests {
             )
             .build();
 
-        let outcome = WorkflowEngine::execute(&workflow, &env, &mut state, None)
+        let resolved = std::sync::Mutex::new(Vec::new());
+        let record = |event: WorkflowEvent| {
+            if let WorkflowEvent::ParallelResolved { stage_names } = event {
+                resolved.lock().unwrap().extend(stage_names);
+            }
+        };
+        let outcome = WorkflowEngine::execute(&workflow, &env, &mut state, Some(&record))
             .await
             .unwrap();
 
         assert_eq!(state.selected_stages, vec![4, 5]);
         assert_eq!(state.concerns.len(), 2);
         assert!(!outcome.early_exit);
+        // The plan is reported as resolved, not guessed from the stage list.
+        assert_eq!(*resolved.lock().unwrap(), vec!["stage_4", "stage_5"]);
     }
 }

--- a/src/workflow/events.rs
+++ b/src/workflow/events.rs
@@ -34,6 +34,9 @@ pub enum WorkflowEvent {
         tokens_out: u32,
         tokens_cached: u32,
     },
+    /// A dynamic fan-out resolved the stages it will run. Emitted whether or
+    /// not the planning stage ran, so a skipped planner still reports a plan.
+    ParallelResolved { stage_names: Vec<&'static str> },
     /// An early-exit condition was satisfied.
     EarlyExitTriggered { reason: &'static str },
     /// The entire workflow has completed.

--- a/src/workflow/prompt.rs
+++ b/src/workflow/prompt.rs
@@ -43,6 +43,48 @@ pub struct PromptTemplate<S> {
     dynamic_inclusions: Vec<DynamicInclusionResolver<S>>,
 }
 
+/// Placeholder for files resolved from state, which carry no path in the
+/// template and so cannot be named by an include directive.
+const DYNAMIC_INCLUDE_MARKER: &str = "@includes";
+
+fn include_directive(path: &Path) -> String {
+    format!("@include(\"{}\")", path.display())
+}
+
+/// A rendered prompt in two kinds of piece. Directives are only ever matched
+/// against `Template`, because a patch under review can contain a directive as
+/// part of its own text and must not be able to place a file.
+enum Segment {
+    Template(String),
+    Included(String),
+}
+
+/// Splits the first template segment holding `directive` and drops `block` in
+/// its place. Returns false when no segment names it, leaving `block` for the
+/// caller to append.
+fn place(segments: &mut Vec<Segment>, directive: &str, block: String) -> bool {
+    for i in 0..segments.len() {
+        let Segment::Template(text) = &segments[i] else {
+            continue;
+        };
+        let Some(pos) = text.find(directive) else {
+            continue;
+        };
+        let before = text[..pos].to_string();
+        let after = text[pos + directive.len()..].to_string();
+        segments.splice(
+            i..=i,
+            [
+                Segment::Template(before),
+                Segment::Included(block),
+                Segment::Template(after),
+            ],
+        );
+        return true;
+    }
+    false
+}
+
 impl<S> PromptTemplate<S> {
     /// Creates a new prompt template from a raw string.
     pub fn new(template: impl Into<String>) -> Self {
@@ -93,47 +135,62 @@ impl<S> PromptTemplate<S> {
 
     /// Renders the expanded prompt for sending to the LLM (expanding file contents).
     pub async fn render_for_model(&self, state: &S, base_dir: &Path) -> Result<String> {
-        let mut buffer = self.substitute_vars(state);
+        let mut segments = vec![Segment::Template(self.raw_template.clone())];
+        let mut trailing = String::new();
 
         for inclusion in &self.static_inclusions {
-            match inclusion {
+            let (path, block) = match inclusion {
                 InclusionDirective::File(path) => {
+                    // A directive naming a file that is not there resolves to
+                    // nothing. It must still be consumed, or it reaches the
+                    // model as literal text.
                     let full_path = base_dir.join(path);
-                    if full_path.exists() {
+                    let block = if full_path.exists() {
                         let content = fs::read_to_string(&full_path)
                             .await
                             .with_context(|| format!("Failed to read file: {:?}", full_path))?;
-                        buffer.push_str(&format!("\n\n# {}\n{}\n", path.display(), content));
-                    }
+                        format!("\n\n# {}\n{}\n", path.display(), content)
+                    } else {
+                        String::new()
+                    };
+                    (path, block)
                 }
                 InclusionDirective::Directory { path, filter } => {
                     let dir_path = base_dir.join(path);
-                    if dir_path.exists() {
-                        let mut entries = fs::read_dir(&dir_path).await?;
-                        let mut file_paths = Vec::new();
-                        while let Some(entry) = entries.next_entry().await? {
-                            let p = entry.path();
-                            if p.extension().is_some_and(|ext| ext == "md")
-                                && let Some(name) = p.file_name().and_then(|n| n.to_str())
-                                && filter(name)
-                            {
-                                file_paths.push(p);
-                            }
-                        }
-                        file_paths.sort();
-                        for file_path in file_paths {
-                            let name = file_path
-                                .strip_prefix(base_dir)
-                                .unwrap_or(&file_path)
-                                .to_string_lossy();
-                            let content = fs::read_to_string(&file_path).await?;
-                            buffer.push_str(&format!("\n\n## {}\n{}\n", name, content));
+                    if !dir_path.exists() {
+                        place(&mut segments, &include_directive(path), String::new());
+                        continue;
+                    }
+                    let mut entries = fs::read_dir(&dir_path).await?;
+                    let mut file_paths = Vec::new();
+                    while let Some(entry) = entries.next_entry().await? {
+                        let p = entry.path();
+                        if p.extension().is_some_and(|ext| ext == "md")
+                            && let Some(name) = p.file_name().and_then(|n| n.to_str())
+                            && filter(name)
+                        {
+                            file_paths.push(p);
                         }
                     }
+                    file_paths.sort();
+                    let mut block = String::new();
+                    for file_path in file_paths {
+                        let name = file_path
+                            .strip_prefix(base_dir)
+                            .unwrap_or(&file_path)
+                            .to_string_lossy();
+                        let content = fs::read_to_string(&file_path).await?;
+                        block.push_str(&format!("\n\n## {}\n{}\n", name, content));
+                    }
+                    (path, block)
                 }
+            };
+            if !place(&mut segments, &include_directive(path), block.clone()) {
+                trailing.push_str(&block);
             }
         }
 
+        let mut dynamic = String::new();
         for dyn_inc in &self.dynamic_inclusions {
             for path in dyn_inc(state) {
                 let full_path = base_dir.join(&path);
@@ -141,42 +198,66 @@ impl<S> PromptTemplate<S> {
                     let content = fs::read_to_string(&full_path)
                         .await
                         .with_context(|| format!("Failed to read dynamic file: {:?}", full_path))?;
-                    buffer.push_str(&format!("\n\n# {}\n{}\n", path.display(), content));
+                    dynamic.push_str(&format!("\n\n# {}\n{}\n", path.display(), content));
                 }
             }
         }
+        if !place(&mut segments, DYNAMIC_INCLUDE_MARKER, dynamic.clone()) {
+            trailing.push_str(&dynamic);
+        }
 
-        Ok(buffer)
+        Ok(self.assemble(segments, trailing, state))
     }
 
     /// Renders the compact prompt for storage in logs/database (keeping `@directives`).
     pub fn render_for_log(&self, state: &S) -> String {
-        let mut buffer = self.substitute_vars(state);
+        let mut segments = vec![Segment::Template(self.raw_template.clone())];
+        let mut trailing = String::new();
 
         for inclusion in &self.static_inclusions {
-            match inclusion {
-                InclusionDirective::File(path) => {
-                    buffer.push_str(&format!("\n\n@{}\n", path.display()));
-                }
+            let (path, token) = match inclusion {
+                InclusionDirective::File(path) => (path, format!("\n\n@{}\n", path.display())),
                 InclusionDirective::Directory { path, .. } => {
-                    buffer.push_str(&format!("\n\n@{}/\n", path.display()));
+                    (path, format!("\n\n@{}/\n", path.display()))
                 }
+            };
+            if !place(&mut segments, &include_directive(path), token.clone()) {
+                trailing.push_str(&token);
             }
         }
 
+        let mut dynamic = String::new();
         for dyn_inc in &self.dynamic_inclusions {
             let files = dyn_inc(state);
             if !files.is_empty() {
                 let tags: Vec<String> = files.iter().map(|p| format!("@{}", p.display())).collect();
-                buffer.push_str(&format!("\n\n{}\n", tags.join(", ")));
+                dynamic.push_str(&format!("\n\n{}\n", tags.join(", ")));
             }
         }
+        if !place(&mut segments, DYNAMIC_INCLUDE_MARKER, dynamic.clone()) {
+            trailing.push_str(&dynamic);
+        }
 
-        buffer
+        self.assemble(segments, trailing, state)
     }
 
-    fn substitute_vars(&self, state: &S) -> String {
-        let mut text = self.raw_template.clone();
+    /// Substitutes variables into the template pieces only, then joins. An
+    /// included file is inserted as it is, and a variable's value is never
+    /// scanned for directives.
+    fn assemble(&self, segments: Vec<Segment>, trailing: String, state: &S) -> String {
+        let mut out = String::new();
+        for segment in segments {
+            match segment {
+                Segment::Template(text) => out.push_str(&self.substitute_vars(&text, state)),
+                Segment::Included(block) => out.push_str(&block),
+            }
+        }
+        out.push_str(&trailing);
+        out
+    }
+
+    fn substitute_vars(&self, text: &str, state: &S) -> String {
+        let mut text = text.to_string();
         for (key, extractor) in &self.vars {
             let pattern = format!("{{{{{}}}}}", key);
             text = text.replace(&pattern, &extractor(state));
@@ -214,6 +295,115 @@ mod tests {
 
         assert_eq!(rendered_model, "Patch diff:\n+int x = 42;");
         assert_eq!(rendered_log, "Patch diff:\n+int x = 42;");
+    }
+
+    #[tokio::test]
+    async fn test_a_directive_for_a_missing_file_is_still_consumed() {
+        // The pre-screen prompt names subsystem.md, which Phase 0 tolerated
+        // being absent. An unexpanded directive would reach the model as text.
+        let temp_dir = tempdir().unwrap();
+        let state = TestState {
+            diff: "foo".to_string(),
+            extra_guides: vec![],
+        };
+
+        let template =
+            PromptTemplate::<TestState>::new("<guides>\n@include(\"absent.md\")\n</guides>")
+                .include_file("absent.md");
+
+        let rendered = template
+            .render_for_model(&state, temp_dir.path())
+            .await
+            .unwrap();
+
+        assert!(
+            !rendered.contains("@include"),
+            "the directive is gone:\n{rendered}"
+        );
+        assert!(rendered.contains("<guides>") && rendered.contains("</guides>"));
+    }
+
+    #[tokio::test]
+    async fn test_a_variable_value_cannot_place_a_file() {
+        // Sashiko reviews arbitrary patches, so a diff can carry a directive as
+        // its own text. Only the template may say where a file goes.
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("locking.md"), "Locking rules")
+            .await
+            .unwrap();
+
+        let state = TestState {
+            diff: "+// @include(\"locking.md\")\n+@includes".to_string(),
+            extra_guides: vec![],
+        };
+
+        let template = PromptTemplate::<TestState>::new("Patch: {{diff}}")
+            .with_var("diff", |s| s.diff.clone())
+            .include_file("locking.md");
+
+        let rendered = template
+            .render_for_model(&state, temp_dir.path())
+            .await
+            .unwrap();
+
+        assert!(
+            rendered.contains("+// @include(\"locking.md\")") && rendered.contains("+@includes"),
+            "a directive in the diff stays text:\n{rendered}"
+        );
+        assert_eq!(
+            rendered.matches("Locking rules").count(),
+            1,
+            "the file is placed once:\n{rendered}"
+        );
+        assert!(
+            rendered.find("+@includes").unwrap() < rendered.find("Locking rules").unwrap(),
+            "and appended, since the template names no place:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_inclusions_render_where_the_template_names_them() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("locking.md"), "Locking rules")
+            .await
+            .unwrap();
+        fs::write(temp_dir.path().join("security.md"), "Security rules")
+            .await
+            .unwrap();
+
+        let state = TestState {
+            diff: "foo".to_string(),
+            extra_guides: vec![PathBuf::from("security.md")],
+        };
+
+        let template = PromptTemplate::<TestState>::new(
+            "<guides>\n@include(\"locking.md\")\n@includes\n</guides>\n\nPatch: {{diff}}",
+        )
+        .with_var("diff", |s| s.diff.clone())
+        .include_file("locking.md")
+        .include_files_from_state(|s| s.extra_guides.clone());
+
+        let rendered = template
+            .render_for_model(&state, temp_dir.path())
+            .await
+            .unwrap();
+
+        let guides_end = rendered.find("</guides>").expect("closing tag survives");
+        assert!(
+            rendered.find("Locking rules").unwrap() < guides_end,
+            "the named file lands inside the block it is named in:\n{rendered}"
+        );
+        assert!(
+            rendered.find("Security rules").unwrap() < guides_end,
+            "the state-resolved file lands at the marker:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("@include(\"locking.md\")") && !rendered.contains("@includes"),
+            "no directive survives into the prompt:\n{rendered}"
+        );
+
+        let logged = template.render_for_log(&state);
+        assert!(logged.find("@locking.md").unwrap() < logged.find("</guides>").unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`designs/DESIGN_DECLARATIVE_AI_WORKFLOWS.md` sets the bar for the migration at "100% behavioral parity with existing review results". These are four places the engine differs from the hand-rolled loop it replaced. The first three change what the model is sent, the fourth what the progress bar is told. None changes the workflow graph.

**Stage 7 lost the commit message.** `use_log_in_context` on `ReviewStage` was true for stages 1, 2 and 7 and false for 3 to 6, as one expression. The workflow states it per stage as a boolean argument, and stage 7 is passed `false`, so it has been reviewing hardware and driver code from the diff hunks alone while its own instruction asks it to judge whether the patch is driver code at all. Rather than flip the one argument I derived the rule from the stage number and deleted the argument, so the seven call sites cannot disagree with each other again.

**Stages 1 to 7 lost five pieces of their instruction.** The old `format_guidance` told the model not to call `TodoWrite` and to carry a suspected bug from that checklist forward as a concern; said what to return when there is nothing to report; gave the meaning of each field; restricted `dismissed_concerns` to candidates investigated and disproved; and told it not to dismiss a concern by assuming the caller handles it. Eleven of the vendored prompts still mention `TodoWrite`, among them `callstack.md`, which stage 3 includes. Stage 10 kept an anti-charity directive of its own, which is why the loss from 1 to 7 reads as an oversight. This keeps the stricter key lists and the `line` and `code_snippet` fields the migration introduced.

**Included files render at the end of the prompt, not where the template puts them.** The design doc says a template's `@include("path")` directives "are expanded inline"; rendering appends instead. Two prompts already depend on the documented behaviour. The system prompt opens `<global_review_guidelines>`, says the documents that follow are the source of truth, and closes it again with nothing in between, while the guides arrive after the patch and the pre-fetched source. And the pre-screen prompt carries a literal `@include("subsystem/subsystem.md")` inside its `<subsystem_guide_index>` tags, which reaches the model as text while the index itself arrives after the patch. A file now renders at its directive when the template has one and is appended when it does not, so a template naming no place behaves as before. The pre-screen prompt needs no change; its directive starts working, and resolves to nothing when the index is absent rather than reaching the model as text. Directives are matched against the template and never against a variable's value, which matters because sashiko reviews arbitrary patches: a diff containing a directive as part of its own text would otherwise place a file into itself.

**The progress bar counts to eleven whatever the plan says.** `ReviewStarted` is emitted when the planner finishes, but the planner is skipped exactly when stages are chosen by hand, and a skipped stage returns before emitting anything, so the branch meant to report a hand-picked list is unreachable. When the planner does run its result is discarded for a hardcoded list of all eleven stages. The list is known where the fan-out resolves it, which happens either way, so it is emitted from there now.

Each commit stands alone and carries a test. A fifth fix belongs with these and is not here: the subsystem guides are dropped on a `--stages` run, so `--stages 1,2,5` sends the model none of the 67 guides under `third_party/prompts/kernel/subsystem/`. Skipping only the planner, as the old code did, breaks four existing tests, because Phase 0 also tolerated a missing `subsystem.md` and a failed response and the stage has neither tolerance, so that fix makes the pre-screen fatal where it used to degrade. How would you want a stage to fail when its failure should not end the review? Given that, this is a small fix on top and I am happy to write it.
