### PR TITLE
RFC: Enable Security Scans

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,19 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -466,7 +466,7 @@ async fn submit_patch(
                 .db
                 .create_fetching_patchset(
                     &format!("{}@sashiko.local", id),
-                    &format!("Fetching {} from {}...", &sha, repo_display),
+                    &format!("Fetching {} from {}...", sha, repo_display),
                     skip_subjects.as_ref(),
                     only_subjects.as_ref(),
                     None,

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -293,7 +293,7 @@ impl FetchAgent {
                         .unwrap_or((None, None, None));
 
                     let article_id = if let Some(number) = mr_number {
-                        format!("mr-{}-{}", number, &commit_or_range)
+                        format!("mr-{}-{}", number, commit_or_range)
                     } else {
                         commit_or_range.clone()
                     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1104,7 +1104,7 @@ fn render_progress(state: &mut ProgressState) {
                             (st, turn)
                         })
                         .collect();
-                    stages_with_turns.sort_by(|a, b| b.1.cmp(&a.1));
+                    stages_with_turns.sort_by_key(|a| std::cmp::Reverse(a.1));
 
                     let (top_stage, top_turn) = stages_with_turns[0];
                     let stage_name = stage_short_name(top_stage);


### PR DESCRIPTION
Hi,

The motivation for this RFC is a continuation of an long-going effort to introduce better CI, scans and checks in the repository.

So far, we have enabled basic CI, integration tests on tag releases, and even dependency bumps.

Now, with the given climate around supply chain attacks, along with the increased visibility and usage of Sashiko, let's enable the use of `cargo-audit` (and eventually `cargo-vet`) to better audit our existing dependencies, and update them when needed.

Here's some sample output for the project:

```
Crate:     h2
Version:   0.3.27
Title:     h2 unbounded empty DATA frames
Date:      2026-08-17
ID:        RUSTSEC-2026-0258
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0258
Solution:  Upgrade to >=0.4.16

Crate:     h2
Version:   0.4.15
Title:     h2 unbounded empty DATA frames
Date:      2026-08-17
ID:        RUSTSEC-2026-0258
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0258
Solution:  Upgrade to >=0.4.16

Crate:     rustls-webpki
Version:   0.101.7
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Crate:     rustls-webpki
Version:   0.101.7
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Crate:     rustls-webpki
Version:   0.101.7
Title:     Reachable panic in certificate revocation list parsing
Date:      2026-04-22
ID:        RUSTSEC-2026-0104
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7

Crate:     rustls-webpki
Version:   0.102.8
Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
Date:      2026-03-20
ID:        RUSTSEC-2026-0049
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
Solution:  Upgrade to >=0.103.10

Crate:     rustls-webpki
Version:   0.102.8
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Crate:     rustls-webpki
Version:   0.102.8
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Crate:     rustls-webpki
Version:   0.102.8
Title:     Reachable panic in certificate revocation list parsing
Date:      2026-04-22
ID:        RUSTSEC-2026-0104
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7

Crate:     bincode
Version:   1.3.3
Warning:   unmaintained
Title:     Bincode is unmaintained
Date:      2025-12-16
ID:        RUSTSEC-2025-0141
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0141

Crate:     rustls-pemfile
Version:   2.2.0
Warning:   unmaintained
Title:     rustls-pemfile is unmaintained
Date:      2025-11-28
ID:        RUSTSEC-2025-0134
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0134

error: 9 vulnerabilities found!
warning: 2 allowed warnings found
```

