### PR TITLE
worker: pass the custom prompt through to the workflow engine

### DIFF
--- a/src/worker/kernel_workflow.rs
+++ b/src/worker/kernel_workflow.rs
@@ -49,6 +49,8 @@ pub struct KernelReviewState {
     pub selected_guides: Vec<String>,
     /// Optional manual stages filter (e.g. `--stages 1,2,5`).
     pub manual_stages: Option<Vec<u8>>,
+    /// Caller-supplied instructions appended to the shared system prompt.
+    pub custom_prompt: Option<String>,
     /// Stages selected by dynamic planning (or overridden by manual_stages).
     pub planned_stages: Vec<u8>,
 
@@ -141,7 +143,7 @@ Baseline SHA: {{{{baseline_sha}}}}
 
 Target Commit:
 {diff_var}
-{{{{prefetched_block}}}}"#
+{{{{prefetched_block}}}}{{{{custom_prompt_block}}}}"#
     ))
     .with_var("target_commit_sha", |s: &KernelReviewState| s.target_commit_sha.clone())
     .with_var("baseline_sha", |s: &KernelReviewState| s.baseline_sha.clone())
@@ -156,6 +158,11 @@ Target Commit:
                 s.prefetched_context
             )
         }
+    })
+    .with_var("custom_prompt_block", |s: &KernelReviewState| {
+        s.custom_prompt.as_deref().map(str::trim).filter(|p| !p.is_empty()).map_or_else(String::new, |p| {
+            format!("\n\n<custom_instructions>\n{p}\n</custom_instructions>")
+        })
     })
     .include_files_from_state(|s: &KernelReviewState| {
         let mut paths = Vec::new();
@@ -982,5 +989,35 @@ mod tests {
         let workflow = build_kernel_review_workflow();
         assert_eq!(workflow.name, "linux_kernel_code_review");
         assert_eq!(workflow.steps.len(), 10);
+    }
+
+    #[test]
+    fn test_custom_prompt_renders_last_and_only_when_it_has_content() {
+        // A non-empty prefetched context, so that closing the prompt is
+        // distinguishable from merely rendering somewhere in it.
+        let render = |custom_prompt| {
+            kernel_system_prompt(true).render_for_log(&KernelReviewState {
+                custom_prompt,
+                prefetched_context: "struct foo { int bar; };".to_string(),
+                ..Default::default()
+            })
+        };
+        let without = render(None);
+
+        for empty in [Some(String::new()), Some("  \n\t ".to_string())] {
+            assert_eq!(
+                render(empty),
+                without,
+                "an empty custom prompt renders nothing"
+            );
+        }
+
+        assert_eq!(
+            render(Some("  Check the locking.  ".to_string())),
+            format!(
+                "{without}\n\n<custom_instructions>\nCheck the locking.\n</custom_instructions>"
+            ),
+            "the custom prompt closes the system prompt"
+        );
     }
 }

--- a/src/worker/prompts.rs
+++ b/src/worker/prompts.rs
@@ -488,6 +488,7 @@ pub struct Worker {
     baseline_sha: Option<String>,
     context_tag: Option<String>,
     stages: Option<Vec<u8>>,
+    custom_prompt: Option<String>,
 }
 
 impl Worker {
@@ -508,6 +509,7 @@ impl Worker {
             baseline_sha: config.baseline_sha,
             context_tag: None,
             stages: config.stages,
+            custom_prompt: config.custom_prompt,
         }
     }
 
@@ -630,6 +632,7 @@ impl Worker {
             follow_up_series_context,
             selected_guides: Vec::new(),
             manual_stages: self.stages.clone(),
+            custom_prompt: self.custom_prompt.clone(),
             planned_stages: Vec::new(),
             all_concerns: Vec::new(),
             all_dismissed_concerns: Vec::new(),


### PR DESCRIPTION
`--custom-prompt` reaches `WorkerConfig` and stops there. Nothing past `Worker::new` reads the field, so once the declarative workflow replaced the hand-rolled pipeline the text has been accepted and silently dropped. `sashiko-cli local -i` feeds a typed rebuttal back through the same option, so re-running after a rebuttal has been reviewing the patch with nothing changed.

Carry it into `KernelReviewState` and render it as a `custom_instructions` block at the end of the shared system prompt, which every stage but the pre-screen uses. The pre-screen selects subsystem guide files rather than reviewing, so it keeps its own prompt. An empty or whitespace-only prompt renders nothing, the same as passing none.

The test renders the real system prompt and compares it byte for byte against the same render with no custom prompt. I checked it fails under five separate breaks of the fix, among them dropping the template placeholder and moving the block ahead of the pre-fetched context.
