### PR TITLE
Take over maintenance of the review repository

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1005,6 +1005,8 @@ async fn get_stats(
     let reviewing = crate::metrics::get_reviewing_patches();
     let messages = crate::metrics::get_messages();
     let patchsets = crate::metrics::get_patchsets();
+    let repo_packs = crate::metrics::get_repo_packs();
+    let repo_pack_bytes = crate::metrics::get_repo_pack_bytes();
 
     Ok(Json(serde_json::json!({
         "status": "ok",
@@ -1012,7 +1014,9 @@ async fn get_stats(
         "pending": pending,
         "reviewing": reviewing,
         "messages": messages,
-        "patchsets": patchsets
+        "patchsets": patchsets,
+        "repo_packs": repo_packs,
+        "repo_pack_bytes": repo_pack_bytes
     })))
 }
 

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -17,7 +17,7 @@ use crate::utils::redact_secret;
 use anyhow::{Result, anyhow};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::process::Stdio;
+use std::process::{Output, Stdio};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, interval};
@@ -418,18 +418,47 @@ impl FetchAgent {
         Ok(())
     }
 
-    async fn fetch_commits(&self, remote: &str, commits: &[String]) -> Result<()> {
-        let mut cmd = Command::new("git");
-        cmd.current_dir(&self.repo_path)
-            .args(crate::git_ops::GIT_PROTOCOL_RESTRICTIONS)
-            .arg("fetch")
-            .arg(remote);
+    /// Runs one `git fetch`, dropping a stale commit-graph and trying
+    /// again when that is what turned the fetch away.  Fetch-pack
+    /// rejects the graph before it opens a connection, so that retry
+    /// repeats no transfer; the wording the commit parse emits can
+    /// come after one, and then the retry pays for it again.  Returns
+    /// git's own output either way; the caller words the failure.
+    async fn fetch_with_graph_retry(&self, args: &[&str]) -> Result<Output> {
+        let mut dropped_graph = false;
 
-        for commit in commits {
-            cmd.arg(commit);
+        loop {
+            let output = Command::new("git")
+                .current_dir(&self.repo_path)
+                .args(crate::git_ops::GIT_PROTOCOL_RESTRICTIONS)
+                .arg("fetch")
+                .args(args)
+                .output()
+                .await?;
+
+            if output.status.success() || dropped_graph {
+                return Ok(output);
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            if !crate::git_ops::is_stale_commit_graph(&stderr) {
+                return Ok(output);
+            }
+
+            warn!("Fetch found a stale commit-graph; dropping it");
+            if let Err(e) = crate::git_ops::drop_commit_graph(&self.repo_path).await {
+                warn!("Failed to drop the commit-graph: {}", e);
+                return Ok(output);
+            }
+            dropped_graph = true;
         }
+    }
 
-        let output = cmd.output().await?;
+    async fn fetch_commits(&self, remote: &str, commits: &[String]) -> Result<()> {
+        let mut args = vec![remote];
+        args.extend(commits.iter().map(String::as_str));
+
+        let output = self.fetch_with_graph_retry(&args).await?;
         if !output.status.success() {
             return Err(anyhow!(
                 "Fetch failed: {}",
@@ -440,12 +469,7 @@ impl FetchAgent {
     }
 
     async fn fetch_all(&self, remote: &str) -> Result<()> {
-        let output = Command::new("git")
-            .current_dir(&self.repo_path)
-            .args(crate::git_ops::GIT_PROTOCOL_RESTRICTIONS)
-            .args(["fetch", remote])
-            .output()
-            .await?;
+        let output = self.fetch_with_graph_retry(&[remote]).await?;
 
         if !output.status.success() {
             return Err(anyhow!(

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -437,6 +437,9 @@ impl FetchAgent {
                 .await?;
 
             if output.status.success() || dropped_graph {
+                if dropped_graph {
+                    crate::git_ops::schedule_commit_graph_rebuild(&self.repo_path);
+                }
                 return Ok(output);
             }
 

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -578,7 +578,8 @@ pub async fn pack_stats(repo_path: &Path) -> Result<(usize, u64)> {
 /// The graph records what the object database holds at the moment of
 /// the walk.  A fetch running beside it costs the graph only the
 /// commits that fetch installs.  A repack is what leaves an entry
-/// with no object behind it, so do not call this where one can run.
+/// with no object behind it, and the object-store lock this takes is
+/// what keeps one out.
 ///
 /// The walk consults the graph already in place, so one naming lost
 /// objects fails the write the way it fails a fetch.  Nothing else
@@ -647,6 +648,46 @@ pub fn schedule_commit_graph_rebuild(repo_path: &Path) {
             error!("Failed to rebuild the commit-graph: {}", e);
         }
     });
+}
+
+/// Rolls the pack directory up into a geometric progression and
+/// writes a multi-pack index over the result.
+///
+/// Loose objects join the rollup.  A fetch carrying fewer objects
+/// than transfer.unpackLimit writes them loose rather than as a pack,
+/// so they are most of what accumulates here.
+///
+/// The pass takes no reachability walk, so it removes no object.  A
+/// commit-graph entry, a worktree, or a scratch clone borrowing from
+/// this store still finds what it named.  Disk goes unreclaimed for
+/// the same reason: an object no ref can reach is rolled up with the
+/// rest.
+pub async fn repack_repository(repo_path: &Path) -> Result<()> {
+    let lock = get_object_store_lock();
+    let _guard = lock.lock().await;
+
+    info!("Repacking {:?}", repo_path);
+    let started = std::time::Instant::now();
+
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["repack", "--geometric=2", "-d", "--write-midx"])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git repack failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    info!(
+        "Repacked {:?} in {:.1}s",
+        repo_path,
+        started.elapsed().as_secs_f64()
+    );
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -726,11 +767,13 @@ fn get_worktree_lock() -> Arc<AsyncMutex<()>> {
         .clone()
 }
 
-/// The lock every pass that walks the shared object store takes: the
-/// commit-graph verify and the commit-graph write.  Two writes
-/// collide on objects/info/commit-graph.lock and one of them dies.
-/// A verify beside a write reads a graph the write is halfway
-/// through replacing.
+/// The lock every pass that walks or rewrites the shared object
+/// store takes: the commit-graph verify, the commit-graph write, and
+/// the repack.  Two writes collide on
+/// objects/info/commit-graph.lock and one of them dies.  A verify
+/// beside a write reads a graph the write is halfway through
+/// replacing.  A walk beside a repack reads the pack directory the
+/// repack is replacing.
 ///
 /// Each pass runs to minutes on a tree the size of Linux, so a
 /// caller can wait that long for the lock.  None of them holds a

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -506,6 +506,14 @@ async fn object_info_dir(repo_path: &Path) -> Result<PathBuf> {
 /// Removes the commit-graph, whole or chained.  The graph is built
 /// from the object database and holds nothing else, so removing it
 /// costs slower revision walks and loses no history.
+///
+/// This takes no object-store lock.  A write ends in a rename, so a
+/// removal racing one leaves either a fresh graph or none, and both
+/// are states the repository is already prepared for.  A fetch
+/// recovering from a stale graph calls here holding a remote lock,
+/// and waiting out a walk under that lock costs more than the race
+/// does.  Callers already holding the lock, such as
+/// write_commit_graph, depend on this staying out.
 pub async fn drop_commit_graph(repo_path: &Path) -> Result<()> {
     let info_dir = object_info_dir(repo_path).await?;
 
@@ -526,28 +534,84 @@ pub async fn drop_commit_graph(repo_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Drops a commit-graph that names commits the object database no
-/// longer holds.  Git reports such a graph as repository corruption
-/// and refuses to fetch, so leaving it in place wedges every remote
-/// until someone removes it by hand.
-pub async fn repair_commit_graph(repo_path: &Path) -> Result<()> {
-    let output = Command::new("git")
+/// Runs one `git commit-graph write`, returning git's own output.
+async fn run_commit_graph_write(repo_path: &Path) -> Result<std::process::Output> {
+    Ok(Command::new("git")
         .current_dir(repo_path)
-        .args(["commit-graph", "verify"])
+        .args(["commit-graph", "write", "--reachable"])
         .output()
-        .await?;
+        .await?)
+}
 
-    if output.status.success() {
-        return Ok(());
+/// Rebuilds the commit-graph from the current object database,
+/// dropping a graph that turns the write away and walking again.
+///
+/// The graph records what the object database holds at the moment of
+/// the walk.  A fetch running beside it costs the graph only the
+/// commits that fetch installs.  A repack is what leaves an entry
+/// with no object behind it, so do not call this where one can run.
+///
+/// The walk consults the graph already in place, so one naming lost
+/// objects fails the write the way it fails a fetch.  Nothing else
+/// here needs that graph, so drop it and rebuild from the object
+/// database alone.  This is the only pass that writes a graph, and
+/// git's verify passes a graph that is merely behind the refs, so
+/// the write cannot be made conditional on one.
+pub async fn write_commit_graph(repo_path: &Path) -> Result<()> {
+    let lock = get_object_store_lock();
+    let _guard = lock.lock().await;
+
+    info!("Writing commit-graph for {:?}", repo_path);
+
+    let mut output = run_commit_graph_write(repo_path).await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if is_stale_commit_graph(&stderr) {
+            warn!(
+                "Commit-graph in {:?} outlived the objects it names; dropping it",
+                repo_path
+            );
+            drop_commit_graph(repo_path).await?;
+            output = run_commit_graph_write(repo_path).await?;
+        }
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    warn!(
-        "Commit-graph in {:?} does not match the object database: {}",
-        repo_path,
-        stderr.lines().next().unwrap_or("").trim()
-    );
-    drop_commit_graph(repo_path).await
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git commit-graph write failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Rebuilds the commit-graph in the background once a recovery has
+/// removed it.
+///
+/// A recovery leaves the repository walking history with no graph
+/// until something writes one back.  The walk takes minutes and every
+/// caller holds a fetch lock, so none of them can wait for it.  A
+/// rebuild already under way stands in for a later one, since it
+/// reads the object database as it finds it.  Call from a tokio
+/// runtime.
+pub fn schedule_commit_graph_rebuild(repo_path: &Path) {
+    static REBUILD_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    let lock = REBUILD_LOCK
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone();
+    let repo_path = repo_path.to_path_buf();
+
+    tokio::spawn(async move {
+        let Ok(_guard) = lock.try_lock() else {
+            info!("A commit-graph rebuild is already running; skipping this one");
+            return;
+        };
+        if let Err(e) = write_commit_graph(&repo_path).await {
+            error!("Failed to rebuild the commit-graph: {}", e);
+        }
+    });
 }
 
 #[allow(dead_code)]
@@ -623,6 +687,22 @@ fn get_global_config_lock() -> Arc<AsyncMutex<()>> {
 fn get_worktree_lock() -> Arc<AsyncMutex<()>> {
     static WORKTREE_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
     WORKTREE_LOCK
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+}
+
+/// The lock every pass that walks the shared object store takes: the
+/// commit-graph verify and the commit-graph write.  Two writes
+/// collide on objects/info/commit-graph.lock and one of them dies.
+/// A verify beside a write reads a graph the write is halfway
+/// through replacing.
+///
+/// Each pass runs to minutes on a tree the size of Linux, so a
+/// caller can wait that long for the lock.  None of them holds a
+/// fetch lock.
+fn get_object_store_lock() -> Arc<AsyncMutex<()>> {
+    static OBJECT_STORE_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    OBJECT_STORE_LOCK
         .get_or_init(|| Arc::new(AsyncMutex::new(())))
         .clone()
 }
@@ -871,6 +951,7 @@ pub async fn ensure_remote(
                         .saturating_sub(started.elapsed())
                         .max(GRAPH_RETRY_FLOOR);
                     attempt = fetch_remote(repo_path, name, &fetch_args, remaining).await;
+                    schedule_commit_graph_rebuild(repo_path);
                 }
                 Err(e) => warn!("Failed to drop the commit-graph: {}", e),
             }

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -627,6 +627,70 @@ fn get_worktree_lock() -> Arc<AsyncMutex<()>> {
         .clone()
 }
 
+/// Git's two wordings for a commit-graph that names a commit the
+/// object database does not hold.  Fetch-pack's negotiation emits
+/// the first.  The second comes from the generic commit parse, which
+/// ref negotiation, a pruning fetch, and the connectivity check all
+/// reach instead.
+const STALE_COMMIT_GRAPH: &[&str] = &[
+    "in the commit graph file but not in the object database",
+    "exists in commit-graph but not in the object database",
+];
+
+/// True when git turned an operation away over a commit-graph that
+/// outlived the objects it names.  Every path that reads the graph
+/// fails this way until the graph is dropped, so a caller that
+/// fetches has a retry worth making.
+pub fn is_stale_commit_graph(message: &str) -> bool {
+    STALE_COMMIT_GRAPH
+        .iter()
+        .any(|wording| message.contains(wording))
+}
+
+/// The least the retry after a graph drop is given, whatever the
+/// first attempt spent.  Fetch-pack rejects the graph before it opens
+/// a connection, but the wording the commit parse emits can arrive
+/// after a long transfer, which leaves nothing of the shared budget.
+/// A retry handed that reports a timeout instead of the recovery it
+/// was, and the graph outlives the cycle.
+const GRAPH_RETRY_FLOOR: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Runs one fetch, returning git's complaint rather than an error
+/// value, since the caller decides which failures are worth a retry.
+async fn fetch_remote(
+    repo_path: &Path,
+    name: &str,
+    args: &[&str],
+    timeout: std::time::Duration,
+) -> std::result::Result<(), String> {
+    let fetch_future = Command::new("git")
+        .current_dir(repo_path)
+        .args(GIT_PROTOCOL_RESTRICTIONS)
+        .args(args)
+        .kill_on_drop(true)
+        .output();
+
+    match tokio::time::timeout(timeout, fetch_future).await {
+        Ok(Ok(fetch)) => {
+            if fetch.status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Failed to fetch remote {}: {}",
+                    name,
+                    String::from_utf8_lossy(&fetch.stderr).trim()
+                ))
+            }
+        }
+        Ok(Err(e)) => Err(format!("Failed to execute git fetch for {}: {}", name, e)),
+        Err(_) => Err(format!(
+            "Git fetch for {} timed out after {} seconds",
+            name,
+            timeout.as_secs()
+        )),
+    }
+}
+
 pub async fn ensure_remote(
     repo_path: &Path,
     name: &str,
@@ -776,13 +840,6 @@ pub async fn ensure_remote(
         }
         fetch_args.push(name);
 
-        let fetch_future = Command::new("git")
-            .current_dir(repo_path)
-            .args(GIT_PROTOCOL_RESTRICTIONS)
-            .args(fetch_args)
-            .kill_on_drop(true)
-            .output();
-
         // Dynamically scale timeout: 30 minutes for heavy initial fetches, 5 minutes for routine updates
         let timeout_duration = if just_added || !head_exists {
             std::time::Duration::from_secs(1800)
@@ -790,28 +847,38 @@ pub async fn ensure_remote(
             std::time::Duration::from_secs(300)
         };
 
-        match tokio::time::timeout(timeout_duration, fetch_future).await {
-            Ok(Ok(fetch)) => {
-                if fetch.status.success() {
-                    fetch_ok = true;
-                } else {
-                    error_msg = format!(
-                        "Failed to fetch remote {}: {}",
-                        name,
-                        String::from_utf8_lossy(&fetch.stderr).trim()
-                    );
+        let started = std::time::Instant::now();
+        let mut attempt = fetch_remote(repo_path, name, &fetch_args, timeout_duration).await;
+
+        // Git reads the commit-graph before it opens a connection, so
+        // a graph naming lost objects fails every remote in the same
+        // way.  Drop it and let this fetch rebuild the answer from the
+        // object database.
+        let stale_graph = attempt
+            .as_ref()
+            .err()
+            .is_some_and(|message| is_stale_commit_graph(message));
+        if stale_graph {
+            warn!("Fetch for {} found a stale commit-graph; dropping it", name);
+            match drop_commit_graph(repo_path).await {
+                Ok(()) => {
+                    // Both attempts come out of the one budget.  This
+                    // holds the remote's lock, and the sync cycle
+                    // walks the remotes one at a time.  The floor is
+                    // what a first attempt that spent the budget
+                    // before it tripped leaves the retry.
+                    let remaining = timeout_duration
+                        .saturating_sub(started.elapsed())
+                        .max(GRAPH_RETRY_FLOOR);
+                    attempt = fetch_remote(repo_path, name, &fetch_args, remaining).await;
                 }
+                Err(e) => warn!("Failed to drop the commit-graph: {}", e),
             }
-            Ok(Err(e)) => {
-                error_msg = format!("Failed to execute git fetch for {}: {}", name, e);
-            }
-            Err(_) => {
-                error_msg = format!(
-                    "Git fetch for {} timed out after {} seconds",
-                    name,
-                    timeout_duration.as_secs()
-                );
-            }
+        }
+
+        match attempt {
+            Ok(()) => fetch_ok = true,
+            Err(message) => error_msg = message,
         }
 
         if !fetch_ok {
@@ -1197,6 +1264,19 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Write;
+
+    #[test]
+    fn test_is_stale_commit_graph_matches_both_wordings() {
+        assert!(is_stale_commit_graph(
+            "error: You are attempting to fetch 1a2b3c, which is in the \
+             commit graph file but not in the object database."
+        ));
+        assert!(is_stale_commit_graph(
+            "fatal: commit 1a2b3c exists in commit-graph but not in the \
+             object database"
+        ));
+        assert!(!is_stale_commit_graph("fatal: couldn't find remote ref"));
+    }
 
     #[tokio::test]
     async fn test_git_ops_extensions() -> Result<()> {

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -478,19 +478,21 @@ pub async fn ensure_gc_disabled(repo_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Locates the directory holding the commit-graph.  It follows the
-/// object directory rather than $GIT_DIR, which is why git resolves
-/// it instead of this function joining the two.
-async fn object_info_dir(repo_path: &Path) -> Result<PathBuf> {
+/// Locates a directory under the object store.  It follows the object
+/// directory rather than $GIT_DIR, which is why git resolves it
+/// instead of this function joining the two.
+async fn object_dir(repo_path: &Path, name: &str) -> Result<PathBuf> {
+    let relative = format!("objects/{}", name);
     let output = Command::new("git")
         .current_dir(repo_path)
-        .args(["rev-parse", "--git-path", "objects/info"])
+        .args(["rev-parse", "--git-path", &relative])
         .output()
         .await?;
 
     if !output.status.success() {
         return Err(anyhow!(
-            "git rev-parse --git-path objects/info failed: {}",
+            "git rev-parse --git-path {} failed: {}",
+            relative,
             String::from_utf8_lossy(&output.stderr).trim()
         ));
     }
@@ -515,7 +517,7 @@ async fn object_info_dir(repo_path: &Path) -> Result<PathBuf> {
 /// does.  Callers already holding the lock, such as
 /// write_commit_graph, depend on this staying out.
 pub async fn drop_commit_graph(repo_path: &Path) -> Result<()> {
-    let info_dir = object_info_dir(repo_path).await?;
+    let info_dir = object_dir(repo_path, "info").await?;
 
     let graph = info_dir.join("commit-graph");
     match tokio::fs::remove_file(&graph).await {
@@ -541,6 +543,33 @@ async fn run_commit_graph_write(repo_path: &Path) -> Result<std::process::Output
         .args(["commit-graph", "write", "--reachable"])
         .output()
         .await?)
+}
+
+/// Counts the pack files in the object store and the bytes they take
+/// up.  Reads the pack directory rather than asking git, so the cost
+/// does not follow the number of loose objects.
+pub async fn pack_stats(repo_path: &Path) -> Result<(usize, u64)> {
+    let pack_dir = object_dir(repo_path, "pack").await?;
+
+    let mut entries = match tokio::fs::read_dir(&pack_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((0, 0)),
+        Err(e) => return Err(anyhow!("Failed to read {:?}: {}", pack_dir, e)),
+    };
+
+    let mut packs = 0usize;
+    let mut bytes = 0u64;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "pack") {
+            packs += 1;
+            if let Ok(meta) = entry.metadata().await {
+                bytes += meta.len();
+            }
+        }
+    }
+
+    Ok((packs, bytes))
 }
 
 /// Rebuilds the commit-graph from the current object database,
@@ -1373,6 +1402,33 @@ mod tests {
              object database"
         ));
         assert!(!is_stale_commit_graph("fatal: couldn't find remote ref"));
+    }
+
+    #[tokio::test]
+    async fn test_pack_stats_counts_only_packs() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let repo_path = temp_dir.path().to_path_buf();
+
+        Command::new("git")
+            .current_dir(&repo_path)
+            .args(["init"])
+            .output()
+            .await?;
+
+        // A repository that has never packed reports nothing.
+        assert_eq!(pack_stats(&repo_path).await?, (0, 0));
+
+        let pack_dir = object_dir(&repo_path, "pack").await?;
+        std::fs::create_dir_all(&pack_dir)?;
+        let mut pack = File::create(pack_dir.join("pack-abc.pack"))?;
+        pack.write_all(b"0123456789")?;
+        File::create(pack_dir.join("pack-abc.idx"))?;
+
+        let (packs, bytes) = pack_stats(&repo_path).await?;
+        assert_eq!(packs, 1);
+        assert_eq!(bytes, 10);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -433,6 +433,51 @@ pub async fn ensure_submodule_config_compat(repo_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Turns off git's own maintenance of the shared repository.
+///
+/// Auto-maintenance detaches from the fetch that triggers it and
+/// repacks while the sync worker keeps fetching, so it can discard
+/// objects a later fetch still names.  Nothing runs gc in its place,
+/// so the packs the repository accumulates are the cost of this.
+///
+/// Every key is attempted whatever the ones before it did, since a
+/// key left at its default is a piece of maintenance still running,
+/// and the error names all of them.  The caller logs and carries on
+/// either way, so the rest of the daemon runs whether or not this
+/// took.
+pub async fn ensure_gc_disabled(repo_path: &Path) -> Result<()> {
+    const KEYS: &[(&str, &str)] = &[
+        ("gc.auto", "0"),
+        ("maintenance.auto", "false"),
+        ("gc.writeCommitGraph", "false"),
+        ("fetch.writeCommitGraph", "false"),
+    ];
+
+    let mut failures = Vec::new();
+    for (key, value) in KEYS {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["config", key, value])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            failures.push(format!(
+                "{} {}: {}",
+                key,
+                value,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(anyhow!("git config failed for {}", failures.join("; ")));
+    }
+
+    Ok(())
+}
+
 #[allow(dead_code)]
 pub async fn cleanup_worktree_dir(worktree_dir: &Path) -> Result<()> {
     if !worktree_dir.exists() {

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -562,6 +562,7 @@ pub async fn write_commit_graph(repo_path: &Path) -> Result<()> {
     let _guard = lock.lock().await;
 
     info!("Writing commit-graph for {:?}", repo_path);
+    let started = std::time::Instant::now();
 
     let mut output = run_commit_graph_write(repo_path).await?;
 
@@ -584,6 +585,11 @@ pub async fn write_commit_graph(repo_path: &Path) -> Result<()> {
         ));
     }
 
+    info!(
+        "Wrote commit-graph for {:?} in {:.1}s",
+        repo_path,
+        started.elapsed().as_secs_f64()
+    );
     Ok(())
 }
 
@@ -951,6 +957,16 @@ pub async fn ensure_remote(
                         .saturating_sub(started.elapsed())
                         .max(GRAPH_RETRY_FLOOR);
                     attempt = fetch_remote(repo_path, name, &fetch_args, remaining).await;
+                    match &attempt {
+                        Ok(()) => info!(
+                            "Fetch for {} succeeded once the commit-graph was gone",
+                            name
+                        ),
+                        Err(message) => warn!(
+                            "Fetch for {} fails with no commit-graph in the way: {}",
+                            name, message
+                        ),
+                    }
                     schedule_commit_graph_rebuild(repo_path);
                 }
                 Err(e) => warn!("Failed to drop the commit-graph: {}", e),

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -478,6 +478,78 @@ pub async fn ensure_gc_disabled(repo_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Locates the directory holding the commit-graph.  It follows the
+/// object directory rather than $GIT_DIR, which is why git resolves
+/// it instead of this function joining the two.
+async fn object_info_dir(repo_path: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["rev-parse", "--git-path", "objects/info"])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git rev-parse --git-path objects/info failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let path = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(repo_path.join(path))
+    }
+}
+
+/// Removes the commit-graph, whole or chained.  The graph is built
+/// from the object database and holds nothing else, so removing it
+/// costs slower revision walks and loses no history.
+pub async fn drop_commit_graph(repo_path: &Path) -> Result<()> {
+    let info_dir = object_info_dir(repo_path).await?;
+
+    let graph = info_dir.join("commit-graph");
+    match tokio::fs::remove_file(&graph).await {
+        Ok(()) => info!("Removed commit-graph {:?}", graph),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(anyhow!("Failed to remove {:?}: {}", graph, e)),
+    }
+
+    let chain = info_dir.join("commit-graphs");
+    match tokio::fs::remove_dir_all(&chain).await {
+        Ok(()) => info!("Removed commit-graph chain {:?}", chain),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(anyhow!("Failed to remove {:?}: {}", chain, e)),
+    }
+
+    Ok(())
+}
+
+/// Drops a commit-graph that names commits the object database no
+/// longer holds.  Git reports such a graph as repository corruption
+/// and refuses to fetch, so leaving it in place wedges every remote
+/// until someone removes it by hand.
+pub async fn repair_commit_graph(repo_path: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["commit-graph", "verify"])
+        .output()
+        .await?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    warn!(
+        "Commit-graph in {:?} does not match the object database: {}",
+        repo_path,
+        stderr.lines().next().unwrap_or("").trim()
+    );
+    drop_commit_graph(repo_path).await
+}
+
 #[allow(dead_code)]
 pub async fn cleanup_worktree_dir(worktree_dir: &Path) -> Result<()> {
     if !worktree_dir.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -847,8 +847,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The walk visits every reachable commit, which runs to minutes
     // on a tree the size of Linux.  Awaiting it here held the sync
     // worker and the reviewer off for that long on every restart.
-    // Run it beside those workers instead.  Auto-maintenance is off,
-    // so nothing repacks underneath the walk.
+    // Run it beside those workers instead.  The repack worker
+    // rewrites the pack directory.  Both passes take the object-store
+    // lock, so it cannot run underneath the walk.
     let graph_repo_path = repo_path.clone();
     tokio::spawn(async move {
         if let Err(e) = sashiko::git_ops::write_commit_graph(&graph_repo_path).await {
@@ -876,6 +877,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let sync_worker = sashiko::worker::sync::GitSyncWorker::new(repo_path.clone());
         tokio::spawn(async move {
             sync_worker.run().await;
+        });
+    }
+
+    // Start Repack Worker
+    {
+        let repack_worker = sashiko::worker::repack::RepackWorker::new(repo_path.clone());
+        tokio::spawn(async move {
+            repack_worker.run().await;
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -839,6 +839,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         error!("Failed to disable git auto-maintenance: {}", e);
     }
 
+    // Recover the object store the way the worktrees above are
+    // recovered.  A commit-graph that outlived the objects it names
+    // fails every fetch until it is removed.
+    if let Err(e) = sashiko::git_ops::repair_commit_graph(&repo_path).await {
+        error!("Failed to check the commit-graph: {}", e);
+    }
+
     if let Some(custom_remotes) = &settings.git.custom_remotes {
         for remote in custom_remotes {
             info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,11 +840,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Recover the object store the way the worktrees above are
-    // recovered.  A commit-graph that outlived the objects it names
-    // fails every fetch until it is removed.
-    if let Err(e) = sashiko::git_ops::repair_commit_graph(&repo_path).await {
-        error!("Failed to check the commit-graph: {}", e);
-    }
+    // recovered.  The write brings the graph up to the refs the last
+    // run left behind, and drops a graph that outlived the objects it
+    // names rather than reporting it.
+    //
+    // The walk visits every reachable commit, which runs to minutes
+    // on a tree the size of Linux.  Awaiting it here held the sync
+    // worker and the reviewer off for that long on every restart.
+    // Run it beside those workers instead.  Auto-maintenance is off,
+    // so nothing repacks underneath the walk.
+    let graph_repo_path = repo_path.clone();
+    tokio::spawn(async move {
+        if let Err(e) = sashiko::git_ops::write_commit_graph(&graph_repo_path).await {
+            error!("Failed to write the commit-graph: {}", e);
+        }
+    });
 
     if let Some(custom_remotes) = &settings.git.custom_remotes {
         for remote in custom_remotes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -886,6 +886,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let metrics_db = db.clone();
+    let metrics_repo_path = repo_path.clone();
     tokio::spawn(async move {
         loop {
             if let Ok(pending) = metrics_db.count_pending_patches().await {
@@ -899,6 +900,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             if let Ok(patchsets) = metrics_db.count_patchsets(None, None).await {
                 sashiko::metrics::set_patchsets(patchsets);
+            }
+            match sashiko::git_ops::pack_stats(&metrics_repo_path).await {
+                Ok((packs, bytes)) => sashiko::metrics::set_repo_packs(packs, bytes),
+                Err(e) => warn!("Failed to count packs in the review repository: {}", e),
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -832,6 +832,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         error!("Failed to ensure submodule config compatibility: {}", e);
     }
 
+    // Auto-maintenance repacks in the background while the sync worker
+    // keeps fetching, which can leave a commit-graph naming objects the
+    // repack removed.
+    if let Err(e) = sashiko::git_ops::ensure_gc_disabled(&repo_path).await {
+        error!("Failed to disable git auto-maintenance: {}", e);
+    }
+
     if let Some(custom_remotes) = &settings.git.custom_remotes {
         for remote in custom_remotes {
             info!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,6 +4,8 @@ pub static PENDING_PATCHES: AtomicUsize = AtomicUsize::new(0);
 pub static REVIEWING_PATCHES: AtomicUsize = AtomicUsize::new(0);
 pub static MESSAGES: AtomicUsize = AtomicUsize::new(0);
 pub static PATCHSETS: AtomicUsize = AtomicUsize::new(0);
+pub static REPO_PACKS: AtomicUsize = AtomicUsize::new(0);
+pub static REPO_PACK_BYTES: AtomicUsize = AtomicUsize::new(0);
 
 pub fn set_pending_patches(count: usize) {
     PENDING_PATCHES.store(count, Ordering::Relaxed);
@@ -21,6 +23,14 @@ pub fn set_patchsets(count: usize) {
     PATCHSETS.store(count, Ordering::Relaxed);
 }
 
+/// Records the size of the review repository's pack directory.  With
+/// git's own maintenance turned off, nothing reclaims packs, so this
+/// is where that cost shows up.
+pub fn set_repo_packs(count: usize, bytes: u64) {
+    REPO_PACKS.store(count, Ordering::Relaxed);
+    REPO_PACK_BYTES.store(bytes as usize, Ordering::Relaxed);
+}
+
 pub fn get_pending_patches() -> usize {
     PENDING_PATCHES.load(Ordering::Relaxed)
 }
@@ -35,4 +45,12 @@ pub fn get_messages() -> usize {
 
 pub fn get_patchsets() -> usize {
     PATCHSETS.load(Ordering::Relaxed)
+}
+
+pub fn get_repo_packs() -> usize {
+    REPO_PACKS.load(Ordering::Relaxed)
+}
+
+pub fn get_repo_pack_bytes() -> usize {
+    REPO_PACK_BYTES.load(Ordering::Relaxed)
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -18,6 +18,7 @@ pub mod kernel_workflow;
 pub mod patchwork;
 pub mod prefetch;
 pub mod prompts;
+pub mod repack;
 pub mod stage;
 pub mod sync;
 

--- a/src/worker/repack.rs
+++ b/src/worker/repack.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::git_ops::repack_repository;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{error, info};
+
+/// How long the worker waits between passes.  What accumulates is
+/// loose objects, and they arrive with every sync cycle rather than
+/// in proportion to what any one fetch carries, so the interval is
+/// what bounds them.  Six hours holds the backlog to a handful of
+/// cycles and leaves the rest of the day without a pass over the
+/// object store.
+const REPACK_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+
+/// How long the worker waits before its first pass.  Startup already
+/// has a commit-graph walk over this object store, and the two cost
+/// more together than apart.  Waiting a whole interval instead would
+/// leave a service that restarts more often than that never packing
+/// at all, and nothing else packs it now that auto-maintenance is
+/// off.
+const FIRST_PASS_DELAY: Duration = Duration::from_secs(15 * 60);
+
+pub struct RepackWorker {
+    repo_path: PathBuf,
+}
+
+impl RepackWorker {
+    pub fn new(repo_path: PathBuf) -> Self {
+        Self { repo_path }
+    }
+
+    pub async fn run(&self) {
+        info!(
+            "RepackWorker started. Will repack every {} hours.",
+            REPACK_INTERVAL.as_secs() / 3600
+        );
+
+        let mut delay = FIRST_PASS_DELAY;
+
+        loop {
+            sleep(delay).await;
+            delay = REPACK_INTERVAL;
+
+            if let Err(e) = repack_repository(&self.repo_path).await {
+                error!("RepackWorker failed to repack: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The sashiko instance I run stopped fetching on August 14. Every
remote failed for a day. Git's auto-maintenance detaches from the fetch that triggers it, so a
repack ran while the sync worker was fetching against the same object
database. It left a commit-graph naming a commit the object database
no longer held. Git treats that as corruption and fails the fetch
before it reaches the network. Restarting the daemon did not clear
it, because startup recovery covers the worktrees and the review
status rather than the object store.

Stop git from maintaining this repository and have the daemon do it.
gc.auto, maintenance.auto, and the two writeCommitGraph keys are set
at startup, so the daemon owns them rather than depending on
repository config edited by hand.

That leaves the daemon responsible for what git used to do, and the
rest of the series supplies it. The commit-graph is written at
startup, since nothing else writes one now and a tree the size of
Linux is slow to walk without one. Pack files are counted on /stats,
because a fetch large enough to keep its pack adds one that nothing
reclaims. The object store is rolled up every six hours, which takes
in the loose objects a smaller fetch unpacks and the pack metric
cannot see.

Recovery has two entry points. A daemon that restarts gets the
startup check. One that stays up would otherwise review against refs
that stop advancing, so a fetch that trips over a stale graph drops
it and retries once. Git words that complaint two ways, from
fetch-pack's negotiation and from the generic commit parse, and the
retry matches either.

The startup write, the fetch-path recovery, and the repack all reach
one object store, and git's own write takes a lock file of its own.
They serialize on a single lock.

The repack walks no reachability, so it removes no object and
reclaims no disk. Reclaiming needs a decision about what is old
enough to expire, which this series does not make.

I realize this amounts to a change in policy. The daemon now decides
when the object store is maintained, and on what schedule, where git
decided before. I am happy to discuss that or to modify it.
