### PR TITLE
prompt_bundle: key the extracted tree on the bundle content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,6 @@ subtle = "2"
 url = "2.5.8"
 percent-encoding = "2.3.2"
 uuid = "1.23.4"
+
+[build-dependencies]
+sha2 = "0.11.0"

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
 use std::io::{self, Write};
@@ -53,11 +54,34 @@ fn main() {
         .trim()
         .to_string();
 
+    // The extracted prompt tree is keyed on this digest rather than on REVISION: local
+    // prompt edits land without bumping REVISION, so a REVISION-keyed cache serves them
+    // stale forever.
+    let mut hasher = Sha256::new();
+    for (relative, absolute) in &files {
+        let bytes = fs::read(absolute).unwrap();
+        hasher.update(relative.as_bytes());
+        hasher.update(b"\0");
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    let digest: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+
     let mut generated_bytes = Vec::new();
     writeln!(
         generated_bytes,
         "pub const PROMPT_BUNDLE_REVISION: &str = {:?};",
         revision
+    )
+    .unwrap();
+    writeln!(
+        generated_bytes,
+        "pub const PROMPT_BUNDLE_DIGEST: &str = {:?};",
+        digest
     )
     .unwrap();
     writeln!(

--- a/src/prompt_bundle.rs
+++ b/src/prompt_bundle.rs
@@ -47,6 +47,8 @@ pub fn install_prompt_bundle(force: bool) -> Result<PathBuf> {
             .with_context(|| format!("failed to write {}", path.display()))?;
     }
 
+    // The directory is named by content digest, so the marker is the only place an
+    // extracted tree records which upstream revision it came from.
     std::fs::write(&marker, PROMPT_BUNDLE_REVISION)
         .with_context(|| format!("failed to write {}", marker.display()))?;
 
@@ -56,7 +58,7 @@ pub fn install_prompt_bundle(force: bool) -> Result<PathBuf> {
 pub fn prompt_bundle_root() -> Result<PathBuf> {
     Ok(data_home()?
         .join("sashiko/prompts")
-        .join(PROMPT_BUNDLE_REVISION))
+        .join(PROMPT_BUNDLE_DIGEST))
 }
 
 fn data_home() -> Result<PathBuf> {
@@ -74,6 +76,25 @@ fn data_home() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn test_prompt_bundle_digest_tracks_bundle_content() {
+        let mut hasher = Sha256::new();
+        for (relative, content) in PROMPT_BUNDLE_FILES {
+            hasher.update(relative.as_bytes());
+            hasher.update(b"\0");
+            hasher.update((content.len() as u64).to_le_bytes());
+            hasher.update(content);
+        }
+        let expected: String = hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect();
+
+        assert_eq!(PROMPT_BUNDLE_DIGEST, expected);
+    }
 
     #[test]
     fn test_prompt_bundle_contains_kernel_review_core() {
@@ -96,7 +117,7 @@ mod tests {
             prompt_bundle_root().unwrap(),
             temp.path()
                 .join("sashiko/prompts")
-                .join(PROMPT_BUNDLE_REVISION)
+                .join(PROMPT_BUNDLE_DIGEST)
         );
 
         unsafe {


### PR DESCRIPTION
## Summary

`prompt_bundle_root()` names the extracted prompt tree after
`third_party/prompts/REVISION`, which records the upstream revision the bundle
was vendored from. Editing a vendored prompt does not move it, and
`install_prompt_bundle()` returns early whenever the completion marker inside
that tree exists, so a rebuild after a prompt edit keeps serving the tree
extracted before the edit. Anyone iterating on the prompts hits this until they
remember `--force`.

This keys the root on a sha256 over the bundle content instead, computed in
`build.rs` and emitted as `PROMPT_BUNDLE_DIGEST`. `REVISION` keeps its other two
jobs, the upstream pin and the content of the marker file an extracted tree
carries.

## One open question

Keying on content means each distinct bundle leaves its own tree under
`$XDG_DATA_HOME/sashiko/prompts/`, and nothing removes the older ones. They
accumulate fastest for the workflow this fixes, someone editing a prompt and
rebuilding. I have not picked a retention policy because I am not sure which one
you would want: drop anything that is not current, keep the last N, or prune only
on an explicit `init --prompts`. Happy to add whichever you prefer, here or as a
follow-up.

## Testing

`make check-pr` passes, with the exception of yamllint, which is not installed on
this machine. This change touches no YAML.

One new test recomputes the hash over `PROMPT_BUNDLE_FILES` and asserts it
matches the generated `PROMPT_BUNDLE_DIGEST`. The existing root test now asserts
the root is named by the digest. End to end, editing a vendored prompt with
`REVISION` untouched changes the digest, and restoring the file changes it back.
