### PR TITLE
nntp: Add TLS support for the news session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +771,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -740,6 +779,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1170,6 +1218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1252,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2656,6 +2724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2753,6 +2840,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3121,6 +3218,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3501,8 +3621,10 @@ dependencies = [
  "libsql",
  "mail-parser",
  "percent-encoding",
+ "rcgen",
  "regex",
  "reqwest",
+ "rustls-native-certs 0.8.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3512,6 +3634,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tiktoken-rs",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "toml",
  "tower-http 0.7.0",
@@ -5021,6 +5144,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,6 +5176,16 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.1",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ libsql = "0.9.29"
 mail-parser = "0.11.3"
 regex = "1.12.2"
 reqwest = { version = "0.13.1", features = ["json"] }
+rustls-native-certs = "0.8.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
@@ -73,6 +74,7 @@ termcolor = "1.4.1"
 thiserror = "2.0.17"
 tiktoken-rs = "0.12.0"
 tokio = { version = "1.52.3", features = ["full"] }
+tokio-rustls = "0.26.4"
 tokio-util = { version = "0.7.17", features = ["codec", "io"] }
 toml = "1.0"
 tower-http = { version = "0.7.0", features = ["cors", "fs", "trace"] }
@@ -86,3 +88,6 @@ subtle = "2"
 url = "2.5.8"
 percent-encoding = "2.3.2"
 uuid = "1.23.4"
+
+[dev-dependencies]
+rcgen = "0.14"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd sashiko
 Copy `Settings.toml` to customize your configuration. For a full reference of every
 setting, see the [Configuration Reference](docs/configuration.md). The default `Settings.toml` includes sections for:
 *   **Database**: SQLite database path (`sashiko.db`).
-*   **NNTP**: Server details and groups to monitor.
+*   **NNTP**: Server details, optional TLS, and groups to monitor.
 *   **AI**: Provider and model selection.
 *   **Server**: API server host and port.
 *   **Git**: Path to the reference kernel repository.

--- a/Settings.toml
+++ b/Settings.toml
@@ -39,6 +39,8 @@ track = ["linux-kernel"]
 [nntp]
 server = "nntp.lore.kernel.org"
 port = 119
+# Wrap the session in TLS (NNTPS). Servers listen for NNTPS on 563.
+# tls = false
 
 # [smtp]
 # **WARNING: BE VERY CAREFUL WHEN ENABLING EMAIL SENDING.**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,12 @@ Optional. Controls forge (GitHub/GitLab) webhook integration.
 |-----|------|---------|-------------|
 | `server` | string | `"nntp.lore.kernel.org"` | NNTP server hostname. |
 | `port` | integer | `119` | NNTP server port. |
+| `tls` | bool | `false` | Wrap the session in TLS (implicit NNTPS). |
+
+Setting `tls` does not change `port`; set it to `563` as well when
+enabling NNTPS. The certificate is verified against the host trust
+store, so an internal CA must be installed there. `lore.kernel.org`
+offers no TLS-protected NNTP, so this is for internal mirrors.
 
 ### `[smtp]`
 

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -60,7 +60,7 @@ impl Ingestor {
                 match NntpClient::connect(
                     &self.settings.nntp.server,
                     self.settings.nntp.port,
-                    false,
+                    self.settings.nntp.tls,
                 )
                 .await
                 {
@@ -335,8 +335,12 @@ impl Ingestor {
     }
 
     async fn process_nntp_cycle(&self) -> Result<()> {
-        let mut client =
-            NntpClient::connect(&self.settings.nntp.server, self.settings.nntp.port, false).await?;
+        let mut client = NntpClient::connect(
+            &self.settings.nntp.server,
+            self.settings.nntp.port,
+            self.settings.nntp.tls,
+        )
+        .await?;
 
         for (name, group_name) in self.get_tracked_groups().await? {
             let group_name = &group_name;
@@ -349,7 +353,7 @@ impl Ingestor {
                     if let Ok(new_client) = NntpClient::connect(
                         &self.settings.nntp.server,
                         self.settings.nntp.port,
-                        false,
+                        self.settings.nntp.tls,
                     )
                     .await
                     {
@@ -430,7 +434,7 @@ impl Ingestor {
                             if let Ok(new_client) = NntpClient::connect(
                                 &self.settings.nntp.server,
                                 self.settings.nntp.port,
-                                false,
+                                self.settings.nntp.tls,
                             )
                             .await
                             {

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -57,7 +57,12 @@ impl Ingestor {
 
         for entry in &self.settings.mailing_lists.track {
             if !entry.contains(':') && !entry.contains('.') && available_groups.is_none() {
-                match NntpClient::connect(&self.settings.nntp.server, self.settings.nntp.port).await
+                match NntpClient::connect(
+                    &self.settings.nntp.server,
+                    self.settings.nntp.port,
+                    false,
+                )
+                .await
                 {
                     Ok(mut client) => match client.list().await {
                         Ok(list) => available_groups = Some(list),
@@ -331,7 +336,7 @@ impl Ingestor {
 
     async fn process_nntp_cycle(&self) -> Result<()> {
         let mut client =
-            NntpClient::connect(&self.settings.nntp.server, self.settings.nntp.port).await?;
+            NntpClient::connect(&self.settings.nntp.server, self.settings.nntp.port, false).await?;
 
         for (name, group_name) in self.get_tracked_groups().await? {
             let group_name = &group_name;
@@ -341,9 +346,12 @@ impl Ingestor {
                 Ok(i) => i,
                 Err(e) => {
                     error!("Failed to select group {}: {}", group_name, e);
-                    if let Ok(new_client) =
-                        NntpClient::connect(&self.settings.nntp.server, self.settings.nntp.port)
-                            .await
+                    if let Ok(new_client) = NntpClient::connect(
+                        &self.settings.nntp.server,
+                        self.settings.nntp.port,
+                        false,
+                    )
+                    .await
                     {
                         client = new_client;
                     }
@@ -422,6 +430,7 @@ impl Ingestor {
                             if let Ok(new_client) = NntpClient::connect(
                                 &self.settings.nntp.server,
                                 self.settings.nntp.port,
+                                false,
                             )
                             .await
                             {

--- a/src/nntp.rs
+++ b/src/nntp.rs
@@ -13,16 +13,27 @@
 // limitations under the License.
 
 use anyhow::{Result, anyhow};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use tracing::{debug, info};
+use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::crypto::CryptoProvider;
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_util::either::Either;
+use tracing::{debug, info, warn};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// The command methods read and write through this, so plaintext and
+/// NNTPS differ only in how `connect` builds the stream.
+type NntpStream = Either<TcpStream, TlsStream<TcpStream>>;
+
 pub struct NntpClient {
-    stream: BufReader<TcpStream>,
+    stream: BufReader<NntpStream>,
     timeout: Duration,
 }
 
@@ -35,13 +46,109 @@ pub struct GroupInfo {
     pub name: String,
 }
 
+/// The crypto provider backing every NNTPS handshake.
+///
+/// Both `ring` and `aws-lc-rs` are linked into this binary by way of
+/// reqwest and lettre. With two providers present rustls cannot pick a
+/// process default on its own, and `ClientConfig::builder()` panics.
+/// Neither crate installs a default; each falls back to its own
+/// provider when none is set. Naming the provider here makes the
+/// choice local rather than a process-wide one for this module alone.
+fn crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(tokio_rustls::rustls::crypto::aws_lc_rs::default_provider())
+}
+
+/// Trust anchors come from the host certificate store, so an internal
+/// CA is installed by the deployment rather than named in the config.
+///
+/// The ingestor reconnects every cycle, so a usable config is built
+/// once and cached. A failure is not cached. The host trust store can
+/// be populated after this process starts, and a cached error would
+/// fail every later cycle until a restart.
+async fn native_tls_config() -> Result<Arc<ClientConfig>> {
+    static CONFIG: OnceLock<Arc<ClientConfig>> = OnceLock::new();
+
+    if let Some(config) = CONFIG.get() {
+        return Ok(config.clone());
+    }
+
+    // Loading the store walks the certificate directory with blocking
+    // file I/O, so it runs off the executor thread.
+    let loaded = tokio::task::spawn_blocking(rustls_native_certs::load_native_certs)
+        .await
+        .map_err(|e| anyhow!("certificate loader panicked: {}", e))?;
+    for error in &loaded.errors {
+        warn!("Ignoring unreadable system certificate: {}", error);
+    }
+
+    let mut roots = RootCertStore::empty();
+    let (added, ignored) = roots.add_parsable_certificates(loaded.certs);
+    debug!("Loaded {} system certificates ({} ignored)", added, ignored);
+    // An empty root store does not fail here; the handshake then fails
+    // with an opaque UnknownIssuer alert.
+    if added == 0 {
+        return Err(anyhow!(
+            "no usable system certificate found; install the CA in the host trust store"
+        ));
+    }
+
+    let config = client_config(roots)?;
+    Ok(CONFIG.get_or_init(|| Arc::new(config)).clone())
+}
+
+/// The one builder chain for every client config, so the TLS test
+/// exercises the same protocol and provider choices as production.
+fn client_config(roots: RootCertStore) -> Result<ClientConfig> {
+    Ok(ClientConfig::builder_with_provider(crypto_provider())
+        .with_safe_default_protocol_versions()
+        .map_err(|e| anyhow!("TLS protocol versions rejected: {}", e))?
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
 impl NntpClient {
-    pub async fn connect(host: &str, port: u16) -> Result<Self> {
+    /// Connect to `host`, wrapping the session in TLS when `tls` is
+    /// set. NNTPS is implicit. The handshake completes before the
+    /// server sends its greeting.
+    pub async fn connect(host: &str, port: u16, tls: bool) -> Result<Self> {
+        let tls_config = if tls {
+            Some(native_tls_config().await?)
+        } else {
+            None
+        };
+        Self::connect_with_tls_config(host, port, tls_config).await
+    }
+
+    pub(crate) async fn connect_with_tls_config(
+        host: &str,
+        port: u16,
+        tls_config: Option<Arc<ClientConfig>>,
+    ) -> Result<Self> {
         let addr = format!("{}:{}", host, port);
-        info!("Connecting to NNTP server at {}", addr);
-        let stream = timeout(DEFAULT_TIMEOUT, TcpStream::connect(addr))
+        info!(
+            "Connecting to NNTP server at {} (tls: {})",
+            addr,
+            tls_config.is_some()
+        );
+        let tcp = timeout(DEFAULT_TIMEOUT, TcpStream::connect(addr))
             .await
             .map_err(|_| anyhow!("Connection timed out"))??;
+
+        let stream = match tls_config {
+            Some(config) => {
+                let server_name = ServerName::try_from(host.to_string())
+                    .map_err(|_| anyhow!("Not a valid TLS server name: {}", host))?;
+                let stream = timeout(
+                    DEFAULT_TIMEOUT,
+                    TlsConnector::from(config).connect(server_name, tcp),
+                )
+                .await
+                .map_err(|_| anyhow!("TLS handshake timed out"))??;
+                Either::Right(stream)
+            }
+            None => Either::Left(tcp),
+        };
+
         let mut reader = BufReader::new(stream);
 
         let mut buf = Vec::new();
@@ -196,6 +303,11 @@ impl NntpClient {
         if !response.starts_with("205") {
             debug!("QUIT response was not 205: {}", response);
         }
+        // Dropping a TlsStream sends no close_notify; only shutdown
+        // does. Either forwards poll_shutdown to whichever side it holds.
+        if let Err(e) = self.stream.get_mut().shutdown().await {
+            debug!("Shutdown after QUIT failed: {}", e);
+        }
         Ok(())
     }
 }
@@ -203,8 +315,12 @@ impl NntpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use std::sync::Arc;
+    use tokio::io::{AsyncRead, AsyncWrite};
     use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
+    use tokio_rustls::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio_rustls::rustls::{RootCertStore, ServerConfig};
 
     #[tokio::test]
     async fn article_preserves_payload_whitespace_and_framing() {
@@ -245,7 +361,7 @@ lf-only \t\n\
                 .unwrap();
         });
 
-        let mut client = NntpClient::connect("127.0.0.1", address.port())
+        let mut client = NntpClient::connect("127.0.0.1", address.port(), false)
             .await
             .unwrap();
         let article_result = client.article("<issue-320@example.test>").await;
@@ -299,7 +415,7 @@ lf-only \t\n\
                 .unwrap();
         });
 
-        let mut client = NntpClient::connect("127.0.0.1", address.port())
+        let mut client = NntpClient::connect("127.0.0.1", address.port(), false)
             .await
             .unwrap();
         let err = client.group("org.kernel.vger.linux-nfs").await.unwrap_err();
@@ -308,5 +424,94 @@ lf-only \t\n\
         assert!(err.to_string().contains(
             "Mismatched GROUP response: expected org.kernel.vger.linux-nfs, got org.kvack.linux-mm"
         ));
+    }
+
+    /// The last line is dot-stuffed on the wire, so a client that
+    /// forgets to unstuff it returns two leading dots.
+    const ARTICLE_LINES: &[&str] = &[
+        "From: someone@example.com",
+        "Subject: [PATCH] test",
+        "",
+        ".signature",
+    ];
+
+    /// Speak just enough NNTP to serve one ARTICLE and a QUIT.
+    async fn serve_one<S>(stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut stream = BufReader::new(stream);
+        stream.write_all(b"201 test server ready\r\n").await?;
+        stream.flush().await?;
+
+        loop {
+            let mut line = Vec::new();
+            if stream.read_until(b'\n', &mut line).await? == 0 {
+                break;
+            }
+            let command = String::from_utf8_lossy(&line).trim().to_string();
+
+            if command.starts_with("ARTICLE") {
+                stream
+                    .write_all(b"220 1 <test@example.com> article\r\n")
+                    .await?;
+                for line in ARTICLE_LINES {
+                    if line.starts_with('.') {
+                        stream.write_all(b".").await?;
+                    }
+                    stream.write_all(line.as_bytes()).await?;
+                    stream.write_all(b"\r\n").await?;
+                }
+                stream.write_all(b".\r\n").await?;
+                stream.flush().await?;
+            } else if command.starts_with("QUIT") {
+                stream.write_all(b"205 closing connection\r\n").await?;
+                stream.flush().await?;
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tls_article_round_trip() {
+        let issued = rcgen::generate_simple_self_signed(vec!["127.0.0.1".to_string()]).unwrap();
+        let cert = issued.cert.der().clone();
+        let key =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(issued.signing_key.serialize_der()));
+
+        let server_config = ServerConfig::builder_with_provider(crypto_provider())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert.clone()], key)
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let stream = acceptor.accept(socket).await.unwrap();
+            serve_one(stream).await.unwrap();
+        });
+
+        // Trust only the certificate the test server just minted, so the
+        // handshake exercises real verification rather than skipping it.
+        let mut roots = RootCertStore::empty();
+        roots.add(cert).unwrap();
+
+        let mut client = NntpClient::connect_with_tls_config(
+            &addr.ip().to_string(),
+            addr.port(),
+            Some(Arc::new(client_config(roots).unwrap())),
+        )
+        .await
+        .expect("TLS connect");
+
+        assert_eq!(client.article("1").await.unwrap(), ARTICLE_LINES);
+        client.quit().await.unwrap();
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -73,6 +73,10 @@ pub struct DatabaseSettings {
 pub struct NntpSettings {
     pub server: String,
     pub port: u16,
+    /// Implicit NNTPS. The server port is set separately, so an
+    /// operator turning this on also moves `port` to 563.
+    #[serde(default)]
+    pub tls: bool,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -622,6 +626,20 @@ mod tests {
             Settings::local_review_path_in(temp.path()),
             temp.path().join("Settings.toml")
         );
+    }
+
+    #[test]
+    fn test_nntp_tls_defaults_to_off() {
+        let nntp: NntpSettings =
+            toml::from_str("server = \"nntp.lore.kernel.org\"\nport = 119\n").unwrap();
+        assert!(!nntp.tls);
+    }
+
+    #[test]
+    fn test_nntp_tls_is_configurable() {
+        let nntp: NntpSettings =
+            toml::from_str("server = \"news.internal.example\"\nport = 563\ntls = true\n").unwrap();
+        assert!(nntp.tls);
     }
 
     #[test]


### PR DESCRIPTION
NntpClient speaks only cleartext. lore.kernel.org offers neither
STARTTLS nor a 563 listener, but an internal public-inbox mirror
can require TLS.

NNTPS is implicit TLS. The handshake runs before the greeting, so
every command method is untouched (patch 1). Trust anchors come
from the host certificate store, which retains the local CA as a
property of the deployment rather than of the config. The config
does name the rustls crypto provider: ring and aws-lc-rs both
reach this binary through reqwest and lettre, and neither installs
a process default.

The knob is nntp.tls, default off, so an existing Settings.toml
continues to connect in the clear (patch 2). The port is not
derived from it. NNTPS listens on 563 rather than 119, and
deriving one from the other would silently move a server an
operator had pinned.

Note: I thought our internal security policy might require the use
of NNTPS, so I implemented these patches. But it turns out only port
22 is open between our internal sashiko and public-inbox instances.
So the patches are untested. Feel free to drop them.
