### PR TITLE
ai/bedrock: Surface real Converse error messages

### DIFF
--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -497,7 +497,11 @@ impl AiProvider for BedrockClient {
                     tracing::warn!("Bedrock throttled, waiting 30s before retry...");
                     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
                 }
-                return Err(anyhow::anyhow!("Bedrock Converse API error: {e:#}"));
+                return Err(anyhow::anyhow!(
+                    "Bedrock Converse API error (model_id={}): {}",
+                    self.model_id,
+                    aws_smithy_types::error::display::DisplayErrorContext(&e)
+                ));
             }
         };
 


### PR DESCRIPTION
`Display` on the AWS SDK's `SdkError` only reports the error category, so every Converse failure was logged as "Bedrock Converse API error: service error" with the message from Bedrock discarded. That made failures such as a rejected inference parameter or a denied action indistinguishable.

Format the error with `DisplayErrorContext`, which walks the source chain and includes the service message, and add the model id so the log names which model rejected the request.