### PR TITLE
e-mail: Send MTD reviews to all the recipients

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -299,12 +299,8 @@ cc = ["media-ci@linuxtv.org"]
 
 [subsystems.mtd]
 lists = ["linux-mtd@lists.infradead.org"]
-cc = ["Miquel Raynal <miquel.raynal@bootlin.com>",
-      "Richard Weinberger <richard@nod.at>",
-      "Vignesh Raghavendra <vigneshr@ti.com>",
-      "Pratyush Yadav <pratyush@kernel.org>",
-      "Michael Walle <mwalle@kernel.org>",
-      "Takahiro Kuwano <takahiro.kuwano@infineon.com>"]
+reply_all = true
+reply_to_author = true
 
 [subsystems.audit]
 lists = ["audit@vger.kernel.org"]


### PR DESCRIPTION
Sending the reviews to the maintainers only applies more pressure on us, so let's just make these reviews fully public by hitting the "answer all" virtual button.

Link: https://lore.kernel.org/linux-mtd/87v78yimb1.fsf@bootlin.com/