### PR TITLE
ai: Key the response cache on provider configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,14 @@ Settings for the Claude Code CLI provider (`provider = "claude-cli"`).
 |-----|------|---------|-------------|
 | `effort` | string | -- | Thinking effort: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`. |
 
+#### `[ai.codex_cli]`
+
+Settings for the Codex CLI provider (`provider = "codex-cli"`).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `effort` | string | -- | Reasoning effort: `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`. Passed as `-c model_reasoning_effort=<effort>`, which outranks `~/.codex/config.toml` but not an enterprise-managed requirements layer. A run whose effort that layer substitutes fails. |
+
 #### `[ai.gemini]`
 
 Settings for the Gemini provider (`provider = "gemini"`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,8 +78,8 @@ Core AI settings that apply to all providers.
 | `temperature` | float | `1.0` | Sampling temperature. |
 | `api_timeout_secs` | integer | `300` | Timeout for individual API calls (seconds). |
 | `log_turns` | bool | `false` | Log each AI request/response turn at info level. Verbose but useful for debugging. |
-| `response_cache` | bool | `false` | Cache AI responses to disk. |
-| `response_cache_ttl_days` | integer | `7` | TTL for cached responses (days). |
+| `response_cache` | bool | `false` | Cache AI responses to disk. Entries are keyed on the provider's own settings as well as the request, so changing `model`, an endpoint, a reasoning level, or an output cap misses the entries recorded under the old value rather than replaying them. |
+| `response_cache_ttl_days` | integer | `7` | TTL for cached responses (days). Entries stranded by a settings change age out on this schedule. |
 
 #### `[ai.claude]`
 

--- a/docs/examples/Settings.gpt-5-codex.toml
+++ b/docs/examples/Settings.gpt-5-codex.toml
@@ -3,3 +3,8 @@
 [ai]
 provider = "codex-cli"
 model = "gpt-5-codex"
+
+[ai.codex_cli]
+# Reasoning effort: "none", "minimal", "low", "medium", "high", "xhigh",
+# "max". Unset accepts the account default.
+# effort = "xhigh"

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -250,6 +250,21 @@ For OpenAI's coding-optimized model, use
 - Prompt sent via stdin to avoid `ARG_MAX` issues
 - No tool access -- sandbox is read-only
 
+**Reasoning effort:**
+
+```toml
+[ai.codex_cli]
+effort = "xhigh"    # "none", "minimal", "low", "medium", "high", "xhigh", "max"
+```
+
+Sashiko passes this as `codex exec -c model_reasoning_effort=<effort>`,
+so the setting applies only to a reasoning model such as `gpt-5-codex`.
+A `-c` override outranks `~/.codex/config.toml`. It does not outrank an
+enterprise-managed requirements layer, which substitutes its own value
+whatever the origin. A run whose effort that layer substitutes fails
+rather than record a review at an effort other than the one configured.
+Leave the setting unset to accept the account default.
+
 #### Devin CLI Setup
 
 Sashiko can use a local [Devin for Terminal](https://cli.devin.ai/) install as

--- a/src/ai/bedrock.rs
+++ b/src/ai/bedrock.rs
@@ -533,6 +533,20 @@ impl AiProvider for BedrockClient {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // max_tokens is what truncates a response, so a raised limit has to
+        // miss the entry recorded under the lower one rather than replay it.
+        let max_tokens = self.max_tokens.to_string();
+        crate::ai::cache_identity_with(
+            &self.model_id,
+            &[
+                ("thinking", self.thinking.as_deref()),
+                ("effort", self.effort.as_deref()),
+                ("max_tokens", Some(max_tokens.as_str())),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/ai/cache.rs
+++ b/src/ai/cache.rs
@@ -97,7 +97,7 @@ impl CachingAiProvider {
         })
     }
 
-    fn compute_cache_key(request: &AiRequest) -> String {
+    fn compute_cache_key(&self, request: &AiRequest) -> String {
         let mut val = serde_json::to_value(request).unwrap_or_default();
         // Strip nondeterministic fields
         if let serde_json::Value::Object(ref mut map) = val {
@@ -105,7 +105,14 @@ impl CachingAiProvider {
         }
         super::scrub_thought_signatures(&mut val);
         let canonical = serde_json::to_string(&val).unwrap_or_default();
-        let hash = Sha256::digest(canonical.as_bytes());
+        // The model and the provider's own knobs never appear in the request,
+        // so hash them alongside it. Without them a raised reasoning effort
+        // replays the answer recorded at the lower one.
+        let mut hasher = Sha256::new();
+        hasher.update(self.inner.cache_identity().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(canonical.as_bytes());
+        let hash = hasher.finalize();
         hash.iter().map(|b| format!("{:02x}", b)).collect()
     }
 }
@@ -113,7 +120,7 @@ impl CachingAiProvider {
 #[async_trait]
 impl AiProvider for CachingAiProvider {
     async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
-        let hash = Self::compute_cache_key(&request);
+        let hash = self.compute_cache_key(&request);
         let hash_prefix = &hash[..12];
 
         let mut rows = self
@@ -205,6 +212,10 @@ impl AiProvider for CachingAiProvider {
 
     fn get_capabilities(&self) -> ProviderCapabilities {
         self.inner.get_capabilities()
+    }
+
+    fn cache_identity(&self) -> String {
+        self.inner.cache_identity()
     }
 
     fn cache_stats(&self) -> Option<CacheStats> {

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -687,6 +687,22 @@ impl AiProvider for ClaudeClient {
         }
     }
 
+    fn cache_identity(&self) -> String {
+        // max_tokens is what truncates a response, so a raised limit has to
+        // miss the entry recorded under the lower one rather than replay it.
+        // base_url separates two endpoints serving the same model name.
+        let max_tokens = self.max_tokens.to_string();
+        crate::ai::cache_identity_with(
+            &self.model,
+            &[
+                ("thinking", self.thinking.as_deref()),
+                ("effort", self.effort.as_deref()),
+                ("max_tokens", Some(max_tokens.as_str())),
+                ("base_url", Some(self.base_url.as_str())),
+            ],
+        )
+    }
+
     // Optional caching methods - implement as no-ops for now
 }
 
@@ -756,6 +772,31 @@ mod tests {
         ToolCall,
     };
     use serde_json::json;
+
+    #[test]
+    fn cache_identity_tracks_the_knobs_outside_the_request() {
+        let client = |max_tokens, base_url: &str| {
+            ClaudeClient::new(
+                "claude-opus-4-7".to_string(),
+                false,
+                max_tokens,
+                base_url.to_string(),
+                None,
+                None,
+            )
+        };
+        let base = client(4096, "https://example.invalid/v1/messages");
+        assert_ne!(
+            base.cache_identity(),
+            client(65536, "https://example.invalid/v1/messages").cache_identity(),
+            "a raised max_tokens must not replay the truncated response"
+        );
+        assert_ne!(
+            base.cache_identity(),
+            client(4096, "https://proxy.invalid/v1/messages").cache_identity(),
+            "a changed base_url must not replay the old endpoint's response"
+        );
+    }
 
     fn make_request(messages: Vec<AiMessage>) -> AiRequest {
         AiRequest {

--- a/src/ai/claude_cli.rs
+++ b/src/ai/claude_cli.rs
@@ -35,7 +35,7 @@ use tracing::{debug, warn};
 
 use crate::ai::{
     AiErrorClass, AiProvider, AiRequest, AiResponse, AiRole, AiUsage, ClassifyAiError,
-    ProviderCapabilities, ToolCall,
+    ProviderCapabilities, ToolCall, cache_identity_with,
 };
 use crate::utils::utf8_prefix;
 
@@ -181,6 +181,10 @@ impl AiProvider for ClaudeCliProvider {
             model_name: self.model.clone(),
             context_window_size: context_window_for_model(&self.model),
         }
+    }
+
+    fn cache_identity(&self) -> String {
+        cache_identity_with(&self.model, &[("effort", self.effort.as_deref())])
     }
 }
 

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -26,10 +26,13 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use super::claude_cli::{build_prompt, parse_inner_response};
-use crate::ai::{AiProvider, AiRequest, AiResponse, AiUsage, ProviderCapabilities};
+use crate::ai::{
+    AiProvider, AiRequest, AiResponse, AiUsage, ProviderCapabilities, cache_identity_with,
+};
 
 pub struct CodexCliProvider {
     pub model: String,
+    pub effort: Option<String>,
 }
 
 #[async_trait]
@@ -39,17 +42,29 @@ impl AiProvider for CodexCliProvider {
 
         debug!("codex-cli prompt length: {} chars", prompt.len());
 
-        // codex exec --json --sandbox read-only -m MODEL
+        // codex exec --json --sandbox read-only -m MODEL \
+        //     [-c model_reasoning_effort=EFFORT]
         // Prompt is passed via stdin to avoid ARG_MAX issues with large prompts.
+        let mut args = vec![
+            "exec".to_string(),
+            "--json".to_string(),
+            "--sandbox".to_string(),
+            "read-only".to_string(),
+            "-m".to_string(),
+            self.model.clone(),
+        ];
+
+        // A `-c` override outranks ~/.codex/config.toml. It does not outrank
+        // an enterprise-managed requirements layer, which overrides a
+        // configured value whatever its origin and reports the substitution as
+        // an error event.
+        if let Some(effort) = &self.effort {
+            args.push("-c".to_string());
+            args.push(format!("model_reasoning_effort={effort}"));
+        }
+
         let mut child = Command::new("codex")
-            .args([
-                "exec",
-                "--json",
-                "--sandbox",
-                "read-only",
-                "-m",
-                &self.model,
-            ])
+            .args(&args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -78,7 +93,23 @@ impl AiProvider for CodexCliProvider {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("codex CLI exited with {}: {}", output.status, stderr.trim());
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // codex reports why it rejected an invocation -- an unsupported
+            // model_reasoning_effort value, say -- as a JSON error event on
+            // stdout, while stderr carries only progress chatter. Either one
+            // can hold the cause the other is missing: a per-turn error event
+            // on stdout does not explain a login failure printed on stderr, so
+            // report both.
+            let mut detail = collect_error_messages(&stdout);
+            let stderr = stderr.trim();
+            if !stderr.is_empty() {
+                detail.push(stderr.to_string());
+            }
+            anyhow::bail!(
+                "codex CLI exited with {}: {}",
+                output.status,
+                detail.join("; ")
+            );
         }
 
         let raw = String::from_utf8_lossy(&output.stdout);
@@ -86,6 +117,7 @@ impl AiProvider for CodexCliProvider {
         // Codex outputs line-delimited JSON events:
         //   {"type": "item.completed", "item": {"text": "..."}}
         //   {"type": "turn.completed", "usage": {"input_tokens": N, "output_tokens": N}}
+        //   {"type": "error", "message": "..."}
         let mut text_parts = Vec::new();
         let mut usage: Option<AiUsage> = None;
 
@@ -95,6 +127,9 @@ impl AiProvider for CodexCliProvider {
                 continue;
             }
             if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
+                if let Some(message) = error_message(&event) {
+                    self.check_error_message(message)?;
+                }
                 match event["type"].as_str() {
                     Some("item.completed") => {
                         if let Some(text) = event["item"]["text"].as_str() {
@@ -145,5 +180,149 @@ impl AiProvider for CodexCliProvider {
             model_name: self.model.clone(),
             context_window_size: 200_000,
         }
+    }
+
+    fn cache_identity(&self) -> String {
+        cache_identity_with(&self.model, &[("effort", self.effort.as_deref())])
+    }
+}
+
+impl CodexCliProvider {
+    /// Handles an error event from a run that exited 0. A requirements layer
+    /// that substitutes its own value for a setting reports the substitution
+    /// this way and lets the run proceed.
+    fn check_error_message(&self, message: &str) -> Result<()> {
+        if is_approval_policy_substitution(message) {
+            debug!("codex-cli: {}", message);
+        } else if self.effort.is_some() && is_effort_substitution(message) {
+            // The response cache files the reply under the configured effort,
+            // so a reply produced at the substituted one must not be returned.
+            anyhow::bail!("codex CLI did not run at the configured effort: {message}");
+        } else {
+            warn!("codex-cli: {}", message);
+        }
+        Ok(())
+    }
+}
+
+/// Returns the explanation an error event carries. A rejected invocation
+/// surfaces either as a bare `{"type":"error"}` line or as an
+/// `item.completed` wrapping an error item; both carry it in `message`.
+fn error_message(event: &Value) -> Option<&str> {
+    [event, &event["item"]]
+        .into_iter()
+        .find(|candidate| candidate["type"] == "error")
+        .and_then(|candidate| candidate["message"].as_str())
+}
+
+/// Pulls the distinct error messages out of a run's stdout.
+fn collect_error_messages(raw: &str) -> Vec<String> {
+    let mut messages = Vec::new();
+    for line in raw.lines() {
+        let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if let Some(message) = error_message(&event)
+            && !messages.iter().any(|m| m == message)
+        {
+            messages.push(message.to_string());
+        }
+    }
+    messages
+}
+
+/// Recognizes the one substitution that carries nothing to act on. `codex
+/// exec` resolves `approval_policy` to `Never` itself, a non-interactive run
+/// having nobody to prompt, so a requirements layer that disallows `Never`
+/// substitutes its own value on every invocation. Nothing here configures the
+/// policy and a `-c` override does not reach the check, so the message names
+/// no setting the operator can change. The sandbox stays read-only whichever
+/// policy wins, so an escalation request is refused under the substituted
+/// value exactly as it was under `Never`.
+fn is_approval_policy_substitution(message: &str) -> bool {
+    message.contains("`approval_policy`")
+}
+
+/// Recognizes a substitution of the effort this provider passed on the
+/// command line.
+fn is_effort_substitution(message: &str) -> bool {
+    message.contains("`model_reasoning_effort`")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_approval_policy_substitution_is_demoted() {
+        assert!(is_approval_policy_substitution(
+            "Configured value for `approval_policy` is disallowed by \
+             requirements; falling back to required value OnRequest."
+        ));
+        assert!(!is_approval_policy_substitution(
+            "Configured value for `model_reasoning_effort` is disallowed by \
+             requirements; falling back to required value medium."
+        ));
+    }
+
+    #[test]
+    fn a_substituted_effort_fails_the_run() {
+        let message = "Configured value for `model_reasoning_effort` is disallowed by \
+                       requirements; falling back to required value medium.";
+        let raised = CodexCliProvider {
+            model: "gpt-5-codex".to_string(),
+            effort: Some("xhigh".to_string()),
+        };
+        assert!(raised.check_error_message(message).is_err());
+
+        // With no effort configured the identity carries none, so the
+        // substituted run is recorded under the identity it ran at.
+        let plain = CodexCliProvider {
+            model: "gpt-5-codex".to_string(),
+            effort: None,
+        };
+        assert!(plain.check_error_message(message).is_ok());
+        assert!(
+            raised
+                .check_error_message(
+                    "Configured value for `approval_policy` is disallowed by \
+                     requirements; falling back to required value OnRequest."
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn error_messages_come_from_both_event_shapes() {
+        let raw = concat!(
+            r#"{"type":"session.created"}"#,
+            "\n",
+            r#"{"type":"error","message":"[reasoning.effort] Invalid value: 'higest'"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"error","message":"disallowed by requirements"}}"#,
+            "\n",
+            r#"not json"#,
+            "\n",
+        );
+        assert_eq!(
+            collect_error_messages(raw),
+            vec![
+                "[reasoning.effort] Invalid value: 'higest'".to_string(),
+                "disallowed by requirements".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn cache_identity_tracks_effort() {
+        let plain = CodexCliProvider {
+            model: "gpt-5-codex".to_string(),
+            effort: None,
+        };
+        let raised = CodexCliProvider {
+            model: "gpt-5-codex".to_string(),
+            effort: Some("xhigh".to_string()),
+        };
+        assert_ne!(plain.cache_identity(), raised.cache_identity());
     }
 }

--- a/src/ai/devin_cli.rs
+++ b/src/ai/devin_cli.rs
@@ -162,11 +162,43 @@ impl AiProvider for DevinCliProvider {
             context_window_size: 200_000,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // Both settings name a file devin reads, so editing one in place
+        // leaves the identity unchanged and the entries recorded under the
+        // old contents still match.
+        crate::ai::cache_identity_with(
+            &self.get_capabilities().model_name,
+            &[
+                ("agent_config", self.agent_config.as_deref()),
+                ("config", self.config.as_deref()),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_provider(agent_config: Option<&str>, config: Option<&str>) -> DevinCliProvider {
+        DevinCliProvider {
+            model: None,
+            agent_config: agent_config.map(str::to_string),
+            config: config.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn cache_identity_tracks_the_config_files() {
+        let base = test_provider(None, None);
+
+        let no_tools = test_provider(Some("/etc/sashiko/no-tools.json"), None);
+        assert_ne!(base.cache_identity(), no_tools.cache_identity());
+
+        let deny_all = test_provider(None, Some("/etc/sashiko/deny-all.yaml"));
+        assert_ne!(base.cache_identity(), deny_all.cache_identity());
+    }
 
     #[test]
     fn test_build_args_minimal() {

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -802,6 +802,11 @@ impl AiProvider for GeminiClient {
             context_window_size: 1_000_000, // Gemini 1.5 Pro default
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // base_url separates two endpoints serving the same model name.
+        crate::ai::cache_identity_with(&self.model, &[("base_url", Some(self.base_url.as_str()))])
+    }
 }
 
 #[cfg(test)]
@@ -812,6 +817,20 @@ mod tests {
         DEFAULT_RETRY_AFTER, ToolCall,
     };
     use serde_json::json;
+
+    #[test]
+    fn cache_identity_tracks_base_url() {
+        let client = |base_url: &str| GeminiClient {
+            model: "gemini-2.5-pro".to_string(),
+            base_url: base_url.to_string(),
+            api_key: String::new(),
+            client: RwLock::new(Client::new()),
+        };
+        assert_ne!(
+            client("https://generativelanguage.googleapis.com").cache_identity(),
+            client("https://proxy.invalid").cache_identity()
+        );
+    }
 
     #[test]
     fn test_quota_exceeded_classifies_as_rate_limit() {

--- a/src/ai/kiro_cli.rs
+++ b/src/ai/kiro_cli.rs
@@ -425,6 +425,12 @@ impl AiProvider for KiroCliProvider {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // context_window_size stays out. Unlike ollama's num_ctx it never
+        // reaches the wire; it only budgets the prompt the cache hashes.
+        crate::ai::cache_identity_with(&self.model, &[("agent", self.agent.as_deref())])
+    }
 }
 
 #[cfg(test)]
@@ -432,6 +438,23 @@ mod tests {
     use super::*;
     use crate::ai::{AiMessage, AiRole, AiTool, create_provider};
     use crate::settings::Settings;
+
+    fn test_provider(agent: Option<&str>) -> KiroCliProvider {
+        KiroCliProvider {
+            model: "claude-sonnet-4-6".to_string(),
+            binary: "kiro-cli".to_string(),
+            agent: agent.map(str::to_string),
+            context_window_size: 200_000,
+            timeout_secs: 60,
+        }
+    }
+
+    #[test]
+    fn cache_identity_tracks_agent() {
+        let base = test_provider(None);
+        let named = test_provider(Some("reviewer"));
+        assert_ne!(base.cache_identity(), named.cache_identity());
+    }
 
     fn sample_request() -> AiRequest {
         AiRequest {

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -367,6 +367,37 @@ pub trait AiProvider: Send + Sync {
     fn cache_stats(&self) -> Option<CacheStats> {
         None
     }
+
+    /// Describes the configuration that shapes a response but travels outside
+    /// the request: the model, and any provider knob such as a reasoning
+    /// effort level. The response cache mixes this into its key, so changing
+    /// one of these settings misses the entries recorded under the old one
+    /// instead of replaying them.
+    fn cache_identity(&self) -> String {
+        self.get_capabilities().model_name
+    }
+}
+
+/// Appends the knobs a provider applies outside the request to its model name,
+/// forming the identity `cache_identity` returns. A knob left unset
+/// contributes nothing, so a provider configured with none of them keys its
+/// entries on the bare model name.
+///
+/// Keying on an identity at all invalidates every entry recorded before one
+/// existed, whose hash covered the request alone. That costs one re-run of
+/// the backlog on the first run after the upgrade, and the stale rows age out
+/// with the TTL sweep.
+pub fn cache_identity_with(model: &str, knobs: &[(&str, Option<&str>)]) -> String {
+    let mut identity = model.to_string();
+    for (name, value) in knobs {
+        if let Some(value) = value {
+            identity.push('|');
+            identity.push_str(name);
+            identity.push('=');
+            identity.push_str(value);
+        }
+    }
+    identity
 }
 
 /// Creates an AI provider, optionally wrapping it with a local response cache.
@@ -556,6 +587,7 @@ pub fn create_provider_from_ai(ai: &AiSettings) -> Result<Arc<dyn AiProvider>> {
         }
         "codex-cli" => Ok(Arc::new(codex_cli::CodexCliProvider {
             model: ai.model.clone(),
+            effort: ai.codex_cli.as_ref().and_then(|c| c.effort.clone()),
         })),
         "copilot-cli" => Ok(Arc::new(copilot_cli::CopilotCliProvider {
             model: ai.model.clone(),

--- a/src/ai/ollama.rs
+++ b/src/ai/ollama.rs
@@ -400,6 +400,25 @@ impl AiProvider for OllamaClient {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // All four knobs reach translate_ollama_request() from this struct
+        // rather than from the request the cache hashes.  max_tokens caps the
+        // reply, context_window_size becomes num_ctx and decides how much of
+        // the prompt the model sees, think_mode turns reasoning on, and
+        // base_url separates two daemons serving the same model name.
+        let max_tokens = self.max_tokens.to_string();
+        let context_window_size = self.context_window_size.to_string();
+        crate::ai::cache_identity_with(
+            &self.model,
+            &[
+                ("max_tokens", Some(max_tokens.as_str())),
+                ("num_ctx", Some(context_window_size.as_str())),
+                ("think_mode", self.think_mode.as_deref()),
+                ("base_url", Some(self.base_url.as_str())),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]
@@ -686,5 +705,31 @@ mod tests {
         assert_eq!(options.num_predict, Some(2048));
 
         Ok(())
+    }
+
+    fn test_client(base_url: &str, max_tokens: u32, think_mode: Option<&str>) -> OllamaClient {
+        OllamaClient::new(
+            base_url.to_string(),
+            "qwen3:32b".to_string(),
+            128_000,
+            max_tokens,
+            60,
+            think_mode.map(str::to_string),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cache_identity_tracks_the_knobs_outside_the_request() {
+        let base = test_client("http://localhost:11434", 2048, None);
+
+        let raised = test_client("http://localhost:11434", 65536, None);
+        assert_ne!(base.cache_identity(), raised.cache_identity());
+
+        let thinking = test_client("http://localhost:11434", 2048, Some("high"));
+        assert_ne!(base.cache_identity(), thinking.cache_identity());
+
+        let elsewhere = test_client("http://gpu-box:11434", 2048, None);
+        assert_ne!(base.cache_identity(), elsewhere.cache_identity());
     }
 }

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -609,6 +609,29 @@ impl AiProvider for OpenAiCompatClient {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // The endpoint and the output cap shape the reply but travel outside
+        // the request, so the bare model name cannot distinguish them. A
+        // gpt-5.x call that hit the 4096 default comes back empty with
+        // finish_reason "length"; raising max_tokens has to miss that entry
+        // rather than replay it. base_url separates two endpoints serving
+        // the same model name, and provider_type decides whether the request
+        // carries max_tokens or max_completion_tokens.
+        let max_tokens = self.max_tokens.to_string();
+        let provider_type = match self.provider_type {
+            OpenAiProviderType::OpenAi => "openai",
+            OpenAiProviderType::OpenAiCompatible => "openai-compatible",
+        };
+        crate::ai::cache_identity_with(
+            &self.model,
+            &[
+                ("max_tokens", Some(max_tokens.as_str())),
+                ("base_url", Some(self.base_url.as_str())),
+                ("provider_type", Some(provider_type)),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]
@@ -1490,5 +1513,27 @@ mod tests {
         );
         // Test strings completely lacking a valid protocol scheme format
         assert!(OpenAiCompatClient::normalize_base_url("completely-broken-input-string").is_err());
+    }
+
+    fn test_client(base_url: &str, max_tokens: u32) -> OpenAiCompatClient {
+        OpenAiCompatClient::new(
+            base_url.to_string(),
+            OpenAiProviderType::OpenAi,
+            "gpt-5.1".to_string(),
+            400_000,
+            max_tokens,
+            60,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cache_identity_tracks_max_tokens_and_base_url() {
+        let capped = test_client("https://api.openai.com/v1", 4096);
+        let raised = test_client("https://api.openai.com/v1", 65536);
+        assert_ne!(capped.cache_identity(), raised.cache_identity());
+
+        let elsewhere = test_client("http://localhost:1234/v1", 4096);
+        assert_ne!(capped.cache_identity(), elsewhere.cache_identity());
     }
 }

--- a/src/ai/vertex.rs
+++ b/src/ai/vertex.rs
@@ -281,6 +281,20 @@ impl AiProvider for VertexClient {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // max_tokens is what truncates a response, so a raised limit has to
+        // miss the entry recorded under the lower one rather than replay it.
+        let max_tokens = self.max_tokens.to_string();
+        crate::ai::cache_identity_with(
+            &self.model,
+            &[
+                ("thinking", self.thinking.as_deref()),
+                ("effort", self.effort.as_deref()),
+                ("max_tokens", Some(max_tokens.as_str())),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/ai/vllm.rs
+++ b/src/ai/vllm.rs
@@ -655,6 +655,26 @@ impl AiProvider for VllmClient {
             context_window_size: self.context_window_size,
         }
     }
+
+    fn cache_identity(&self) -> String {
+        // guided_json and enable_tools change the shape of the reply rather
+        // than its wording: one constrains it to JSON, the other decides
+        // whether it can call tools at all.
+        let max_tokens = self.max_tokens.map(|m| m.to_string());
+        let enable_thinking = self.enable_thinking.map(|v| v.to_string());
+        let guided_json = self.guided_json.to_string();
+        let enable_tools = self.enable_tools.to_string();
+        crate::ai::cache_identity_with(
+            &self.model,
+            &[
+                ("max_tokens", max_tokens.as_deref()),
+                ("enable_thinking", enable_thinking.as_deref()),
+                ("guided_json", Some(guided_json.as_str())),
+                ("enable_tools", Some(enable_tools.as_str())),
+                ("base_url", Some(self.base_url.as_str())),
+            ],
+        )
+    }
 }
 
 #[cfg(test)]
@@ -662,6 +682,42 @@ mod tests {
     use super::*;
     use crate::ai::{AiErrorClass, AiMessage, ClassifyAiError, DEFAULT_RETRY_AFTER};
     use serde_json::json;
+
+    fn test_client(
+        base_url: &str,
+        enable_thinking: Option<bool>,
+        guided_json: bool,
+        enable_tools: bool,
+    ) -> VllmClient {
+        VllmClient::new(
+            base_url.to_string(),
+            "Qwen3-32B".to_string(),
+            32_768,
+            Some(2048),
+            60,
+            enable_thinking,
+            guided_json,
+            enable_tools,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cache_identity_tracks_the_knobs_outside_the_request() {
+        let base = test_client("http://localhost:8000/v1", None, false, false);
+
+        let thinking = test_client("http://localhost:8000/v1", Some(false), false, false);
+        assert_ne!(base.cache_identity(), thinking.cache_identity());
+
+        let guided = test_client("http://localhost:8000/v1", None, true, false);
+        assert_ne!(base.cache_identity(), guided.cache_identity());
+
+        let tools = test_client("http://localhost:8000/v1", None, false, true);
+        assert_ne!(base.cache_identity(), tools.cache_identity());
+
+        let elsewhere = test_client("http://gpu-box:8000/v1", None, false, false);
+        assert_ne!(base.cache_identity(), elsewhere.cache_identity());
+    }
 
     fn user_request(content: &str) -> AiRequest {
         AiRequest {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -318,6 +318,20 @@ pub struct ClaudeCliSettings {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[allow(unused)]
+pub struct CodexCliSettings {
+    /// Reasoning effort passed as `codex exec -c model_reasoning_effort=<v>`.
+    /// Valid values: "none", "minimal", "low", "medium", "high", "xhigh",
+    /// "max". Leave unset for the account default. A `-c` override outranks
+    /// `~/.codex/config.toml`, but not an enterprise-managed requirements
+    /// layer, which substitutes its own value whatever the origin. A run
+    /// whose effort that layer substitutes fails.
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[allow(unused)]
 pub struct DevinCliSettings {
     /// Path to a Devin declarative agent config file (JSON or YAML) passed via
     /// `--agent-config`. Use this to disable all tools for a strictly
@@ -367,6 +381,7 @@ pub struct AiSettings {
     pub vllm: Option<VllmSettings>,
     pub kiro_cli: Option<KiroCliSettings>,
     pub claude_cli: Option<ClaudeCliSettings>,
+    pub codex_cli: Option<CodexCliSettings>,
     pub devin_cli: Option<DevinCliSettings>,
 }
 


### PR DESCRIPTION
The response cache hashes the AiRequest, so two runs that differ only
in provider configuration collide. Every knob that shapes a reply while
travelling outside the request body is invisible to the key: a thinking
level, a reasoning effort, a max_tokens cap, a base_url, ollama's
num_ctx. Change one and the answer recorded under the old value comes
back, so the new setting looks inert.

The fix is a cache_identity hook on the provider trait, mixed into the
key beside the request. A provider reports the model name and the knobs
it applies itself, through a shared cache_identity_with() helper so the
providers spell that identity the same way.

Two consequences worth checking. Entries written before this hashed the
request alone and no longer match, so the first run after the change
re-issues the backlog once and the stale rows age out with the TTL
sweep. And the identity has to name every out-of-band knob rather than
the one that motivated the patch. max_tokens is the case that bites: a
gpt-5.x call that hits the 4096 default returns empty content with
finish_reason "length", and raising the cap has to miss that entry
rather than replay it.

The hook arrives with the codex-cli effort setting that needed it. That
provider spawns "codex exec" with a model argument and nothing else, and
model_reasoning_effort in ~/.codex/config.toml does not reach a login
governed by enterprise-managed requirements, because that policy layer
supersedes the user config file. A "-c model_reasoning_effort=<effort>"
command-line override does reach it. The policy layer may substitute its
own value rather than reject the override, and it reports the
substitution as an error event while codex still exits 0, so those
events are logged on the success path as well. A review that ran at some
other level then says so rather than passing for a configured one.

The identity is spelled out provider by provider in the two patches
that follow, and the response_cache option's documentation now says
the key covers those settings rather than the request alone.

All three patches were verified standalone on top of 54a74baa37f8:
sign-offs valid, clippy clean, 500 unit and 39 integration tests
passing.
