### PR TITLE
Improvements for local review

### DIFF
--- a/docs/examples/Settings.example.toml
+++ b/docs/examples/Settings.example.toml
@@ -6,3 +6,8 @@ temperature = 1.0
 
 [ai.gemini]
 explicit_prompt_caching = false
+
+[review]
+# Reviews run concurrently up to this many patches. Sized for one developer's
+# machine; the daemon's own Settings.toml uses a much larger fan-out.
+concurrency = 4

--- a/docs/sashiko-cli.md
+++ b/docs/sashiko-cli.md
@@ -312,6 +312,7 @@ model = "gemini-3.1-pro-preview"
 repository_path = "/path/to/your/kernel/tree"
 
 [review]
+concurrency = 4
 worktree_dir = "review_trees"
 ```
 

--- a/src/ai/backoff_provider.rs
+++ b/src/ai/backoff_provider.rs
@@ -1,0 +1,306 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A pass-through [`AiProvider`] decorator that retries with backoff on
+//! rate-limit and transient (e.g. 503 "overloaded") errors.
+//!
+//! The daemon classifies provider errors and backs off before retrying them.
+//! A worker running reviews in-process calls the provider directly, so its only
+//! recourse is the stage loop retrying immediately and blindly. This decorator
+//! gives that path the same behaviour, reusing [`QuotaManager`] and the typed
+//! [`AiErrorClass`] classification the providers already produce:
+//!
+//! - `RateLimit` (429 / quota): account-wide, so it is reported to a shared
+//!   [`QuotaManager`] and every concurrent request waits out the window.
+//! - `Transient` (503 overloaded, 500/502/504, 529): a momentary server-side
+//!   failure, so only this call backs off, exponentially and with jitter so
+//!   concurrent stages do not resynchronise onto the same retry instant.
+//! - `Fatal`: propagated immediately.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::time::sleep;
+use tracing::warn;
+
+use crate::ai::quota::QuotaManager;
+use crate::ai::{
+    AiErrorClass, AiProvider, AiRequest, AiResponse, CacheStats, ProviderCapabilities,
+    classify_ai_error, get_log_prefix,
+};
+
+/// Maximum number of attempts (initial try plus retries) for a single call
+/// before the last error is propagated. Bounds wall-clock so a sustained
+/// outage cannot hang a review indefinitely; transient blips resolve well
+/// within this.
+const MAX_ATTEMPTS: u32 = 6;
+
+/// Lets a caller account for the time spent waiting on the shared quota gate
+/// and stop the retry loop early.
+///
+/// The daemon bounds a review by an activity deadline rather than by an attempt
+/// count, and does not want a rate-limit wait to consume that budget, so it
+/// credits the wait back and fails once the deadline passes.
+pub trait RetryBudget: Send + Sync {
+    /// Time spent blocked on the shared quota gate before an attempt.
+    fn credit_wait(&self, slept: Duration);
+    /// Return an error to abandon further retries.
+    fn check(&self) -> Result<()>;
+}
+
+/// Adds rate-limit and transient retry with backoff around an inner provider.
+pub struct BackoffProvider {
+    inner: Arc<dyn AiProvider>,
+    /// Shared across the run, so one rate-limit response backs every
+    /// concurrent request off together.
+    quota: Arc<QuotaManager>,
+    /// Base unit of the exponential transient backoff. Tests use a tiny value
+    /// so they run in real time.
+    base_delay: Duration,
+    /// Attempt ceiling, or None to retry until `budget` says to stop.
+    max_attempts: Option<u32>,
+    budget: Option<Arc<dyn RetryBudget>>,
+}
+
+impl BackoffProvider {
+    /// With a `budget`, retries until it reports the caller's deadline has
+    /// passed. Without one, falls back to a fixed attempt ceiling, which bounds
+    /// wall-clock for callers that have no deadline of their own.
+    pub fn new(
+        inner: Arc<dyn AiProvider>,
+        quota: Arc<QuotaManager>,
+        budget: Option<Arc<dyn RetryBudget>>,
+    ) -> Self {
+        Self {
+            inner,
+            quota,
+            base_delay: Duration::from_secs(1),
+            max_attempts: budget.is_none().then_some(MAX_ATTEMPTS),
+            budget,
+        }
+    }
+}
+
+#[async_trait]
+impl AiProvider for BackoffProvider {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let mut attempt: u32 = 0;
+        let mut transient_streak: i32 = 0;
+        loop {
+            // Honour any active global rate-limit window before trying. The
+            // wait is reported so a caller can keep it off its own deadline.
+            let slept = self.quota.wait_for_access().await;
+            if let Some(budget) = &self.budget {
+                budget.credit_wait(slept);
+                budget.check()?;
+            }
+
+            match self.inner.generate_content(request.clone()).await {
+                Ok(response) => {
+                    self.quota.report_success().await;
+                    return Ok(response);
+                }
+                Err(e) => {
+                    attempt += 1;
+                    if let Some(max) = self.max_attempts
+                        && attempt >= max
+                    {
+                        return Err(e);
+                    }
+                    match classify_ai_error(&e) {
+                        AiErrorClass::RateLimit { retry_after } => {
+                            // Account-wide: block every concurrent request
+                            // until it clears. The next iteration's
+                            // wait_for_access() performs the sleep.
+                            self.quota.report_quota_error(retry_after).await;
+                        }
+                        AiErrorClass::Transient { retry_after } => {
+                            // Server-side blip. Exponential backoff with
+                            // jitter, floored by any server-suggested delay.
+                            // Per-call, not global.
+                            transient_streak += 1;
+                            let mult = 2.0_f64.powi(transient_streak - 1).min(60.0);
+                            let backoff = self.base_delay.mul_f64(mult).max(retry_after);
+                            let jittered = backoff + backoff.mul_f64(0.25 * fastrand::f64());
+                            warn!(
+                                "{}Transient AI error (streak {}); backing off {:.1}s then retry {}/{}: {}",
+                                get_log_prefix(),
+                                transient_streak,
+                                jittered.as_secs_f64(),
+                                attempt,
+                                MAX_ATTEMPTS,
+                                e
+                            );
+                            sleep(jittered).await;
+                        }
+                        AiErrorClass::Fatal => return Err(e),
+                    }
+                }
+            }
+        }
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        self.inner.estimate_tokens(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        self.inner.get_capabilities()
+    }
+
+    fn cache_stats(&self) -> Option<CacheStats> {
+        self.inner.cache_stats()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::gemini::GeminiError;
+    use crate::ai::{AiMessage, AiRole};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    enum Behaviour {
+        Transient,
+        RateLimit,
+        Fatal,
+    }
+
+    struct MockProvider {
+        calls: AtomicU32,
+        fail_times: u32,
+        behaviour: Behaviour,
+        rate_limit_after: Duration,
+    }
+
+    #[async_trait]
+    impl AiProvider for MockProvider {
+        async fn generate_content(&self, _request: AiRequest) -> Result<AiResponse> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if n < self.fail_times {
+                let err = match self.behaviour {
+                    Behaviour::Transient => {
+                        GeminiError::TransientError(Duration::from_secs(0), "503 overloaded".into())
+                    }
+                    Behaviour::RateLimit => GeminiError::QuotaExceeded(self.rate_limit_after),
+                    Behaviour::Fatal => GeminiError::PermissionDenied("nope".into()),
+                };
+                return Err(err.into());
+            }
+            Ok(AiResponse {
+                content: Some("ok".into()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                usage: None,
+                truncated: false,
+            })
+        }
+
+        fn estimate_tokens(&self, _request: &AiRequest) -> usize {
+            0
+        }
+
+        fn get_capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                model_name: "mock".into(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    fn mock(
+        behaviour: Behaviour,
+        fail_times: u32,
+        rate_limit_after: Duration,
+    ) -> Arc<MockProvider> {
+        Arc::new(MockProvider {
+            calls: AtomicU32::new(0),
+            fail_times,
+            behaviour,
+            rate_limit_after,
+        })
+    }
+
+    /// A BackoffProvider with a tiny base delay so transient backoff runs in
+    /// real time without needing the tokio virtual clock.
+    fn fast(inner: Arc<dyn AiProvider>) -> BackoffProvider {
+        BackoffProvider {
+            inner,
+            quota: Arc::new(QuotaManager::new()),
+            base_delay: Duration::from_millis(1),
+            max_attempts: Some(MAX_ATTEMPTS),
+            budget: None,
+        }
+    }
+
+    fn dummy_request() -> AiRequest {
+        AiRequest {
+            system: None,
+            messages: vec![AiMessage {
+                role: AiRole::User,
+                content: Some("hi".into()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn transient_backs_off_then_succeeds() {
+        let m = mock(Behaviour::Transient, 3, Duration::ZERO);
+        let resp = fast(m.clone())
+            .generate_content(dummy_request())
+            .await
+            .unwrap();
+        assert_eq!(resp.content.as_deref(), Some("ok"));
+        assert_eq!(m.calls.load(Ordering::SeqCst), 4); // 3 transient failures + success
+    }
+
+    #[tokio::test]
+    async fn transient_gives_up_after_max_attempts() {
+        let m = mock(Behaviour::Transient, u32::MAX, Duration::ZERO);
+        let err = fast(m.clone()).generate_content(dummy_request()).await;
+        assert!(err.is_err());
+        assert_eq!(m.calls.load(Ordering::SeqCst), MAX_ATTEMPTS); // bounded
+    }
+
+    #[tokio::test]
+    async fn fatal_propagates_without_retry() {
+        let m = mock(Behaviour::Fatal, u32::MAX, Duration::ZERO);
+        let err = fast(m.clone()).generate_content(dummy_request()).await;
+        assert!(err.is_err());
+        assert_eq!(m.calls.load(Ordering::SeqCst), 1); // no retry on fatal
+    }
+
+    #[tokio::test]
+    async fn rate_limit_waits_then_succeeds() {
+        // QuotaManager uses std::Instant, so use a tiny real delay here.
+        let m = mock(Behaviour::RateLimit, 2, Duration::from_millis(5));
+        let resp = fast(m.clone())
+            .generate_content(dummy_request())
+            .await
+            .unwrap();
+        assert_eq!(resp.content.as_deref(), Some("ok"));
+        assert_eq!(m.calls.load(Ordering::SeqCst), 3); // 2 rate-limit failures + success
+    }
+}

--- a/src/ai/backoff_provider.rs
+++ b/src/ai/backoff_provider.rs
@@ -61,6 +61,37 @@ pub trait RetryBudget: Send + Sync {
     fn check(&self) -> Result<()>;
 }
 
+/// A [`RetryBudget`] backed by a wall-clock deadline shared with the caller.
+///
+/// Time spent parked on the quota gate is credited back, so waiting out a rate
+/// limit does not consume the caller's budget.
+pub struct DeadlineBudget {
+    deadline: Arc<std::sync::Mutex<tokio::time::Instant>>,
+}
+
+impl DeadlineBudget {
+    pub fn new(deadline: Arc<std::sync::Mutex<tokio::time::Instant>>) -> Self {
+        Self { deadline }
+    }
+}
+
+impl RetryBudget for DeadlineBudget {
+    fn credit_wait(&self, slept: Duration) {
+        let mut d = self.deadline.lock().unwrap();
+        *d += slept;
+    }
+
+    fn check(&self) -> Result<()> {
+        let current = { *self.deadline.lock().unwrap() };
+        if tokio::time::Instant::now() > current {
+            return Err(anyhow::anyhow!(
+                "Review tool timed out (active time exceeded)"
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Adds rate-limit and transient retry with backoff around an inner provider.
 pub struct BackoffProvider {
     inner: Arc<dyn AiProvider>,
@@ -290,6 +321,26 @@ mod tests {
         let err = fast(m.clone()).generate_content(dummy_request()).await;
         assert!(err.is_err());
         assert_eq!(m.calls.load(Ordering::SeqCst), 1); // no retry on fatal
+    }
+
+    #[tokio::test]
+    async fn expired_budget_stops_before_calling() {
+        struct Expired;
+        impl RetryBudget for Expired {
+            fn credit_wait(&self, _slept: Duration) {}
+            fn check(&self) -> Result<()> {
+                Err(anyhow::anyhow!("deadline exceeded"))
+            }
+        }
+        let m = mock(Behaviour::Transient, u32::MAX, Duration::ZERO);
+        let provider = BackoffProvider::new(
+            m.clone(),
+            Arc::new(QuotaManager::new()),
+            Some(Arc::new(Expired)),
+        );
+        assert!(provider.generate_content(dummy_request()).await.is_err());
+        // The budget gates the loop, so the inner provider is never reached.
+        assert_eq!(m.calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/src/ai/concurrency_limited_provider.rs
+++ b/src/ai/concurrency_limited_provider.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A pass-through [`AiProvider`] decorator that caps the number of concurrent
+//! `generate_content` calls against a shared semaphore.
+//!
+//! A review fans its analysis stages out concurrently, so a single patch can
+//! issue one model call per stage at once, and the worker reviews several
+//! patches in parallel on top of that. The daemon bounds this globally with its
+//! own LLM semaphore, but a worker running reviews in-process has nothing in
+//! front of it. Sharing one semaphore across every provider the run creates
+//! turns `[review] concurrency` into a real ceiling on in-flight model calls.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+
+use crate::ai::{AiProvider, AiRequest, AiResponse, CacheStats, ProviderCapabilities};
+
+/// How many concurrent model calls a review `concurrency` allows.
+///
+/// Derived from the shape of a review workflow: its analysis stages run as one
+/// parallel fan-out, whose width the planning stage chooses per patch, followed
+/// by consolidation stages that run sequentially. An active review therefore
+/// averages roughly three concurrent calls, so scaling to `concurrency * 3`
+/// saturates model capacity while worktrees and worker processes stay gated at
+/// `concurrency` itself. The factor is empirical rather than a bound the
+/// workflow guarantees.
+///
+/// A configuration asking for no parallelism stays fully serial rather than
+/// being widened.
+pub fn llm_permits(concurrency: usize) -> usize {
+    if concurrency < 2 {
+        1
+    } else {
+        concurrency * 3
+    }
+}
+
+/// Limits concurrent model calls to the permits of a shared semaphore. All
+/// other behaviour is delegated unchanged to the inner provider.
+pub struct ConcurrencyLimitedProvider {
+    inner: Arc<dyn AiProvider>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl ConcurrencyLimitedProvider {
+    /// The semaphore is shared, so every provider built from it draws on the
+    /// same pool of permits.
+    pub fn new(inner: Arc<dyn AiProvider>, semaphore: Arc<Semaphore>) -> Self {
+        Self { inner, semaphore }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_llm_permits_keeps_a_serial_configuration_serial() {
+        // Widening these would defeat the point of asking for no parallelism,
+        // which is what someone does to stay under a provider's limits.
+        assert_eq!(llm_permits(0), 1);
+        assert_eq!(llm_permits(1), 1);
+
+        // Above that, calls are allowed to run wider than the worktrees are.
+        assert_eq!(llm_permits(2), 6);
+        assert_eq!(llm_permits(16), 48);
+    }
+}
+
+#[async_trait]
+impl AiProvider for ConcurrencyLimitedProvider {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|e| anyhow::anyhow!("concurrency semaphore closed: {e}"))?;
+        self.inner.generate_content(request).await
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        self.inner.estimate_tokens(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        self.inner.get_capabilities()
+    }
+
+    fn cache_stats(&self) -> Option<CacheStats> {
+        self.inner.cache_stats()
+    }
+}

--- a/src/ai/logging_provider.rs
+++ b/src/ai/logging_provider.rs
@@ -1,0 +1,116 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A pass-through [`AiProvider`] decorator that logs each model turn — the
+//! request that is sent and the response that comes back — at INFO level.
+//!
+//! This is the single, shared implementation of per-turn logging. The review
+//! worker (`worker::prompts`) drives the same stage loop in both local-CLI and
+//! daemon modes, and every model call funnels through `generate_content`, so
+//! wrapping the provider here logs turns identically for both paths. It is
+//! enabled by the `[ai] log_turns` setting and wired in at `bin/review.rs`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::info;
+
+use crate::ai::{AiProvider, AiRequest, AiResponse, CacheStats, ProviderCapabilities};
+
+/// Wraps any [`AiProvider`], logging each request/response turn. All other
+/// behaviour is delegated unchanged to the inner provider.
+pub struct LoggingProvider {
+    inner: Arc<dyn AiProvider>,
+    turn: AtomicU64,
+}
+
+impl LoggingProvider {
+    pub fn new(inner: Arc<dyn AiProvider>) -> Self {
+        Self {
+            inner,
+            turn: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl AiProvider for LoggingProvider {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let turn = self.turn.fetch_add(1, Ordering::SeqCst) + 1;
+        // The worker tags requests with their patch context (e.g. "[ps:0 p:1] ").
+        let tag = request.context_tag.clone().unwrap_or_default();
+
+        // Log the outgoing request (its most recent message).
+        let n_msgs = request.messages.len();
+        if let Some(last) = request.messages.last() {
+            let role = format!("{:?}", last.role).to_lowercase();
+            if let Some(tool_calls) = &last.tool_calls {
+                let names: Vec<&str> = tool_calls
+                    .iter()
+                    .map(|t| t.function_name.as_str())
+                    .collect();
+                info!("{tag}→ Turn {turn} ({n_msgs} msgs): [{role}] tool_calls={names:?}");
+            } else {
+                let content = last.content.as_deref().unwrap_or("(no text content)");
+                let preview: String = content.chars().take(300).collect();
+                let ellipsis = if content.chars().count() > 300 { "…" } else { "" };
+                info!("{tag}→ Turn {turn} ({n_msgs} msgs): [{role}] {preview}{ellipsis}");
+            }
+        }
+
+        let response = self.inner.generate_content(request).await?;
+
+        // Log the response: text, any tool calls, and token usage.
+        if let Some(content) = &response.content {
+            let preview: String = content.chars().take(500).collect();
+            let ellipsis = if content.chars().count() > 500 { "…" } else { "" };
+            info!("{tag}← Turn {turn} text: {preview}{ellipsis}");
+        }
+        if let Some(tool_calls) = &response.tool_calls {
+            for call in tool_calls {
+                let args = call.arguments.to_string();
+                let preview: String = args.chars().take(200).collect();
+                let ellipsis = if args.chars().count() > 200 { "…" } else { "" };
+                info!(
+                    "{tag}← Turn {turn} tool_call: {}({preview}{ellipsis})",
+                    call.function_name
+                );
+            }
+        }
+        if let Some(usage) = &response.usage {
+            info!(
+                "{tag}← Turn {turn} tokens: in={} out={} cached={}",
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.cached_tokens.unwrap_or(0)
+            );
+        }
+
+        Ok(response)
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        self.inner.estimate_tokens(request)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        self.inner.get_capabilities()
+    }
+
+    fn cache_stats(&self) -> Option<CacheStats> {
+        self.inner.cache_stats()
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -638,6 +638,7 @@ pub fn create_provider_from_ai(ai: &AiSettings) -> Result<Arc<dyn AiProvider>> {
         p => bail!("Unsupported AI provider: {}", p),
     }
 }
+pub mod backoff_provider;
 #[cfg(feature = "bedrock")]
 pub mod bedrock;
 pub mod cache;

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -648,6 +648,7 @@ pub mod copilot_cli;
 pub mod devin_cli;
 pub mod gemini;
 pub mod kiro_cli;
+pub mod logging_provider;
 pub mod ollama;
 pub mod openai;
 pub mod proxy;

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -644,6 +644,7 @@ pub mod cache;
 pub mod claude;
 pub mod claude_cli;
 pub mod codex_cli;
+pub mod concurrency_limited_provider;
 pub mod copilot_cli;
 pub mod devin_cli;
 pub mod gemini;

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -411,6 +411,22 @@ pub async fn run_worker(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Wrap the raw provider with the decorators a worker-run review needs.
+///
+/// Per-turn logging is implemented once, as a provider decorator, rather than
+/// in each front end: both local-CLI and daemon-spawned worker reviews run this
+/// same path, so wrapping here covers both.
+fn decorate_provider(
+    inner: std::sync::Arc<dyn crate::ai::AiProvider>,
+    ai: &AiSettings,
+) -> std::sync::Arc<dyn crate::ai::AiProvider> {
+    if ai.log_turns {
+        std::sync::Arc::new(crate::ai::logging_provider::LoggingProvider::new(inner))
+    } else {
+        inner
+    }
+}
+
 async fn review_single_patch(
     worktree: &GitWorktree,
     ai: &AiSettings,
@@ -444,6 +460,7 @@ async fn review_single_patch(
 
         let provider =
             crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
+        let provider = decorate_provider(provider, ai);
         let prompts_tool_path = Some(options.prompts.join("tool.md"));
 
         let mut patch_files = Vec::new();
@@ -1147,6 +1164,57 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::process::Command;
+    use std::sync::Arc;
+
+    /// A provider that does nothing; the decoration tests only care about
+    /// whether it was wrapped, which `Arc::ptr_eq` answers directly.
+    struct StubProvider;
+
+    #[async_trait::async_trait]
+    impl crate::ai::AiProvider for StubProvider {
+        async fn generate_content(
+            &self,
+            _request: crate::ai::AiRequest,
+        ) -> Result<crate::ai::AiResponse> {
+            unreachable!("decoration tests never issue a request")
+        }
+        fn estimate_tokens(&self, _request: &crate::ai::AiRequest) -> usize {
+            0
+        }
+        fn get_capabilities(&self) -> crate::ai::ProviderCapabilities {
+            crate::ai::ProviderCapabilities {
+                model_name: "stub".into(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    fn stub() -> Arc<dyn crate::ai::AiProvider> {
+        Arc::new(StubProvider)
+    }
+
+    #[test]
+    fn test_decorate_provider_log_turns_gate() -> Result<()> {
+        let mut settings = Settings::new()?;
+
+        // Off: the provider is handed back untouched, so a review that does not
+        // ask for turn logging pays nothing for it.
+        settings.ai.log_turns = false;
+        let inner = stub();
+        assert!(Arc::ptr_eq(
+            &inner,
+            &decorate_provider(inner.clone(), &settings.ai)
+        ));
+
+        // On: wrapped, so the turns are logged.
+        settings.ai.log_turns = true;
+        let inner = stub();
+        assert!(!Arc::ptr_eq(
+            &inner,
+            &decorate_provider(inner.clone(), &settings.ai)
+        ));
+        Ok(())
+    }
 
     fn git(repo_path: &Path, args: &[&str]) -> Result<()> {
         let output = Command::new("git")

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -425,6 +425,7 @@ fn decorate_provider(
     inner: std::sync::Arc<dyn crate::ai::AiProvider>,
     ai: &AiSettings,
     llm_semaphore: &Arc<Semaphore>,
+    quota: &Arc<crate::ai::quota::QuotaManager>,
 ) -> std::sync::Arc<dyn crate::ai::AiProvider> {
     let provider: std::sync::Arc<dyn crate::ai::AiProvider> = if ai.log_turns {
         std::sync::Arc::new(crate::ai::logging_provider::LoggingProvider::new(inner))
@@ -436,12 +437,20 @@ fn decorate_provider(
         return provider;
     }
 
-    std::sync::Arc::new(
+    let provider: std::sync::Arc<dyn crate::ai::AiProvider> = std::sync::Arc::new(
         crate::ai::concurrency_limited_provider::ConcurrencyLimitedProvider::new(
             provider,
             llm_semaphore.clone(),
         ),
-    )
+    );
+
+    // Backoff goes outermost, so a call that is waiting out a rate limit holds
+    // no concurrency permit while it sleeps.
+    std::sync::Arc::new(crate::ai::backoff_provider::BackoffProvider::new(
+        provider,
+        quota.clone(),
+        None,
+    ))
 }
 
 async fn review_single_patch(
@@ -456,6 +465,7 @@ async fn review_single_patch(
     options: &WorkerOptions,
     baseline_sha: &str,
     llm_semaphore: &Arc<Semaphore>,
+    quota: &Arc<crate::ai::quota::QuotaManager>,
     progress: Option<&ProgressCallback<'_>>,
 ) -> Result<Value> {
     let mut last_error = None;
@@ -478,7 +488,7 @@ async fn review_single_patch(
 
         let provider =
             crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
-        let provider = decorate_provider(provider, ai, llm_semaphore);
+        let provider = decorate_provider(provider, ai, llm_semaphore, quota);
         let prompts_tool_path = Some(options.prompts.join("tool.md"));
 
         let mut patch_files = Vec::new();
@@ -849,6 +859,8 @@ async fn run_worker_in_worktree(
     let llm_semaphore = Arc::new(Semaphore::new(
         crate::ai::concurrency_limited_provider::llm_permits(concurrency),
     ));
+    // Shared so a rate-limit response from one request backs the whole run off.
+    let quota = Arc::new(crate::ai::quota::QuotaManager::new());
 
     // Execute patch reviews concurrently with a limit
     let futures_stream = futures::stream::iter(patches_to_review.iter().map(|p| {
@@ -858,6 +870,7 @@ async fn run_worker_in_worktree(
         let subject_clone = subject.clone();
         let all_patches = &patches;
         let llm_semaphore = &llm_semaphore;
+        let quota = &quota;
         async move {
             review_single_patch(
                 worktree,
@@ -871,6 +884,7 @@ async fn run_worker_in_worktree(
                 options,
                 baseline_sha,
                 llm_semaphore,
+                quota,
                 progress,
             )
             .await
@@ -1221,12 +1235,101 @@ mod tests {
         Arc::new(StubProvider)
     }
 
+    /// Fails the first call with a rate limit, then succeeds, so a test can
+    /// tell whether the retry limiter was actually installed.
+    struct RateLimitOnce {
+        calls: std::sync::atomic::AtomicU32,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ai::AiProvider for RateLimitOnce {
+        async fn generate_content(
+            &self,
+            _request: crate::ai::AiRequest,
+        ) -> Result<crate::ai::AiResponse> {
+            use std::sync::atomic::Ordering;
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(crate::ai::gemini::GeminiError::QuotaExceeded(
+                    std::time::Duration::from_millis(5),
+                )
+                .into());
+            }
+            Ok(crate::ai::AiResponse {
+                content: Some("ok".into()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                usage: None,
+                truncated: false,
+            })
+        }
+        fn estimate_tokens(&self, _request: &crate::ai::AiRequest) -> usize {
+            0
+        }
+        fn get_capabilities(&self) -> crate::ai::ProviderCapabilities {
+            crate::ai::ProviderCapabilities {
+                model_name: "rate-limit-once".into(),
+                context_window_size: 1000,
+            }
+        }
+    }
+
+    fn dummy_request() -> crate::ai::AiRequest {
+        crate::ai::AiRequest {
+            system: None,
+            messages: vec![crate::ai::AiMessage {
+                role: crate::ai::AiRole::User,
+                content: Some("hi".into()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: None,
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decorate_provider_retries_rate_limits_for_in_process_reviews() -> Result<()> {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let mut settings = Settings::new()?;
+        settings.ai.log_turns = false;
+        let sem = Arc::new(Semaphore::new(4));
+        let quota = Arc::new(crate::ai::quota::QuotaManager::new());
+
+        // In-process: the limiter waits out the window and retries, so the
+        // caller sees a success rather than the rate-limit error.
+        settings.ai.provider = "claude-cli".to_string();
+        let inner = Arc::new(RateLimitOnce {
+            calls: AtomicU32::new(0),
+        });
+        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota);
+        let response = decorated.generate_content(dummy_request()).await?;
+        assert_eq!(response.content.as_deref(), Some("ok"));
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+
+        // Daemon-spawned worker: the daemon owns the retry, so the error is
+        // passed straight back instead of being retried here as well.
+        settings.ai.provider = "stdio-claude".to_string();
+        let inner = Arc::new(RateLimitOnce {
+            calls: AtomicU32::new(0),
+        });
+        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota);
+        assert!(decorated.generate_content(dummy_request()).await.is_err());
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
     #[test]
     fn test_decorate_provider_log_turns_gate() -> Result<()> {
         let mut settings = Settings::new()?;
         // A stdio provider skips the limiters, isolating the logging decision.
         settings.ai.provider = "stdio-gemini".to_string();
         let sem = Arc::new(Semaphore::new(1));
+        let quota = Arc::new(crate::ai::quota::QuotaManager::new());
 
         // Off: the provider is handed back untouched, so a review that does not
         // ask for turn logging pays nothing for it.
@@ -1234,7 +1337,7 @@ mod tests {
         let inner = stub();
         assert!(Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
         ));
 
         // On: wrapped, so the turns are logged.
@@ -1242,7 +1345,7 @@ mod tests {
         let inner = stub();
         assert!(!Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
         ));
         Ok(())
     }
@@ -1252,6 +1355,7 @@ mod tests {
         let mut settings = Settings::new()?;
         settings.ai.log_turns = false;
         let sem = Arc::new(Semaphore::new(1));
+        let quota = Arc::new(crate::ai::quota::QuotaManager::new());
 
         // A daemon-spawned worker is throttled by the daemon, so it must be
         // left unwrapped rather than limited twice.
@@ -1259,7 +1363,7 @@ mod tests {
         let inner = stub();
         assert!(Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
         ));
 
         // A review running in-process has nothing in front of it, so it gets
@@ -1268,7 +1372,7 @@ mod tests {
         let inner = stub();
         assert!(!Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
         ));
         Ok(())
     }

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -280,18 +280,12 @@ pub async fn run_worker(
     let (mut ai, configured_repo_path, concurrency) = if let Some(path) = &options.settings_path {
         let local_settings = Settings::local_review_from_file(path)
             .with_context(|| format!("Failed to load settings from {}", path.display()))?;
-        let concurrency = local_settings
-            .review
-            .and_then(|r| r.concurrency)
-            .unwrap_or(4);
+        let concurrency = local_settings.review.concurrency;
         (local_settings.ai, None, concurrency)
     } else if repo_override.is_some() {
         let local_settings =
             Settings::local_review_settings().context("Failed to load local review settings")?;
-        let concurrency = local_settings
-            .review
-            .and_then(|r| r.concurrency)
-            .unwrap_or(4);
+        let concurrency = local_settings.review.concurrency;
         (local_settings.ai, None, concurrency)
     } else {
         let settings = Settings::new().context("Failed to load settings")?;

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -277,24 +277,36 @@ pub async fn run_worker(
     repo_override: Option<PathBuf>,
     progress: Option<&ProgressCallback<'_>>,
 ) -> Result<Value> {
-    let (mut ai, configured_repo_path, concurrency) = if let Some(path) = &options.settings_path {
-        let local_settings = Settings::local_review_from_file(path)
-            .with_context(|| format!("Failed to load settings from {}", path.display()))?;
-        let concurrency = local_settings.review.concurrency;
-        (local_settings.ai, None, concurrency)
-    } else if repo_override.is_some() {
-        let local_settings =
-            Settings::local_review_settings().context("Failed to load local review settings")?;
-        let concurrency = local_settings.review.concurrency;
-        (local_settings.ai, None, concurrency)
-    } else {
-        let settings = Settings::new().context("Failed to load settings")?;
-        (
-            settings.ai,
-            Some(PathBuf::from(settings.git.repository_path)),
-            settings.review.concurrency,
-        )
-    };
+    let (mut ai, configured_repo_path, concurrency, timeout_seconds) =
+        if let Some(path) = &options.settings_path {
+            let local_settings = Settings::local_review_from_file(path)
+                .with_context(|| format!("Failed to load settings from {}", path.display()))?;
+            let review = local_settings.review;
+            (
+                local_settings.ai,
+                None,
+                review.concurrency,
+                review.timeout_seconds,
+            )
+        } else if repo_override.is_some() {
+            let local_settings =
+                Settings::local_review_settings().context("Failed to load local review settings")?;
+            let review = local_settings.review;
+            (
+                local_settings.ai,
+                None,
+                review.concurrency,
+                review.timeout_seconds,
+            )
+        } else {
+            let settings = Settings::new().context("Failed to load settings")?;
+            (
+                settings.ai,
+                Some(PathBuf::from(settings.git.repository_path)),
+                settings.review.concurrency,
+                settings.review.timeout_seconds,
+            )
+        };
 
     if let Some(provider) = &options.ai_provider {
         ai.provider = provider.clone();
@@ -386,6 +398,7 @@ pub async fn run_worker(
         &worktree,
         &ai,
         concurrency,
+        timeout_seconds,
         patchset_id,
         subject,
         patches,
@@ -420,6 +433,7 @@ fn decorate_provider(
     ai: &AiSettings,
     llm_semaphore: &Arc<Semaphore>,
     quota: &Arc<crate::ai::quota::QuotaManager>,
+    retry_budget: &Option<Arc<dyn crate::ai::backoff_provider::RetryBudget>>,
 ) -> std::sync::Arc<dyn crate::ai::AiProvider> {
     let provider: std::sync::Arc<dyn crate::ai::AiProvider> = if ai.log_turns {
         std::sync::Arc::new(crate::ai::logging_provider::LoggingProvider::new(inner))
@@ -440,10 +454,12 @@ fn decorate_provider(
 
     // Backoff goes outermost, so a call that is waiting out a rate limit holds
     // no concurrency permit while it sleeps.
+    // With a retry budget it stops at the review's deadline, as in the daemon;
+    // without one it falls back to an attempt ceiling.
     std::sync::Arc::new(crate::ai::backoff_provider::BackoffProvider::new(
         provider,
         quota.clone(),
-        None,
+        retry_budget.clone(),
     ))
 }
 
@@ -460,6 +476,7 @@ async fn review_single_patch(
     baseline_sha: &str,
     llm_semaphore: &Arc<Semaphore>,
     quota: &Arc<crate::ai::quota::QuotaManager>,
+    retry_budget: &Option<Arc<dyn crate::ai::backoff_provider::RetryBudget>>,
     progress: Option<&ProgressCallback<'_>>,
 ) -> Result<Value> {
     let mut last_error = None;
@@ -482,7 +499,7 @@ async fn review_single_patch(
 
         let provider =
             crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
-        let provider = decorate_provider(provider, ai, llm_semaphore, quota);
+        let provider = decorate_provider(provider, ai, llm_semaphore, quota, retry_budget);
         let prompts_tool_path = Some(options.prompts.join("tool.md"));
 
         let mut patch_files = Vec::new();
@@ -667,6 +684,7 @@ async fn run_worker_in_worktree(
     worktree: &GitWorktree,
     ai: &AiSettings,
     concurrency: usize,
+    timeout_seconds: u64,
     patchset_id: i64,
     subject: String,
     patches: Vec<PatchInput>,
@@ -855,6 +873,17 @@ async fn run_worker_in_worktree(
     ));
     // Shared so a rate-limit response from one request backs the whole run off.
     let quota = Arc::new(crate::ai::quota::QuotaManager::new());
+    // Bound the run by [review] timeout_seconds, as the daemon does. Time spent
+    // waiting out a rate limit is credited back rather than charged to it.
+    // 0 disables the limit, leaving retries bounded by their attempt ceiling.
+    let retry_budget: Option<Arc<dyn crate::ai::backoff_provider::RetryBudget>> =
+        (timeout_seconds > 0).then(|| {
+            let deadline = Arc::new(std::sync::Mutex::new(
+                tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_seconds),
+            ));
+            Arc::new(crate::ai::backoff_provider::DeadlineBudget::new(deadline))
+                as Arc<dyn crate::ai::backoff_provider::RetryBudget>
+        });
 
     // Execute patch reviews concurrently with a limit
     let futures_stream = futures::stream::iter(patches_to_review.iter().map(|p| {
@@ -865,6 +894,7 @@ async fn run_worker_in_worktree(
         let all_patches = &patches;
         let llm_semaphore = &llm_semaphore;
         let quota = &quota;
+        let retry_budget = &retry_budget;
         async move {
             review_single_patch(
                 worktree,
@@ -879,6 +909,7 @@ async fn run_worker_in_worktree(
                 baseline_sha,
                 llm_semaphore,
                 quota,
+                retry_budget,
                 progress,
             )
             .await
@@ -1300,7 +1331,7 @@ mod tests {
         let inner = Arc::new(RateLimitOnce {
             calls: AtomicU32::new(0),
         });
-        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota);
+        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None);
         let response = decorated.generate_content(dummy_request()).await?;
         assert_eq!(response.content.as_deref(), Some("ok"));
         assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
@@ -1311,9 +1342,41 @@ mod tests {
         let inner = Arc::new(RateLimitOnce {
             calls: AtomicU32::new(0),
         });
-        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota);
+        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None);
         assert!(decorated.generate_content(dummy_request()).await.is_err());
         assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_decorate_provider_honours_the_retry_budget() -> Result<()> {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        /// Stands in for a review whose deadline has already passed.
+        struct Expired;
+        impl crate::ai::backoff_provider::RetryBudget for Expired {
+            fn credit_wait(&self, _slept: std::time::Duration) {}
+            fn check(&self) -> Result<()> {
+                Err(anyhow!("deadline exceeded"))
+            }
+        }
+
+        let mut settings = Settings::new()?;
+        settings.ai.log_turns = false;
+        settings.ai.provider = "claude-cli".to_string();
+        let sem = Arc::new(Semaphore::new(4));
+        let quota = Arc::new(crate::ai::quota::QuotaManager::new());
+        let budget: Option<Arc<dyn crate::ai::backoff_provider::RetryBudget>> =
+            Some(Arc::new(Expired));
+
+        let inner = Arc::new(RateLimitOnce {
+            calls: AtomicU32::new(0),
+        });
+        let decorated = decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &budget);
+        assert!(decorated.generate_content(dummy_request()).await.is_err());
+        // The budget is consulted before the request goes out, so a review that
+        // is already past its deadline stops rather than retrying through it.
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 0);
         Ok(())
     }
 
@@ -1331,7 +1394,7 @@ mod tests {
         let inner = stub();
         assert!(Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None)
         ));
 
         // On: wrapped, so the turns are logged.
@@ -1339,7 +1402,7 @@ mod tests {
         let inner = stub();
         assert!(!Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None)
         ));
         Ok(())
     }
@@ -1357,7 +1420,7 @@ mod tests {
         let inner = stub();
         assert!(Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None)
         ));
 
         // A review running in-process has nothing in front of it, so it gets
@@ -1366,7 +1429,7 @@ mod tests {
         let inner = stub();
         assert!(!Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota)
+            &decorate_provider(inner.clone(), &settings.ai, &sem, &quota, &None)
         ));
         Ok(())
     }

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -28,7 +28,9 @@ use std::{
     collections::HashMap,
     io::Write,
     path::{Path, PathBuf},
+    sync::Arc,
 };
+use tokio::sync::Semaphore;
 use tracing::{error, info};
 
 #[derive(Clone, Debug)]
@@ -416,15 +418,30 @@ pub async fn run_worker(
 /// Per-turn logging is implemented once, as a provider decorator, rather than
 /// in each front end: both local-CLI and daemon-spawned worker reviews run this
 /// same path, so wrapping here covers both.
+///
+/// The limiters are skipped for a daemon-spawned worker, which reaches the
+/// model through a stdio provider and is throttled by the daemon instead.
 fn decorate_provider(
     inner: std::sync::Arc<dyn crate::ai::AiProvider>,
     ai: &AiSettings,
+    llm_semaphore: &Arc<Semaphore>,
 ) -> std::sync::Arc<dyn crate::ai::AiProvider> {
-    if ai.log_turns {
+    let provider: std::sync::Arc<dyn crate::ai::AiProvider> = if ai.log_turns {
         std::sync::Arc::new(crate::ai::logging_provider::LoggingProvider::new(inner))
     } else {
         inner
+    };
+
+    if ai.provider.starts_with("stdio-") {
+        return provider;
     }
+
+    std::sync::Arc::new(
+        crate::ai::concurrency_limited_provider::ConcurrencyLimitedProvider::new(
+            provider,
+            llm_semaphore.clone(),
+        ),
+    )
 }
 
 async fn review_single_patch(
@@ -438,6 +455,7 @@ async fn review_single_patch(
     patch_shas: &HashMap<i64, String>,
     options: &WorkerOptions,
     baseline_sha: &str,
+    llm_semaphore: &Arc<Semaphore>,
     progress: Option<&ProgressCallback<'_>>,
 ) -> Result<Value> {
     let mut last_error = None;
@@ -460,7 +478,7 @@ async fn review_single_patch(
 
         let provider =
             crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
-        let provider = decorate_provider(provider, ai);
+        let provider = decorate_provider(provider, ai, llm_semaphore);
         let prompts_tool_path = Some(options.prompts.join("tool.md"));
 
         let mut patch_files = Vec::new();
@@ -824,6 +842,14 @@ async fn run_worker_in_worktree(
         })
         .collect();
 
+    // Cap in-flight model calls across the whole run. The patch fan-out below
+    // is bounded by `concurrency`; each patch then fans its stages out
+    // concurrently on top of that, so without a shared ceiling the number of
+    // simultaneous requests is unbounded.
+    let llm_semaphore = Arc::new(Semaphore::new(
+        crate::ai::concurrency_limited_provider::llm_permits(concurrency),
+    ));
+
     // Execute patch reviews concurrently with a limit
     let futures_stream = futures::stream::iter(patches_to_review.iter().map(|p| {
         let rich_patches = rich_patches.clone();
@@ -831,6 +857,7 @@ async fn run_worker_in_worktree(
         let options = &options;
         let subject_clone = subject.clone();
         let all_patches = &patches;
+        let llm_semaphore = &llm_semaphore;
         async move {
             review_single_patch(
                 worktree,
@@ -843,6 +870,7 @@ async fn run_worker_in_worktree(
                 patch_shas,
                 options,
                 baseline_sha,
+                llm_semaphore,
                 progress,
             )
             .await
@@ -1196,6 +1224,9 @@ mod tests {
     #[test]
     fn test_decorate_provider_log_turns_gate() -> Result<()> {
         let mut settings = Settings::new()?;
+        // A stdio provider skips the limiters, isolating the logging decision.
+        settings.ai.provider = "stdio-gemini".to_string();
+        let sem = Arc::new(Semaphore::new(1));
 
         // Off: the provider is handed back untouched, so a review that does not
         // ask for turn logging pays nothing for it.
@@ -1203,7 +1234,7 @@ mod tests {
         let inner = stub();
         assert!(Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai)
+            &decorate_provider(inner.clone(), &settings.ai, &sem)
         ));
 
         // On: wrapped, so the turns are logged.
@@ -1211,7 +1242,33 @@ mod tests {
         let inner = stub();
         assert!(!Arc::ptr_eq(
             &inner,
-            &decorate_provider(inner.clone(), &settings.ai)
+            &decorate_provider(inner.clone(), &settings.ai, &sem)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_decorate_provider_skips_limiters_for_stdio_workers() -> Result<()> {
+        let mut settings = Settings::new()?;
+        settings.ai.log_turns = false;
+        let sem = Arc::new(Semaphore::new(1));
+
+        // A daemon-spawned worker is throttled by the daemon, so it must be
+        // left unwrapped rather than limited twice.
+        settings.ai.provider = "stdio-claude".to_string();
+        let inner = stub();
+        assert!(Arc::ptr_eq(
+            &inner,
+            &decorate_provider(inner.clone(), &settings.ai, &sem)
+        ));
+
+        // A review running in-process has nothing in front of it, so it gets
+        // the limiter.
+        settings.ai.provider = "claude-cli".to_string();
+        let inner = stub();
+        assert!(!Arc::ptr_eq(
+            &inner,
+            &decorate_provider(inner.clone(), &settings.ai, &sem)
         ));
         Ok(())
     }

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1728,28 +1728,12 @@ async fn run_review_tool_with_cmd(
     // than an open-coded loop. A review is bounded by its activity deadline
     // rather than an attempt count, and time spent waiting out a rate limit is
     // credited back so it does not consume that budget.
-    struct DeadlineBudget {
-        deadline: Arc<std::sync::Mutex<TokioInstant>>,
-    }
-    impl crate::ai::backoff_provider::RetryBudget for DeadlineBudget {
-        fn credit_wait(&self, slept: Duration) {
-            let mut d = self.deadline.lock().unwrap();
-            *d += slept;
-        }
-        fn check(&self) -> Result<()> {
-            let current = { *self.deadline.lock().unwrap() };
-            if TokioInstant::now() > current {
-                return Err(anyhow::anyhow!("Review tool timed out (active time exceeded)"));
-            }
-            Ok(())
-        }
-    }
     let provider: Arc<dyn AiProvider> = Arc::new(crate::ai::backoff_provider::BackoffProvider::new(
         provider,
         quota_manager.clone(),
-        Some(Arc::new(DeadlineBudget {
-            deadline: deadline.clone(),
-        })),
+        Some(Arc::new(crate::ai::backoff_provider::DeadlineBudget::new(
+            deadline.clone(),
+        ))),
     ));
 
     let mut spawned_tasks = Vec::new();

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1724,6 +1724,34 @@ async fn run_review_tool_with_cmd(
         TokioInstant::now() + Duration::from_secs(settings.review.timeout_seconds),
     ));
 
+    // Retry rate-limited and transient failures with the shared limiter rather
+    // than an open-coded loop. A review is bounded by its activity deadline
+    // rather than an attempt count, and time spent waiting out a rate limit is
+    // credited back so it does not consume that budget.
+    struct DeadlineBudget {
+        deadline: Arc<std::sync::Mutex<TokioInstant>>,
+    }
+    impl crate::ai::backoff_provider::RetryBudget for DeadlineBudget {
+        fn credit_wait(&self, slept: Duration) {
+            let mut d = self.deadline.lock().unwrap();
+            *d += slept;
+        }
+        fn check(&self) -> Result<()> {
+            let current = { *self.deadline.lock().unwrap() };
+            if TokioInstant::now() > current {
+                return Err(anyhow::anyhow!("Review tool timed out (active time exceeded)"));
+            }
+            Ok(())
+        }
+    }
+    let provider: Arc<dyn AiProvider> = Arc::new(crate::ai::backoff_provider::BackoffProvider::new(
+        provider,
+        quota_manager.clone(),
+        Some(Arc::new(DeadlineBudget {
+            deadline: deadline.clone(),
+        })),
+    ));
+
     let mut spawned_tasks = Vec::new();
     let interaction_result =
         async {
@@ -1796,10 +1824,8 @@ async fn run_review_tool_with_cmd(
 
                                         let db_clone = db.clone();
                                         let provider_clone = provider.clone();
-                                        let quota_clone = quota_manager.clone();
                                         let settings_clone = settings.clone();
                                         let stdin_clone = stdin_writer.clone();
-                                        let deadline_clone = deadline.clone();
                                         let total_tokens_used_clone = total_tokens_used.clone();
                                         let total_output_tokens_used_clone = total_output_tokens_used.clone();
                                         let abort_tx_clone = abort_tx.clone();
@@ -1843,57 +1869,9 @@ async fn run_review_tool_with_cmd(
                                             }
 
                                             let ctx_tag = req.context_tag.clone().unwrap_or_default();
-                                            let resp_payload = crate::ai::LOG_CONTEXT.scope(ctx_tag, async {
-                                                let mut local_transient_errors = 0;
-                                                loop {
-                                                    let slept = quota_clone.wait_for_access().await;
-                                                    {
-                                                        let mut d = deadline_clone.lock().unwrap();
-                                                        *d += slept;
-                                                    }
-
-                                                    let current_deadline = {
-                                                        let d = deadline_clone.lock().unwrap();
-                                                        *d
-                                                    };
-
-                                                    if TokioInstant::now() > current_deadline {
-                                                        return Err(anyhow::anyhow!(
-                                                            "Review tool timed out (active time exceeded)"
-                                                        ));
-                                                    }
-
-                                                    match provider_clone.generate_content(req.clone()).await {
-                                                        Ok(resp) => {
-                                                            quota_clone.report_success().await;
-                                                            break Ok(resp);
-                                                        }
-                                                        Err(e) => {
-                                                            match classify_ai_error(&e) {
-                                                                AiErrorClass::RateLimit { retry_after } => {
-                                                                    quota_clone
-                                                                        .report_quota_error(retry_after)
-                                                                        .await;
-                                                                    continue;
-                                                                }
-                                                                AiErrorClass::Transient { retry_after } => {
-                                                                    local_transient_errors += 1;
-                                                                    let backoff_secs = (1.0 * (2.0_f64.powi(local_transient_errors - 1))).min(60.0);
-                                                                    let backoff = std::time::Duration::from_secs_f64(backoff_secs).max(retry_after);
-                                                                    tracing::warn!(
-                                                                        "AI provider transient error (streak: {}). Locally backing off for {:.2}s",
-                                                                        local_transient_errors,
-                                                                        backoff.as_secs_f64()
-                                                                    );
-                                                                    tokio::time::sleep(backoff).await;
-                                                                    continue;
-                                                                }
-                                                                AiErrorClass::Fatal => break Err(e),
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }).await;
+                                            let resp_payload = crate::ai::LOG_CONTEXT
+                                                .scope(ctx_tag, provider_clone.generate_content(req.clone()))
+                                                .await;
 
                                             let reply = match resp_payload {
                                                 Ok(p) => {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -134,16 +134,8 @@ impl Reviewer {
         .await
         .expect("Failed to create AI provider");
 
-        // Mathematically derived from Sashiko's review pipeline stage composition:
-        // Stages 1-7 run in parallel (7 slots), while Stages 8-11 run sequentially (1 slot).
-        // On average, an active patch review consumes ~3 LLM slots over its execution lifetime.
-        // Thus, the global LLM request semaphore is scaled to (concurrency * 3) to fully
-        // saturate LLM capacity while gating local processes/worktrees strictly to `concurrency`.
-        let llm_concurrency = if concurrency < 2 {
-            1
-        } else {
-            std::cmp::max(1, concurrency * 3)
-        };
+        let llm_concurrency =
+            crate::ai::concurrency_limited_provider::llm_permits(concurrency);
 
         Self {
             db,
@@ -1614,6 +1606,16 @@ async fn run_review_tool_with_cmd(
     provider: Arc<dyn AiProvider>,
     llm_semaphore: Arc<Semaphore>,
 ) -> Result<serde_json::Value> {
+    // Cap concurrent model calls with the shared limiter instead of taking the
+    // semaphore by hand around each call. This also releases the permit as soon
+    // as the call returns, so a request that is backing off no longer occupies
+    // a slot while it sleeps.
+    let provider: Arc<dyn AiProvider> = Arc::new(
+        crate::ai::concurrency_limited_provider::ConcurrencyLimitedProvider::new(
+            provider,
+            llm_semaphore.clone(),
+        ),
+    );
     cmd.args([
         "--json",
         "--baseline",
@@ -1801,7 +1803,6 @@ async fn run_review_tool_with_cmd(
                                         let total_tokens_used_clone = total_tokens_used.clone();
                                         let total_output_tokens_used_clone = total_output_tokens_used.clone();
                                         let abort_tx_clone = abort_tx.clone();
-                                        let llm_semaphore_clone = llm_semaphore.clone();
 
                                         let handle = tokio::spawn(async move {
                                             let req: AiRequest = match serde_json::from_value(payload) {
@@ -1861,8 +1862,6 @@ async fn run_review_tool_with_cmd(
                                                             "Review tool timed out (active time exceeded)"
                                                         ));
                                                     }
-
-                                                    let _permit = llm_semaphore_clone.acquire().await?;
 
                                                     match provider_clone.generate_content(req.clone()).await {
                                                         Ok(resp) => {

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1712,7 +1712,7 @@ async fn run_review_tool_with_cmd(
 
     let stdin_writer = Arc::new(tokio::sync::Mutex::new(stdin));
 
-    use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
     use tokio::time::Instant as TokioInstant;
     use tokio::time::{timeout, timeout_at};
@@ -1741,7 +1741,6 @@ async fn run_review_tool_with_cmd(
             let ai_started = Arc::new(AtomicBool::new(false));
             let total_tokens_used = Arc::new(AtomicUsize::new(0));
             let total_output_tokens_used = Arc::new(AtomicUsize::new(0));
-            let turn_count = Arc::new(AtomicU32::new(0));
 
             let (abort_tx, mut abort_rx) = tokio::sync::mpsc::channel::<anyhow::Error>(1);
 
@@ -1799,7 +1798,6 @@ async fn run_review_tool_with_cmd(
                                         let settings_clone = settings.clone();
                                         let stdin_clone = stdin_writer.clone();
                                         let deadline_clone = deadline.clone();
-                                        let turn_count_clone = turn_count.clone();
                                         let total_tokens_used_clone = total_tokens_used.clone();
                                         let total_output_tokens_used_clone = total_output_tokens_used.clone();
                                         let abort_tx_clone = abort_tx.clone();
@@ -1840,24 +1838,6 @@ async fn run_review_tool_with_cmd(
                                                             content.len(),
                                                         )
                                                         .await;
-                                                }
-                                            }
-
-                                            let mut local_turn = turn_count_clone.fetch_add(1, Ordering::SeqCst);
-                                            local_turn += 1;
-
-                                            if settings_clone.ai.log_turns {
-                                                let n_msgs = req.messages.len();
-                                                let last = req.messages.last();
-                                                let role_str = last.map(|m| format!("{:?}", m.role).to_lowercase()).unwrap_or_default();
-                                                let content_preview = last.and_then(|m| m.content.as_deref()).unwrap_or("(no text content)");
-                                                let preview: String = content_preview.chars().take(300).collect();
-                                                let ellipsis = if content_preview.chars().count() > 300 { "…" } else { "" };
-                                                if let Some(tool_calls) = last.and_then(|m| m.tool_calls.as_ref()) {
-                                                    let names: Vec<&str> = tool_calls.iter().map(|t| t.function_name.as_str()).collect();
-                                                    info!("→ Turn {} ({} msgs): [{role_str}] tool_calls={:?}", local_turn, n_msgs, names);
-                                                } else {
-                                                    info!("→ Turn {} ({} msgs): [{role_str}] {}{}", local_turn, n_msgs, preview, ellipsis);
                                                 }
                                             }
 
@@ -1965,27 +1945,6 @@ async fn run_review_tool_with_cmd(
 
                                                             let _ = abort_tx_clone.send(ReviewError::BudgetExceeded(err_msg).into()).await;
                                                             return;
-                                                        }
-                                                    }
-
-                                                    if settings_clone.ai.log_turns {
-                                                        if let Some(content) = &p.content {
-                                                            let preview: String = content.chars().take(500).collect();
-                                                            let ellipsis = if content.chars().count() > 500 { "…" } else { "" };
-                                                            info!("← Turn {} text: {}{}", local_turn, preview, ellipsis);
-                                                        }
-                                                        if let Some(tool_calls) = &p.tool_calls {
-                                                            for call in tool_calls {
-                                                                let args_str = call.arguments.to_string();
-                                                                let args_preview: String = args_str.chars().take(200).collect();
-                                                                let ellipsis = if args_str.chars().count() > 200 { "…" } else { "" };
-                                                                info!("← Turn {} tool_call: {}({}{})", local_turn, call.function_name, args_preview, ellipsis);
-                                                            }
-                                                        }
-                                                        if let Some(usage) = &p.usage {
-                                                            info!("← Turn {} tokens: in={} out={} cached={}",
-                                                                local_turn, usage.prompt_tokens, usage.completion_tokens,
-                                                                usage.cached_tokens.unwrap_or(0));
                                                         }
                                                     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -532,13 +532,13 @@ fn default_forge() -> ForgeSettings {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct LocalReviewReviewSettings {
-    pub concurrency: Option<usize>,
+    pub concurrency: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct LocalReviewSettings {
     pub ai: AiSettings,
-    pub review: Option<LocalReviewReviewSettings>,
+    pub review: LocalReviewReviewSettings,
 }
 impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
@@ -627,6 +627,31 @@ mod tests {
             let _ = Settings::from_file("Settings")
                 .expect("Production 'Settings.toml' failed to parse");
         }
+    }
+
+    /// concurrency is required for local reviews exactly as it is for the
+    /// daemon, so an absent [review] section is an error rather than a guess
+    /// at how much machine the review has to itself.
+    #[test]
+    fn test_local_review_requires_a_review_section() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Settings.toml");
+        let ai = "[ai]\nprovider = \"gemini\"\nmodel = \"gemini-3-pro\"\n";
+
+        std::fs::write(&path, ai).unwrap();
+        assert!(Settings::local_review_from_file(&path).is_err());
+
+        std::fs::write(&path, format!("{}\n[review]\nconcurrency = 8\n", ai)).unwrap();
+        let settings = Settings::local_review_from_file(&path).unwrap();
+        assert_eq!(settings.review.concurrency, 8);
+    }
+
+    /// `sashiko init` writes this template, so it has to satisfy the shape a
+    /// local review reads or the two commands disagree out of the box.
+    #[test]
+    fn test_init_template_satisfies_local_review() {
+        Settings::local_review_from_file("docs/examples/Settings.example.toml")
+            .expect("init template must parse as local review settings");
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -533,6 +533,8 @@ fn default_forge() -> ForgeSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct LocalReviewReviewSettings {
     pub concurrency: usize,
+    #[serde(default = "default_review_timeout")]
+    pub timeout_seconds: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -644,6 +646,8 @@ mod tests {
         std::fs::write(&path, format!("{}\n[review]\nconcurrency = 8\n", ai)).unwrap();
         let settings = Settings::local_review_from_file(&path).unwrap();
         assert_eq!(settings.review.concurrency, 8);
+        // timeout_seconds keeps a default, as it does for the daemon.
+        assert_eq!(settings.review.timeout_seconds, 3600);
     }
 
     /// `sashiko init` writes this template, so it has to satisfy the shape a


### PR DESCRIPTION
Hi, while doing Sashiko work in a number of different places, I kept running into things that only the daemon knew how to do, but I wanted to use the one-shot `sashiko review` (and, earlier, `sashiko-cli`). This series lifts logging, concurrency, backoff, and settings up for use by both daemon and local review systems.

I'm not too familiar with this codebase (nor Rust generally), so I may be going about things very wrong. Hopefully I'm not far off! :P