### PR TITLE
review: point read_prompt at the prompt directory, not a file

### DIFF
--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -509,7 +509,8 @@ async fn review_single_patch(
         let provider =
             crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
         let provider = decorate_provider(provider, ai, llm_semaphore, quota, &retry_budget);
-        let prompts_tool_path = Some(options.prompts.join("tool.md"));
+        // The directory itself: read_prompt resolves a name against it.
+        let prompts_tool_path = Some(options.prompts.clone());
 
         let mut patch_files = Vec::new();
         if let Some(sha) = patch_shas.get(&p.index) {

--- a/src/toolbox/tools_test.rs
+++ b/src/toolbox/tools_test.rs
@@ -417,6 +417,31 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// read_prompt resolves the requested name against its base, so the base
+    /// has to be the prompt directory. Handed a file, every call fails while
+    /// canonicalizing, which is how a caller passing `<prompts>/tool.md` went
+    /// unnoticed: the tool is optional, so its errors look like the model
+    /// simply choosing not to use it.
+    #[test]
+    fn test_read_prompt_base_is_the_prompt_directory() {
+        let (linux_path, prompts_path) = get_test_paths();
+        let rt = Runtime::new().unwrap();
+        // A guide the workflow already loads by name, so it cannot go missing
+        // without breaking the review itself. The nested path also covers the
+        // subdirectory case, which is most of what the tool is asked for.
+        let args = json!({ "name": "subsystem/locking.md" });
+
+        let toolbox = ToolBox::new(linux_path.clone(), Some(prompts_path.clone()));
+        let result = rt
+            .block_on(toolbox.call("read_prompt", args.clone()))
+            .expect("a name under the prompt directory must resolve");
+        assert!(!result["content"].as_str().unwrap_or_default().is_empty());
+
+        // A file as the base cannot resolve anything.
+        let wrong = ToolBox::new(linux_path, Some(prompts_path.join("tool.md")));
+        assert!(rt.block_on(wrong.call("read_prompt", args)).is_err());
+    }
+
     #[test]
     fn test_git_read_files_truncation() {
         let (linux_path, _prompts_path) = get_test_paths();


### PR DESCRIPTION
The read_prompt tool resolves the name it is given against a base path, so that base has to be the prompt directory: ToolBox is constructed with one everywhere else, and its test reads "technical-patterns.md" relative to it. Worker-run reviews instead passed `<prompts>/tool.md`, a file, and one that exists in no prompt bundle. Every call therefore failed while canonicalizing the base, with "Failed to canonicalize base path: No such file or directory".

The tool is how a stage reaches a guide the pre-screen did not select: any of the subsystem guides, severity.md, false-positive-guide.md. Losing it costs a review the guidance it went looking for, and it fails quietly, because a tool erroring is indistinguishable from a model deciding not to call it.

Pass the directory. The test pins both directions, since the failure only shows up as an absence.