### PR TITLE
local_review: keep completed patch reviews when one patch fails

### DIFF
--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -891,6 +891,7 @@ async fn run_worker_in_worktree(
         let all_patches = &patches;
         let llm_semaphore = &llm_semaphore;
         let quota = &quota;
+        let patch_index = p.index;
         async move {
             review_single_patch(
                 worktree,
@@ -909,13 +910,25 @@ async fn run_worker_in_worktree(
                 progress,
             )
             .await
+            .map_err(|e| (patch_index, e))
         }
     }));
 
     let mut buffered = futures_stream.buffer_unordered(concurrency);
     let mut results = Vec::new();
+    let mut review_failures: Vec<(i64, String)> = Vec::new();
     while let Some(res) = buffered.next().await {
-        results.push(res?);
+        match res {
+            Ok(review) => results.push(review),
+            // Returning here would drop every review that already completed,
+            // and they cannot be recovered: this path builds its provider with
+            // create_provider_from_ai, so no response cache, and the turn log
+            // keeps only previews. Record the failure and keep the rest.
+            Err((patch_index, e)) => {
+                error!("AI review for patch {} failed: {}", patch_index, e);
+                review_failures.push((patch_index, e.to_string()));
+            }
+        }
     }
 
     // Aggregate findings, inline reviews, history, input context, and concern counts
@@ -1001,7 +1014,15 @@ async fn run_worker_in_worktree(
         "dismissed_concerns_count": total_dismissed_concerns_count
     });
 
-    let combined_result = json!({
+    for (patch_index, message) in &review_failures {
+        patch_results.push(json!({
+            "index": patch_index,
+            "status": "review_failed",
+            "error": message
+        }));
+    }
+
+    let mut combined_result = json!({
         "patchset_id": patchset_id,
         "baseline": baseline_arg,
         "patches": patch_results,
@@ -1013,6 +1034,16 @@ async fn run_worker_in_worktree(
         "tokens_out": total_tokens_out,
         "tokens_cached": total_tokens_cached
     });
+
+    if !review_failures.is_empty() {
+        let indices: Vec<String> = review_failures.iter().map(|(i, _)| i.to_string()).collect();
+        combined_result["error"] = json!(format!(
+            "AI review failed for {} of {} patches (index {})",
+            review_failures.len(),
+            patches_to_review.len(),
+            indices.join(", ")
+        ));
+    }
 
     Ok(combined_result)
 }

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -1014,13 +1014,7 @@ async fn run_worker_in_worktree(
         "dismissed_concerns_count": total_dismissed_concerns_count
     });
 
-    for (patch_index, message) in &review_failures {
-        patch_results.push(json!({
-            "index": patch_index,
-            "status": "review_failed",
-            "error": message
-        }));
-    }
+    record_review_failures(&mut patch_results, &review_failures);
 
     let mut combined_result = json!({
         "patchset_id": patchset_id,
@@ -1035,15 +1029,11 @@ async fn run_worker_in_worktree(
         "tokens_cached": total_tokens_cached
     });
 
-    if !review_failures.is_empty() {
-        let indices: Vec<String> = review_failures.iter().map(|(i, _)| i.to_string()).collect();
-        combined_result["error"] = json!(format!(
-            "AI review failed for {} of {} patches (index {})",
-            review_failures.len(),
-            patches_to_review.len(),
-            indices.join(", ")
-        ));
-    }
+    set_review_failure_error(
+        &mut combined_result,
+        &review_failures,
+        patches_to_review.len(),
+    );
 
     Ok(combined_result)
 }
@@ -1087,6 +1077,38 @@ pub fn result_has_high_or_critical_findings(result: &Value) -> bool {
             .to_ascii_lowercase();
         is_new && matches!(severity.as_str(), "critical" | "high")
     })
+}
+
+/// Records each failed patch review as an entry in patch_results, alongside
+/// the entries written for patch application.
+fn record_review_failures(patch_results: &mut Vec<Value>, review_failures: &[(i64, String)]) {
+    for (patch_index, message) in review_failures {
+        patch_results.push(json!({
+            "index": patch_index,
+            "status": "review_failed",
+            "error": message
+        }));
+    }
+}
+
+/// Sets the top level error field when any patch review failed, so that
+/// result_has_error still reports the run as failed even though the reviews
+/// that succeeded are returned.
+fn set_review_failure_error(
+    combined_result: &mut Value,
+    review_failures: &[(i64, String)],
+    total_patches: usize,
+) {
+    if review_failures.is_empty() {
+        return;
+    }
+    let indices: Vec<String> = review_failures.iter().map(|(i, _)| i.to_string()).collect();
+    combined_result["error"] = json!(format!(
+        "AI review failed for {} of {} patches (index {})",
+        review_failures.len(),
+        total_patches,
+        indices.join(", ")
+    ));
 }
 
 async fn apply_single_patch(
@@ -1734,6 +1756,47 @@ mod tests {
         assert!(ctx_str.contains("Current Patch Under Review: [Patch 1 of 2] - Patch 1"));
         assert!(ctx_str.contains("Series End Commit (Final State): sha2"));
         assert!(ctx_str.contains("- [Patch 2 of 2] (commit sha2): Patch 2"));
+    }
+
+    #[test]
+    fn test_record_review_failures_marks_each_failed_patch() {
+        let mut patch_results = vec![json!({"index": 1, "status": "applied"})];
+        let failures = vec![
+            (2, "timed out".to_string()),
+            (3, "provider returned no content".to_string()),
+        ];
+
+        record_review_failures(&mut patch_results, &failures);
+
+        assert_eq!(patch_results.len(), 3);
+        assert_eq!(patch_results[0]["status"], "applied");
+        assert_eq!(patch_results[1]["status"], "review_failed");
+        assert_eq!(patch_results[1]["index"], 2);
+        assert_eq!(patch_results[1]["error"], "timed out");
+        assert_eq!(patch_results[2]["index"], 3);
+    }
+
+    #[test]
+    fn test_review_failure_error_is_set_so_the_run_still_reports_failure() {
+        let mut combined_result = json!({"patchset_id": 7, "review": {}});
+        let failures = vec![(2, "timed out".to_string())];
+
+        set_review_failure_error(&mut combined_result, &failures, 12);
+
+        assert!(result_has_error(&combined_result));
+        let message = combined_result["error"].as_str().unwrap_or_default();
+        assert!(message.contains("1 of 12"), "unexpected message: {message}");
+        assert!(message.contains('2'), "unexpected message: {message}");
+    }
+
+    #[test]
+    fn test_no_review_failure_error_when_every_patch_succeeded() {
+        let mut combined_result = json!({"patchset_id": 7, "review": {}});
+
+        set_review_failure_error(&mut combined_result, &[], 12);
+
+        assert!(!result_has_error(&combined_result));
+        assert!(combined_result.get("error").is_none());
     }
 
     #[test]


### PR DESCRIPTION

A local series review collects its results with `results.push(res?)`.
`review_single_patch` retries three times and only then returns `Err`, so
when a patch finally gives up that `?` returns from
`run_worker_in_worktree` and takes everything with it: every review that
had already completed is dropped, and every review still in flight is
cancelled when the stream is dropped. On a twelve patch series that can be
eleven finished reviews thrown away, and they are not recoverable
afterwards. This path builds its provider with `create_provider_from_ai`
rather than `create_provider_cached`, so there is no response cache to
replay from, and the turn log keeps only 300 and 500 character previews.

The daemon already handles the same situation the other way: it splits a
series into one worker per patch and counts a failed patch rather than
discarding the others. The divergence only affects the local path, since
the fan-out runs when no `--review-patch-index` was given and the daemon
always passes one, so this is reachable from `sashiko review` and a
hand-run `sashiko worker` but not from the service.

The first commit collects the failures instead of short circuiting. Each
one becomes a `review_failed` entry in `patch_results`, which already
carries per patch `index`, `status` and `error`, and the top level `error`
field is set so `result_has_error` still reports the run as failed and the
exit code is unchanged. That mirrors what the same function already does
when patch application fails. The aggregation below the loop needed no
changes, since it reads each result with `if let Some`. The second commit
moves the recording into two helpers next to `apply_single_patch` and adds
unit tests; no functional change.

I have not hit this particular loss in a real run, so the trigger is
reasoning rather than an incident: the `DeadlineBudget` is built once
before the three attempt loop and shared across all three, so once a patch
exceeds `timeout_seconds` its remaining attempts fail on their first model
call, and `AiErrorClass::Fatal` returns without retrying, so the outer loop
re-runs the same patch into the same error three times.

What I can say from experience is what the missing cache costs, though from
a different failure on the same path: a review of mine failed at a late
stage, which discards that review's earlier stages rather than its
siblings, and re-running it cost $3.33 against a hosted endpoint. This
patch does not address that case. It is only why "dropped" and "paid for
again" are the same thing here.

`make check-all` passes. The new tests cover the recording and the error
signalling, not the loop itself, so the change has not been exercised end
to end against a series where a patch genuinely exhausts its attempts.

One unrelated thing in case CI hits it: on one run
`ai::kiro_cli::tests::test_generate_content_with_fake_acp_server` failed
with "Text file busy". It passes in isolation on both `main` and this
branch and looks like a pre-existing race in a test that writes a fake
binary and then spawns it.
