### PR TITLE
email: add virtualization subsystem

### DIFF
--- a/sashiko.dev/email_policy.toml
+++ b/sashiko.dev/email_policy.toml
@@ -175,6 +175,14 @@ reply_to_author = false
 cc_individuals = false
 cc = ["Chuck Lever <cel@kernel.org>", "Jeff Layton <jlayton@kernel.org>", "Anna Schumaker <anna@kernel.org>"]
 
+[subsystems.virtualization]
+lists = ["virtualization@lists.linux.dev"]
+reply_to_author = true
+send_positive_review = true
+cc = ["virtualization@lists.linux.dev",
+      "Michael S. Tsirkin <mst@redhat.com>",
+      "Eugenio Perez <eperezma@redhat.com>"]
+
 [subsystems.kvm]
 lists = ["kvm@vger.kernel.org"]
 reply_to_author = true


### PR DESCRIPTION
Add a policy entry for the virtualization@lists.linux.dev mailing list
so that sashiko reviews of virtio patches CC the virtio maintainers.

Signed-off-by: Michael S. Tsirkin <mst@redhat.com>