### PR TITLE
ai: honour response_cache for local reviews

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -421,6 +421,44 @@ pub async fn create_provider_cached(
     }
 }
 
+/// The response cache used by callers that have no database to sit beside.
+///
+/// `create_provider_cached` derives its location from `settings.database.url`,
+/// which only the daemon has. Local reviews get an XDG path instead,
+/// overridable with SASHIKO_RESPONSE_CACHE.
+pub fn local_response_cache_path() -> Result<std::path::PathBuf> {
+    if let Some(path) = std::env::var_os("SASHIKO_RESPONSE_CACHE") {
+        return Ok(std::path::PathBuf::from(path));
+    }
+    Ok(crate::prompt_bundle::data_home()?
+        .join("sashiko")
+        .join("response_cache.db"))
+}
+
+/// Creates an AI provider from AI settings alone, wrapping it with the local
+/// response cache when enabled.
+///
+/// `create_provider_cached` needs full `Settings` for the cache location, so a
+/// caller holding only `AiSettings`, such as a local review, could not honour
+/// `response_cache` at all.
+pub async fn create_provider_cached_from_ai(ai: &AiSettings) -> Result<Arc<dyn AiProvider>> {
+    let provider = create_provider_from_ai(ai)?;
+    if !ai.response_cache {
+        return Ok(provider);
+    }
+    let cache_path = local_response_cache_path()?;
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let cached = cache::CachingAiProvider::new(
+        provider,
+        &cache_path.to_string_lossy(),
+        ai.response_cache_ttl_days,
+    )
+    .await?;
+    Ok(Arc::new(cached))
+}
+
 /// Creates an AI provider based on the application settings.
 pub fn create_provider(settings: &Settings) -> Result<Arc<dyn AiProvider>> {
     create_provider_from_ai(&settings.ai)
@@ -909,6 +947,36 @@ pub(crate) fn start_stdin_reader(registry: Arc<IpcRegistry>) -> tokio::task::Joi
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_local_response_cache_path_prefers_the_env_override() {
+        // Serialised with the XDG case below by running in one test, since
+        // both mutate process environment.
+        unsafe {
+            std::env::set_var("SASHIKO_RESPONSE_CACHE", "/tmp/sashiko-test-cache.db");
+        }
+        let path = local_response_cache_path().unwrap();
+        unsafe {
+            std::env::remove_var("SASHIKO_RESPONSE_CACHE");
+        }
+        assert_eq!(path, std::path::PathBuf::from("/tmp/sashiko-test-cache.db"));
+
+        let old = std::env::var_os("XDG_DATA_HOME");
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", "/tmp/sashiko-test-xdg");
+        }
+        let path = local_response_cache_path().unwrap();
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/tmp/sashiko-test-xdg/sashiko/response_cache.db")
+        );
+    }
+
     use super::*;
     use crate::worker::prompts::ReviewError;
     use anyhow::anyhow;

--- a/src/local_review.rs
+++ b/src/local_review.rs
@@ -506,8 +506,9 @@ async fn review_single_patch(
             );
         }
 
-        let provider =
-            crate::ai::create_provider_from_ai(ai).context("Failed to create AI provider")?;
+        let provider = crate::ai::create_provider_cached_from_ai(ai)
+            .await
+            .context("Failed to create AI provider")?;
         let provider = decorate_provider(provider, ai, llm_semaphore, quota, &retry_budget);
         let prompts_tool_path = Some(options.prompts.join("tool.md"));
 

--- a/src/prompt_bundle.rs
+++ b/src/prompt_bundle.rs
@@ -59,7 +59,8 @@ pub fn prompt_bundle_root() -> Result<PathBuf> {
         .join(PROMPT_BUNDLE_REVISION))
 }
 
-fn data_home() -> Result<PathBuf> {
+/// The XDG data directory, shared with the local response cache.
+pub(crate) fn data_home() -> Result<PathBuf> {
     if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
         return Ok(PathBuf::from(data_home));
     }


### PR DESCRIPTION

`AiSettings` carries `response_cache`, but only the daemon ever consulted
it. `sashiko review` builds its provider with `create_provider_from_ai`,
which is uncached, so turning the setting on did nothing on that path and
there was nothing in the output to say so.

`create_provider_cached` cannot be reused there, since it derives the cache
location from `settings.database.url` and a local review holds `AiSettings`
alone with no database beside it. This adds `create_provider_cached_from_ai`,
which places the cache under the XDG data directory already used for the
prompt bundle and lets `SASHIKO_RESPONSE_CACHE` override it. The helper that
resolves that directory is now shared rather than copied. `response_cache`
still defaults to false, so nothing changes unless it is switched on.

It matters most on a retry. A run that fails part way re-issues every
earlier call, and with no cache each of those is paid for again. One such
retry after a late-stage failure cost me $3.33 against a hosted endpoint,
which is what sent me looking at this.

`make check-all` passes, and there is a test for the path resolution
covering both the environment override and the XDG default. I am relying on
#480 having made the cache key safe across provider configurations rather
than having exercised that myself.
