### PR TITLE
forge: derive patchset slug from "repo url" not "pr url"

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1236,7 +1236,7 @@ async fn forge_webhook(
     let commit_range = format!("{}..{}", metadata.base_sha, metadata.head_sha);
     let placeholder_id = format!("mr-{}-{}", metadata.pr_number, commit_range);
 
-    let slug = metadata.pr_url.as_ref().map(|url| {
+    let slug = metadata.repo_url.as_ref().map(|url| {
         let repo = crate::forge::extract_repo_name_from_url(url);
         format!("{}-{}", repo, metadata.pr_number)
     });


### PR DESCRIPTION
The GitHub webhook built the patchset slug from pr_url, whose last path segment is the PR number, producing slugs like 79-79 instead of reponame-79. Extract the repo name from repo_url (the clone URL) instead, matching the documented ([sashiko_document](https://github.com/sashiko-dev/sashiko/blob/54a74baa37f8f9d416903d45aed75dfb01e99b19/src/schema.sql#L88)) reponame-prnum format.