### PR TITLE
ai/gemini: use 'user' role for function responses

### DIFF
--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -570,9 +570,8 @@ fn translate_ai_request(request: AiRequest) -> Result<GenerateContentRequest> {
                 });
             }
             AiRole::Tool => {
-                // Gemini expects a 'function' role for tool responses
                 contents.push(Content {
-                    role: "function".to_string(),
+                    role: "user".to_string(),
                     parts: vec![Part::FunctionResponse {
                         function_response: FunctionResponse {
                             name: msg


### PR DESCRIPTION
When returning function/tool execution outputs to Google's Gemini API (generateContent):, setting the top-level Content role to 'function' causes the endpoint to reject the request with a 400 Bad Request error:

    Role 'function' is not supported. Please use a valid role: SYSTEM,
    USER, ASSISTANT, DEVELOPER, CONTEXT, USER_CONTEXT, MODEL...

In Gemini's API schema, function/tool responses containing a functionResponse part must be submitted under the 'user' role instead of OpenAI's convention of 'function' or 'tool'.

Map function response turns to the 'user' role when constructing the Gemini payload to satisfy API schema validation.