### PR TITLE
ai: add goose as a completion backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please, note that as with any other LLM-based tools, Sashiko's output is probabi
 - **Automated Ingestion**: Monitors mailing lists (`lore.kernel.org`), GitHub PRs, and GitLab MRs for new patch submissions.
 - **Manual Ingestion**: Can ingest patches from local git repositories or specific PRs/MRs.
 - **Forge Integration** *(Experimental)*: Automatic PR/MR review via GitHub and GitLab webhooks. This feature is unofficial and unsupported — use at your own risk.
-- **Self-contained**: Doesn't depend on 3rd-party tools and works with multiple LLM providers (Gemini, Claude, and GitHub Copilot CLI are currently supported).
+- **Self-contained**: Doesn't depend on 3rd-party tools and works with multiple LLM providers (Gemini, Claude, GitHub Copilot CLI and goose are currently supported).
 - **Web interface and CLI**: Provides a web interface for monitoring and a CLI tool for local development. Email support will be added soon.
 
 ## Prompts
@@ -133,7 +133,7 @@ to print the template or `sashiko init --path <file>` to choose a different
 location.
 
 For Claude, Claude Code CLI, GitHub Copilot CLI, AWS Bedrock, Vertex AI,
-Kiro CLI, Devin CLI, and OpenAI-compatible endpoints, see the
+Kiro CLI, Devin CLI, goose, and OpenAI-compatible endpoints, see the
 [LLM Provider Configuration Guide](docs/llm-providers.md).
 
 #### 3.  **Build**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,17 @@ Settings for the Kiro CLI provider (`provider = "kiro-cli"`).
 | `agent` | string | -- | Custom agent name (optional). |
 | `context_window_size` | integer | `200000` | Context window size. |
 
+#### `[ai.goose_cli]`
+
+Settings for the goose provider (`provider = "goose"`).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `binary` | string | `"goose"` | Path to the goose binary. |
+| `goose_provider` | string | `"openai"` | Backend goose itself talks to, passed as GOOSE_PROVIDER. |
+| `env` | table | `{}` | Environment overrides for the goose child process, e.g. `OPENAI_HOST`. goose inherits Sashiko's environment; these entries win. |
+| `context_window_size` | integer | `128000` | Context window size. goose adds roughly 5k tokens of its own prompt, so keep `max_input_tokens` well below this. |
+
 ### `[server]`
 
 | Key | Type | Default | Description |

--- a/docs/examples/Settings.goose-cli.toml
+++ b/docs/examples/Settings.goose-cli.toml
@@ -1,0 +1,29 @@
+[ai]
+provider = "goose"
+# Model identifier the goose backend serves. For a local vLLM server this is
+# the --served-model-name value.
+model = "qwen3-8b-ov"
+api_timeout_secs = 1800
+# goose prepends its own system prompt and platform tool schemas (~5k tokens)
+# to every request, so leave headroom below the server's context length.
+max_input_tokens = 4000
+max_interactions = 50
+
+[ai.goose_cli]
+binary = "goose"
+# Backend goose itself talks to. Any goose provider id works: "openai",
+# "ollama", "anthropic", "google", ...
+goose_provider = "openai"
+context_window_size = 32768
+
+# Environment for the goose child process. goose inherits Sashiko's
+# environment; these entries win. Point the OpenAI-compatible client at a
+# local vLLM server:
+[ai.goose_cli.env]
+OPENAI_HOST = "http://localhost:8000"
+OPENAI_BASE_PATH = "v1/chat/completions"
+OPENAI_API_KEY = "dummy"
+
+[review]
+concurrency = 1
+timeout_seconds = 7200

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -226,6 +226,64 @@ cp docs/examples/Settings.kiro-cli.toml Settings.toml
 - An isolated temporary agent with a deny-all hook prevents accidental
   tool execution
 
+## goose
+
+Uses [goose](https://goose-docs.ai/) as the completion backend.
+goose speaks the Agent Client Protocol on stdio, and it fronts any backend
+goose itself supports, which makes this the shortest path to a fully local
+review: goose in front of a vLLM or Ollama server.
+
+Like Sashiko, goose is a Linux Foundation project -- it sits under the
+[Agentic AI Foundation (AAIF)](https://aaif.io/).
+
+**Prerequisites:** Install `goose` and make sure the backend it points at is
+reachable.
+
+**Apply the example config:**
+
+```bash
+cp docs/examples/Settings.goose-cli.toml Settings.toml
+```
+
+**What you get:**
+
+- Runs `goose acp` as a stateless completion backend
+- Each request gets a throwaway `XDG_CONFIG_HOME` whose `config.yaml` pins
+  goose to chat mode, so goose never runs a tool of its own and Sashiko's
+  tool protocol stays the only tool layer
+- The throwaway config also keeps the user's own goose configuration,
+  extensions and session history out of a review
+- Token usage is taken from goose's own `session/prompt` accounting rather
+  than estimated
+
+**Pointing goose at a local model:**
+
+```toml
+[ai]
+provider = "goose"
+model = "qwen3-8b-ov"
+
+[ai.goose_cli]
+goose_provider = "openai"
+context_window_size = 32768
+
+[ai.goose_cli.env]
+OPENAI_HOST = "http://localhost:8000"
+OPENAI_BASE_PATH = "v1/chat/completions"
+OPENAI_API_KEY = "dummy"
+```
+
+`goose_provider` accepts any goose provider id (`openai`, `ollama`,
+`anthropic`, `google`, ...). The `[ai.goose_cli.env]` table is passed to the
+goose child process; goose inherits Sashiko's environment, so exported
+variables work too and the table only overrides them. Keep real API keys in
+the environment rather than in the settings file.
+
+goose prepends its own system prompt and platform tool schemas to every
+request, which costs roughly 5k tokens before Sashiko's prompt is even
+counted. Set `max_input_tokens` well below `context_window_size` so a review
+prompt plus that overhead still fits.
+
 ## Codex CLI
 
 Uses a local [Codex CLI](https://github.com/openai/codex) (OpenAI)

--- a/src/ai/acp.rs
+++ b/src/ai/acp.rs
@@ -1,0 +1,424 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared Agent Client Protocol (ACP) stdio transport.
+//!
+//! Several coding agents expose an ACP server on stdio. Sashiko drives one as
+//! a stateless completion backend: initialize, open a session, send a single
+//! prompt, collect the streamed agent text, then kill the child. The agent's
+//! own tools are never used -- Sashiko's ToolBox stays the only tool layer, so
+//! callers are expected to launch the agent in whatever no-tool mode it offers.
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+use tracing::debug;
+
+use crate::utils::redact_secret;
+
+pub type StderrPreview = Arc<Mutex<String>>;
+
+const STDERR_PREVIEW_LIMIT: usize = 4096;
+
+/// One ACP subprocess invocation.
+pub struct AcpProcess {
+    /// Prefix used in error messages, e.g. "kiro-cli ACP".
+    pub label: String,
+    /// Executable to spawn.
+    pub binary: String,
+    /// Arguments that put the executable into ACP stdio mode.
+    pub args: Vec<String>,
+    /// Working directory of the child process.
+    pub working_dir: Option<PathBuf>,
+    /// Environment overrides for the child. The parent environment is
+    /// inherited; these entries win.
+    pub env: BTreeMap<String, String>,
+    /// Value sent as the `cwd` of `session/new`. Some agents require an
+    /// absolute path here.
+    pub session_cwd: String,
+}
+
+/// Result of a single ACP prompt.
+pub struct AcpPrompt {
+    /// Concatenated agent message chunks.
+    pub text: String,
+    /// Raw `session/prompt` result, which carries the stop reason and, on some
+    /// agents, token usage.
+    pub result: Value,
+}
+
+impl AcpProcess {
+    /// Runs one prompt to completion against a freshly spawned ACP agent.
+    pub async fn run_prompt(&self, prompt: &str) -> Result<AcpPrompt> {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&self.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        if let Some(dir) = &self.working_dir {
+            cmd.current_dir(dir);
+        }
+        for (key, value) in &self.env {
+            cmd.env(key, value);
+        }
+
+        let mut child = cmd.spawn().map_err(|e| {
+            anyhow::anyhow!("Failed to spawn {}: {}. Is it installed?", self.label, e)
+        })?;
+
+        let stderr_preview: StderrPreview = Arc::new(Mutex::new(String::new()));
+        if let Some(stderr) = child.stderr.take() {
+            let stderr_preview = stderr_preview.clone();
+            let label = self.label.clone();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    record_stderr_line(&stderr_preview, &label, &line).await;
+                }
+            });
+        }
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .with_context(|| format!("{} stdin missing", self.label))?;
+        let stdout = child
+            .stdout
+            .take()
+            .with_context(|| format!("{} stdout missing", self.label))?;
+        let mut lines = BufReader::new(stdout).lines();
+        let mut next_id = 0u64;
+
+        self.write_rpc_checked(
+            &mut stdin,
+            next_id,
+            "initialize",
+            json!({
+                "protocolVersion": 1,
+                "clientCapabilities": {},
+                "clientInfo": {
+                    "name": "sashiko",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+            &stderr_preview,
+        )
+        .await?;
+        self.read_rpc_response(&mut lines, next_id, &stderr_preview, None)
+            .await?;
+        next_id += 1;
+
+        self.write_rpc_checked(
+            &mut stdin,
+            next_id,
+            "session/new",
+            json!({
+                "cwd": self.session_cwd,
+                "mcpServers": [],
+            }),
+            &stderr_preview,
+        )
+        .await?;
+        let session = self
+            .read_rpc_response(&mut lines, next_id, &stderr_preview, None)
+            .await?;
+        let session_id = match session.get("sessionId").and_then(Value::as_str) {
+            Some(session_id) => session_id.to_string(),
+            None => {
+                anyhow::bail!(
+                    "{} session/new response missing sessionId{}",
+                    self.label,
+                    stderr_context(&stderr_preview).await
+                );
+            }
+        };
+        next_id += 1;
+
+        self.write_rpc_checked(
+            &mut stdin,
+            next_id,
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [
+                    {
+                        "type": "text",
+                        "text": prompt,
+                    }
+                ],
+            }),
+            &stderr_preview,
+        )
+        .await?;
+        let mut chunks = Vec::new();
+        let result = self
+            .read_rpc_response(&mut lines, next_id, &stderr_preview, Some(&mut chunks))
+            .await?;
+
+        drop(stdin);
+        let _ = child.kill().await;
+
+        Ok(AcpPrompt {
+            text: chunks.join(""),
+            result,
+        })
+    }
+
+    async fn write_rpc_checked(
+        &self,
+        stdin: &mut ChildStdin,
+        id: u64,
+        method: &str,
+        params: Value,
+        stderr_preview: &StderrPreview,
+    ) -> Result<()> {
+        if let Err(e) = write_rpc(stdin, id, method, params).await {
+            anyhow::bail!(
+                "{} write failed for {}: {}{}",
+                self.label,
+                method,
+                e,
+                stderr_context(stderr_preview).await
+            );
+        }
+        Ok(())
+    }
+
+    async fn read_rpc_response(
+        &self,
+        lines: &mut Lines<BufReader<ChildStdout>>,
+        target_id: u64,
+        stderr_preview: &StderrPreview,
+        mut chunks: Option<&mut Vec<String>>,
+    ) -> Result<Value> {
+        loop {
+            let line = match lines.next_line().await {
+                Ok(Some(line)) => line,
+                Ok(None) => {
+                    anyhow::bail!(
+                        "{} exited before response {}{}",
+                        self.label,
+                        target_id,
+                        stderr_context(stderr_preview).await
+                    );
+                }
+                Err(e) => {
+                    anyhow::bail!(
+                        "{} stdout read failed before response {}: {}{}",
+                        self.label,
+                        target_id,
+                        e,
+                        stderr_context(stderr_preview).await
+                    );
+                }
+            };
+            let msg: Value = match serde_json::from_str(&line) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    debug!("Ignoring malformed ACP stdout line: {} ({})", line, e);
+                    continue;
+                }
+            };
+
+            if msg.get("id").and_then(Value::as_u64) == Some(target_id) {
+                if let Some(error) = msg.get("error") {
+                    let code = error.get("code").and_then(Value::as_i64).unwrap_or(-1);
+                    let message = error
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown ACP error");
+                    anyhow::bail!(
+                        "{} error {}: {}{}",
+                        self.label,
+                        code,
+                        message,
+                        stderr_context(stderr_preview).await
+                    );
+                }
+                return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
+            }
+
+            if let Some(text) = extract_acp_text_chunk(&msg)
+                && let Some(chunks) = chunks.as_deref_mut()
+            {
+                chunks.push(text);
+            }
+        }
+    }
+}
+
+async fn write_rpc(stdin: &mut ChildStdin, id: u64, method: &str, params: Value) -> Result<()> {
+    let msg = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    });
+    let mut line = serde_json::to_string(&msg)?;
+    line.push('\n');
+    stdin.write_all(line.as_bytes()).await?;
+    stdin.flush().await?;
+    Ok(())
+}
+
+async fn record_stderr_line(stderr_preview: &StderrPreview, label: &str, line: &str) {
+    let redacted = redact_secret(line);
+    debug!("[{} stderr] {}", label, redacted);
+
+    if redacted.trim().is_empty() {
+        return;
+    }
+
+    let mut preview = stderr_preview.lock().await;
+    if !preview.is_empty() {
+        preview.push('\n');
+    }
+    preview.push_str(redacted.trim_end());
+    trim_stderr_preview(&mut preview);
+}
+
+fn trim_stderr_preview(preview: &mut String) {
+    if preview.len() <= STDERR_PREVIEW_LIMIT {
+        return;
+    }
+
+    let excess = preview.len() - STDERR_PREVIEW_LIMIT;
+    let drain_to = preview
+        .char_indices()
+        .find_map(|(idx, _)| (idx >= excess).then_some(idx))
+        .unwrap_or(preview.len());
+    preview.drain(..drain_to);
+}
+
+pub async fn stderr_context(stderr_preview: &StderrPreview) -> String {
+    let preview = stderr_preview.lock().await.trim().to_string();
+    if preview.is_empty() {
+        String::new()
+    } else {
+        format!("; stderr: {}", preview)
+    }
+}
+
+pub fn extract_acp_text_chunk(msg: &Value) -> Option<String> {
+    if msg.get("method")?.as_str()? != "session/update" {
+        return None;
+    }
+
+    let update = msg.get("params")?.get("update")?;
+    let update_type = update
+        .get("sessionUpdate")
+        .or_else(|| update.get("type"))?
+        .as_str()?;
+    if !matches!(update_type, "AgentMessageChunk" | "agent_message_chunk") {
+        return None;
+    }
+
+    extract_text_content(update.get("content")?)
+}
+
+fn extract_text_content(content: &Value) -> Option<String> {
+    match content {
+        Value::String(text) => Some(text.clone()),
+        Value::Object(map) => map
+            .get("text")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(extract_text_content)
+                .collect::<Vec<_>>()
+                .join("");
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_snake_case_chunk() {
+        let input = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "hello"}
+                }
+            }
+        });
+        assert_eq!(extract_acp_text_chunk(&input).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn extracts_camel_case_chunk_array() {
+        let input = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "AgentMessageChunk",
+                    "content": [
+                        {"type": "text", "text": "hel"},
+                        {"type": "text", "text": "lo"}
+                    ]
+                }
+            }
+        });
+        assert_eq!(extract_acp_text_chunk(&input).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn ignores_tool_call_updates() {
+        let input = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {"sessionUpdate": "tool_call", "content": {"text": "ignored"}}
+            }
+        });
+        assert!(extract_acp_text_chunk(&input).is_none());
+    }
+
+    #[test]
+    fn trims_preview_to_limit() {
+        let mut preview = "x".repeat(STDERR_PREVIEW_LIMIT + 128);
+        trim_stderr_preview(&mut preview);
+        assert_eq!(preview.len(), STDERR_PREVIEW_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn records_and_redacts_stderr() {
+        let preview: StderrPreview = Arc::new(Mutex::new(String::new()));
+        record_stderr_line(&preview, "test", "boom token=abc123").await;
+        let context = stderr_context(&preview).await;
+        assert!(context.contains("token=[REDACTED]"));
+        assert!(!context.contains("abc123"));
+    }
+}

--- a/src/ai/goose_cli.rs
+++ b/src/ai/goose_cli.rs
@@ -1,0 +1,398 @@
+// Copyright 2026 The Sashiko Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! AI provider that shells out to `goose acp`.
+//!
+//! [goose](https://goose-docs.ai/) is an open-source agent that speaks
+//! the Agent Client Protocol on stdio and can front any of its own configured
+//! backends, including a local vLLM or Ollama server. Sashiko drives it as a
+//! pure completion backend.
+//!
+//! goose is part of the Agentic AI Foundation (AAIF) at the Linux Foundation,
+//! as is Sashiko.
+//!
+//! Each request runs in a throwaway configuration directory whose `config.yaml`
+//! pins goose to chat mode, so goose never executes a tool of its own:
+//! Sashiko's ToolBox stays the only tool layer. The directory also keeps the
+//! user's own goose configuration and session history out of a review.
+//!
+//! goose reports token usage in its `session/prompt` result, which is used
+//! verbatim when present. Note that goose prepends its own system prompt and
+//! platform tool schemas to every request, so its input token count is
+//! noticeably higher than the prompt Sashiko sends. Budget for that when
+//! setting `context_window_size`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::timeout;
+use tracing::debug;
+
+use super::acp::AcpProcess;
+use super::claude_cli::{build_prompt, parse_inner_response};
+use super::token_budget::TokenBudget;
+use crate::ai::{AiProvider, AiRequest, AiResponse, AiUsage, ProviderCapabilities};
+
+pub struct GooseCliProvider {
+    /// Model identifier passed to goose as GOOSE_MODEL.
+    pub model: String,
+    /// goose executable.
+    pub binary: String,
+    /// Backend goose itself talks to, passed as GOOSE_PROVIDER.
+    pub goose_provider: String,
+    /// Extra environment for the child, e.g. OPENAI_HOST for a local vLLM
+    /// server. The parent environment is inherited; these entries win.
+    pub env: BTreeMap<String, String>,
+    pub context_window_size: usize,
+    pub timeout_secs: u64,
+}
+
+/// Isolated goose configuration. Chat mode is what makes goose a completion
+/// backend: it answers with text and never calls a tool.
+const CONFIG_YAML: &str = "GOOSE_MODE: chat\n\
+GOOSE_TELEMETRY_ENABLED: false\n\
+extensions: {}\n";
+
+/// Builds the arguments that put goose into ACP stdio mode.
+fn build_args() -> Vec<String> {
+    vec!["acp".to_string()]
+}
+
+/// Creates the throwaway configuration directory for one goose run. The
+/// returned TempDir must outlive the child process.
+fn create_isolated_config() -> Result<TempDir> {
+    let tmp = tempfile::tempdir()?;
+    let config_dir = tmp.path().join("goose");
+    std::fs::create_dir_all(&config_dir)?;
+    std::fs::write(config_dir.join("config.yaml"), CONFIG_YAML)?;
+    Ok(tmp)
+}
+
+/// Environment for one goose run. `env` overrides are applied last so a
+/// configuration file can correct any default.
+fn build_env(
+    model: &str,
+    goose_provider: &str,
+    context_window_size: usize,
+    config_home: &str,
+    extra: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    env.insert("XDG_CONFIG_HOME".to_string(), config_home.to_string());
+    env.insert("GOOSE_PROVIDER".to_string(), goose_provider.to_string());
+    env.insert("GOOSE_MODEL".to_string(), model.to_string());
+    env.insert("GOOSE_MODE".to_string(), "chat".to_string());
+    env.insert("GOOSE_DISABLE_KEYRING".to_string(), "1".to_string());
+    env.insert("GOOSE_TELEMETRY_ENABLED".to_string(), "false".to_string());
+    env.insert(
+        "GOOSE_CONTEXT_LIMIT".to_string(),
+        context_window_size.to_string(),
+    );
+    for (key, value) in extra {
+        env.insert(key.clone(), value.clone());
+    }
+    env
+}
+
+/// Reads goose's own token accounting out of a `session/prompt` result.
+fn usage_from_result(result: &Value) -> Option<AiUsage> {
+    let usage = result.get("usage")?;
+    let field = |name: &str| usage.get(name).and_then(Value::as_u64).map(|v| v as usize);
+
+    let prompt_tokens = field("inputTokens")?;
+    let completion_tokens = field("outputTokens")?;
+    let total_tokens = field("totalTokens").unwrap_or(prompt_tokens + completion_tokens);
+
+    Some(AiUsage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        cached_tokens: None,
+    })
+}
+
+impl GooseCliProvider {
+    async fn run_acp_prompt(&self, prompt: &str) -> Result<(String, Value)> {
+        let tmp = create_isolated_config()?;
+        let config_home = tmp.path().to_string_lossy().to_string();
+
+        let process = AcpProcess {
+            label: "goose acp".to_string(),
+            binary: self.binary.clone(),
+            args: build_args(),
+            working_dir: Some(tmp.path().to_path_buf()),
+            env: build_env(
+                &self.model,
+                &self.goose_provider,
+                self.context_window_size,
+                &config_home,
+                &self.env,
+            ),
+            // goose rejects a relative session cwd.
+            session_cwd: config_home,
+        };
+
+        let prompt = process.run_prompt(prompt).await?;
+        Ok((prompt.text, prompt.result))
+    }
+}
+
+#[async_trait]
+impl AiProvider for GooseCliProvider {
+    async fn generate_content(&self, request: AiRequest) -> Result<AiResponse> {
+        let prompt = build_prompt(&request);
+        debug!("goose prompt length: {} chars", prompt.len());
+
+        let (text, result) = timeout(
+            Duration::from_secs(self.timeout_secs),
+            self.run_acp_prompt(&prompt),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("goose acp timed out after {} seconds", self.timeout_secs)
+        })??;
+
+        // goose reports its own token counts; fall back to estimates when a
+        // build omits them.
+        let usage = usage_from_result(&result).or_else(|| {
+            let prompt_tokens = TokenBudget::estimate_tokens(&prompt);
+            let completion_tokens = TokenBudget::estimate_tokens(&text);
+            Some(AiUsage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+                cached_tokens: None,
+            })
+        });
+
+        parse_inner_response(&text, usage)
+    }
+
+    fn estimate_tokens(&self, request: &AiRequest) -> usize {
+        let prompt = build_prompt(request);
+        TokenBudget::estimate_tokens(&prompt)
+    }
+
+    fn get_capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            model_name: self.model.clone(),
+            context_window_size: self.context_window_size,
+        }
+    }
+
+    fn cache_identity(&self) -> String {
+        // The backend goose fronts changes the answer, so it belongs in the
+        // identity. context_window_size stays out: it only budgets the prompt
+        // the cache already hashes.
+        crate::ai::cache_identity_with(&self.model, &[("provider", Some(&self.goose_provider))])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{AiMessage, AiRole, AiTool, create_provider};
+    use crate::settings::Settings;
+
+    fn test_provider(binary: &str, goose_provider: &str) -> GooseCliProvider {
+        GooseCliProvider {
+            model: "qwen3-8b-ov".to_string(),
+            binary: binary.to_string(),
+            goose_provider: goose_provider.to_string(),
+            env: BTreeMap::new(),
+            context_window_size: 8192,
+            timeout_secs: 60,
+        }
+    }
+
+    fn sample_request() -> AiRequest {
+        AiRequest {
+            system: Some("You are a kernel reviewer.".to_string()),
+            messages: vec![AiMessage {
+                role: AiRole::User,
+                content: Some("Review this patch.".to_string()),
+                thought: None,
+                thought_signature: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: Some(vec![AiTool {
+                name: "read_file".to_string(),
+                description: "Read a file".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            temperature: None,
+            response_format: None,
+            context_tag: None,
+        }
+    }
+
+    #[test]
+    fn args_request_acp_mode() {
+        assert_eq!(build_args(), vec!["acp".to_string()]);
+    }
+
+    #[test]
+    fn isolated_config_pins_chat_mode() {
+        let tmp = create_isolated_config().unwrap();
+        let config = std::fs::read_to_string(tmp.path().join("goose/config.yaml")).unwrap();
+        assert!(config.contains("GOOSE_MODE: chat"));
+        assert!(config.contains("extensions: {}"));
+    }
+
+    #[test]
+    fn env_pins_provider_model_and_config_home() {
+        let env = build_env("m1", "openai", 4096, "/tmp/cfg", &BTreeMap::new());
+        assert_eq!(env.get("GOOSE_MODEL").unwrap(), "m1");
+        assert_eq!(env.get("GOOSE_PROVIDER").unwrap(), "openai");
+        assert_eq!(env.get("GOOSE_MODE").unwrap(), "chat");
+        assert_eq!(env.get("GOOSE_CONTEXT_LIMIT").unwrap(), "4096");
+        assert_eq!(env.get("XDG_CONFIG_HOME").unwrap(), "/tmp/cfg");
+    }
+
+    #[test]
+    fn env_overrides_win() {
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "OPENAI_HOST".to_string(),
+            "http://localhost:8000".to_string(),
+        );
+        extra.insert("GOOSE_MODE".to_string(), "auto".to_string());
+        let env = build_env("m1", "openai", 4096, "/tmp/cfg", &extra);
+        assert_eq!(env.get("OPENAI_HOST").unwrap(), "http://localhost:8000");
+        assert_eq!(env.get("GOOSE_MODE").unwrap(), "auto");
+    }
+
+    #[test]
+    fn cache_identity_tracks_backend_provider() {
+        let openai = test_provider("goose", "openai");
+        let ollama = test_provider("goose", "ollama");
+        assert_ne!(openai.cache_identity(), ollama.cache_identity());
+    }
+
+    #[test]
+    fn usage_is_read_from_prompt_result() {
+        let result = serde_json::json!({
+            "stopReason": "end_turn",
+            "usage": {"totalTokens": 5114, "inputTokens": 4992, "outputTokens": 122}
+        });
+        let usage = usage_from_result(&result).unwrap();
+        assert_eq!(usage.prompt_tokens, 4992);
+        assert_eq!(usage.completion_tokens, 122);
+        assert_eq!(usage.total_tokens, 5114);
+    }
+
+    #[test]
+    fn usage_is_absent_without_counts() {
+        let result = serde_json::json!({"stopReason": "end_turn"});
+        assert!(usage_from_result(&result).is_none());
+    }
+
+    #[test]
+    fn estimate_tokens_is_non_zero() {
+        let provider = test_provider("goose", "openai");
+        assert!(provider.estimate_tokens(&sample_request()) > 0);
+    }
+
+    #[test]
+    fn factory_creates_provider() {
+        let mut settings = Settings::new().expect("Failed to load settings");
+        settings.ai.provider = "goose".to_string();
+        settings.ai.model = "qwen3-8b-ov".to_string();
+
+        let provider = create_provider(&settings).unwrap();
+        let caps = provider.get_capabilities();
+        assert_eq!(caps.model_name, "qwen3-8b-ov");
+        assert_eq!(caps.context_window_size, 128_000);
+    }
+
+    /// Fake ACP agent: replies to initialize, session/new and session/prompt.
+    fn fake_goose(dir: &std::path::Path) -> std::path::PathBuf {
+        let fake = dir.join("fake-goose");
+        std::fs::write(
+            &fake,
+            r#"#!/bin/sh
+i=0
+while IFS= read -r line; do
+  case "$i" in
+    0) printf '%s\n' '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1}}' ;;
+    1) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"20260911_1"}}' ;;
+    2)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"20260911_1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"content\":\"ok\"}"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn","usage":{"totalTokens":30,"inputTokens":20,"outputTokens":10}}}'
+      exit 0
+      ;;
+  esac
+  i=$((i + 1))
+done
+"#,
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        fake
+    }
+
+    #[tokio::test]
+    async fn generate_content_with_fake_acp_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = fake_goose(tmp.path());
+        let provider = test_provider(&fake.to_string_lossy(), "openai");
+
+        let response = provider.generate_content(sample_request()).await.unwrap();
+        assert_eq!(response.content.as_deref(), Some("ok"));
+        let usage = response.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 20);
+        assert_eq!(usage.completion_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn generate_content_reports_redacted_stderr_on_exit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = tmp.path().join("failing-goose");
+        std::fs::write(
+            &fake,
+            r#"#!/bin/sh
+printf '%s\n' 'provider rejected request api_key=abc123' >&2
+sleep 0.1
+exit 2
+"#,
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let provider = test_provider(&fake.to_string_lossy(), "openai");
+        let err = provider
+            .generate_content(sample_request())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("goose acp exited before response 0"));
+        assert!(err.contains("api_key=[REDACTED]"));
+        assert!(!err.contains("abc123"));
+    }
+}

--- a/src/ai/kiro_cli.rs
+++ b/src/ai/kiro_cli.rs
@@ -19,23 +19,18 @@
 //! This makes the provider a pure completion backend: Sashiko's own ToolBox
 //! remains the only tool execution layer.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use serde_json::{Value, json};
-use std::process::Stdio;
-use std::sync::Arc;
+use std::collections::BTreeMap;
 use std::time::Duration;
 use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
-use tokio::process::{ChildStdin, ChildStdout, Command};
-use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::debug;
 
+use super::acp::AcpProcess;
 use super::claude_cli::{build_prompt, parse_inner_response};
 use super::token_budget::TokenBudget;
 use crate::ai::{AiProvider, AiRequest, AiResponse, AiUsage, ProviderCapabilities};
-use crate::utils::redact_secret;
 
 pub struct KiroCliProvider {
     pub model: String,
@@ -44,9 +39,6 @@ pub struct KiroCliProvider {
     pub context_window_size: usize,
     pub timeout_secs: u64,
 }
-
-type StderrPreview = Arc<Mutex<String>>;
-const STDERR_PREVIEW_LIMIT: usize = 4096;
 
 /// Agent JSON for the isolated no-tool Sashiko provider agent.
 const AGENT_JSON: &str = r#"{
@@ -105,170 +97,6 @@ fn create_isolated_workspace() -> Result<TempDir> {
     Ok(tmp)
 }
 
-async fn write_rpc(stdin: &mut ChildStdin, id: u64, method: &str, params: Value) -> Result<()> {
-    let msg = json!({
-        "jsonrpc": "2.0",
-        "id": id,
-        "method": method,
-        "params": params,
-    });
-    let mut line = serde_json::to_string(&msg)?;
-    line.push('\n');
-    stdin.write_all(line.as_bytes()).await?;
-    stdin.flush().await?;
-    Ok(())
-}
-
-async fn write_rpc_checked(
-    stdin: &mut ChildStdin,
-    id: u64,
-    method: &str,
-    params: Value,
-    stderr_preview: &StderrPreview,
-) -> Result<()> {
-    if let Err(e) = write_rpc(stdin, id, method, params).await {
-        anyhow::bail!(
-            "kiro-cli ACP write failed for {}: {}{}",
-            method,
-            e,
-            stderr_context(stderr_preview).await
-        );
-    }
-    Ok(())
-}
-
-async fn read_rpc_response(
-    lines: &mut Lines<BufReader<ChildStdout>>,
-    target_id: u64,
-    stderr_preview: &StderrPreview,
-    mut chunks: Option<&mut Vec<String>>,
-) -> Result<Value> {
-    loop {
-        let line = match lines.next_line().await {
-            Ok(Some(line)) => line,
-            Ok(None) => {
-                anyhow::bail!(
-                    "kiro-cli ACP exited before response {}{}",
-                    target_id,
-                    stderr_context(stderr_preview).await
-                );
-            }
-            Err(e) => {
-                anyhow::bail!(
-                    "kiro-cli ACP stdout read failed before response {}: {}{}",
-                    target_id,
-                    e,
-                    stderr_context(stderr_preview).await
-                );
-            }
-        };
-        let msg: Value = match serde_json::from_str(&line) {
-            Ok(msg) => msg,
-            Err(e) => {
-                debug!("Ignoring malformed ACP stdout line: {} ({})", line, e);
-                continue;
-            }
-        };
-
-        if msg.get("id").and_then(Value::as_u64) == Some(target_id) {
-            if let Some(error) = msg.get("error") {
-                let code = error.get("code").and_then(Value::as_i64).unwrap_or(-1);
-                let message = error
-                    .get("message")
-                    .and_then(Value::as_str)
-                    .unwrap_or("unknown ACP error");
-                anyhow::bail!(
-                    "kiro-cli ACP error {}: {}{}",
-                    code,
-                    message,
-                    stderr_context(stderr_preview).await
-                );
-            }
-            return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
-        }
-
-        if let Some(text) = extract_acp_text_chunk(&msg)
-            && let Some(chunks) = chunks.as_deref_mut()
-        {
-            chunks.push(text);
-        }
-    }
-}
-
-async fn record_stderr_line(stderr_preview: &StderrPreview, line: &str) {
-    let redacted = redact_secret(line);
-    debug!("[kiro-cli acp stderr] {}", redacted);
-
-    if redacted.trim().is_empty() {
-        return;
-    }
-
-    let mut preview = stderr_preview.lock().await;
-    if !preview.is_empty() {
-        preview.push('\n');
-    }
-    preview.push_str(redacted.trim_end());
-    trim_stderr_preview(&mut preview);
-}
-
-fn trim_stderr_preview(preview: &mut String) {
-    if preview.len() <= STDERR_PREVIEW_LIMIT {
-        return;
-    }
-
-    let excess = preview.len() - STDERR_PREVIEW_LIMIT;
-    let drain_to = preview
-        .char_indices()
-        .find_map(|(idx, _)| (idx >= excess).then_some(idx))
-        .unwrap_or(preview.len());
-    preview.drain(..drain_to);
-}
-
-async fn stderr_context(stderr_preview: &StderrPreview) -> String {
-    let preview = stderr_preview.lock().await.trim().to_string();
-    if preview.is_empty() {
-        String::new()
-    } else {
-        format!("; stderr: {}", preview)
-    }
-}
-
-fn extract_acp_text_chunk(msg: &Value) -> Option<String> {
-    if msg.get("method")?.as_str()? != "session/update" {
-        return None;
-    }
-
-    let update = msg.get("params")?.get("update")?;
-    let update_type = update
-        .get("sessionUpdate")
-        .or_else(|| update.get("type"))?
-        .as_str()?;
-    if !matches!(update_type, "AgentMessageChunk" | "agent_message_chunk") {
-        return None;
-    }
-
-    extract_text_content(update.get("content")?)
-}
-
-fn extract_text_content(content: &Value) -> Option<String> {
-    match content {
-        Value::String(text) => Some(text.clone()),
-        Value::Object(map) => map
-            .get("text")
-            .and_then(Value::as_str)
-            .map(ToString::to_string),
-        Value::Array(items) => {
-            let text = items
-                .iter()
-                .filter_map(extract_text_content)
-                .collect::<Vec<_>>()
-                .join("");
-            (!text.is_empty()).then_some(text)
-        }
-        _ => None,
-    }
-}
-
 impl KiroCliProvider {
     async fn run_acp_prompt(
         &self,
@@ -276,104 +104,16 @@ impl KiroCliProvider {
         agent_name: &str,
         isolated_workspace: Option<&TempDir>,
     ) -> Result<String> {
-        let args = build_args(&self.model, agent_name);
-
-        let mut cmd = Command::new(&self.binary);
-        cmd.args(&args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-
-        if let Some(tmp) = isolated_workspace {
-            cmd.current_dir(tmp.path());
-        }
-
-        cmd.kill_on_drop(true);
-        let mut child = cmd.spawn().map_err(|e| {
-            anyhow::anyhow!("Failed to spawn kiro-cli ACP: {}. Is it installed?", e)
-        })?;
-
-        let stderr_preview = Arc::new(Mutex::new(String::new()));
-        if let Some(stderr) = child.stderr.take() {
-            let stderr_preview = stderr_preview.clone();
-            tokio::spawn(async move {
-                let mut lines = BufReader::new(stderr).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    record_stderr_line(&stderr_preview, &line).await;
-                }
-            });
-        }
-
-        let mut stdin = child.stdin.take().context("kiro-cli ACP stdin missing")?;
-        let stdout = child.stdout.take().context("kiro-cli ACP stdout missing")?;
-        let mut lines = BufReader::new(stdout).lines();
-        let mut next_id = 0u64;
-
-        write_rpc_checked(
-            &mut stdin,
-            next_id,
-            "initialize",
-            json!({
-                "protocolVersion": 1,
-                "clientCapabilities": {},
-                "clientInfo": {
-                    "name": "sashiko",
-                    "version": env!("CARGO_PKG_VERSION"),
-                },
-            }),
-            &stderr_preview,
-        )
-        .await?;
-        read_rpc_response(&mut lines, next_id, &stderr_preview, None).await?;
-        next_id += 1;
-
-        write_rpc_checked(
-            &mut stdin,
-            next_id,
-            "session/new",
-            json!({
-                "cwd": ".",
-                "mcpServers": [],
-            }),
-            &stderr_preview,
-        )
-        .await?;
-        let session = read_rpc_response(&mut lines, next_id, &stderr_preview, None).await?;
-        let session_id = match session.get("sessionId").and_then(Value::as_str) {
-            Some(session_id) => session_id.to_string(),
-            None => {
-                anyhow::bail!(
-                    "kiro-cli ACP session/new response missing sessionId{}",
-                    stderr_context(&stderr_preview).await
-                );
-            }
+        let process = AcpProcess {
+            label: "kiro-cli ACP".to_string(),
+            binary: self.binary.clone(),
+            args: build_args(&self.model, agent_name),
+            working_dir: isolated_workspace.map(|tmp| tmp.path().to_path_buf()),
+            env: BTreeMap::new(),
+            session_cwd: ".".to_string(),
         };
-        next_id += 1;
 
-        write_rpc_checked(
-            &mut stdin,
-            next_id,
-            "session/prompt",
-            json!({
-                "sessionId": session_id,
-                "prompt": [
-                    {
-                        "type": "text",
-                        "text": prompt,
-                    }
-                ],
-            }),
-            &stderr_preview,
-        )
-        .await?;
-        let mut chunks = Vec::new();
-        read_rpc_response(&mut lines, next_id, &stderr_preview, Some(&mut chunks)).await?;
-
-        drop(stdin);
-        let _ = child.kill().await;
-
-        Ok(chunks.join(""))
+        Ok(process.run_prompt(prompt).await?.text)
     }
 }
 
@@ -559,54 +299,6 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_acp_text_chunk_snake_case() {
-        let input = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": "session/update",
-            "params": {
-                "sessionId": "s1",
-                "update": {
-                    "sessionUpdate": "agent_message_chunk",
-                    "content": {"type": "text", "text": "hello"}
-                }
-            }
-        });
-        assert_eq!(extract_acp_text_chunk(&input).as_deref(), Some("hello"));
-    }
-
-    #[test]
-    fn test_extract_acp_text_chunk_camel_case() {
-        let input = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": "session/update",
-            "params": {
-                "sessionId": "s1",
-                "update": {
-                    "sessionUpdate": "AgentMessageChunk",
-                    "content": [
-                        {"type": "text", "text": "hel"},
-                        {"type": "text", "text": "lo"}
-                    ]
-                }
-            }
-        });
-        assert_eq!(extract_acp_text_chunk(&input).as_deref(), Some("hello"));
-    }
-
-    #[test]
-    fn test_extract_acp_ignores_tool_updates() {
-        let input = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": "session/update",
-            "params": {
-                "sessionId": "s1",
-                "update": {"sessionUpdate": "tool_call", "content": {"text": "ignored"}}
-            }
-        });
-        assert!(extract_acp_text_chunk(&input).is_none());
-    }
-
-    #[test]
     fn test_parse_tool_calls_json() {
         let text = r#"{"tool_calls":[{"id":"c1","function_name":"read_file","arguments":{"path":"README.md"}}]}"#;
         let resp = parse_inner_response(text, None).unwrap();
@@ -727,11 +419,5 @@ exit 2
         assert!(err.contains("kiro-cli ACP exited before response 0"));
         assert!(err.contains("stderr: authentication failed token=[REDACTED]"));
         assert!(!err.contains("abc123"));
-    }
-
-    #[test]
-    fn test_redact_secret_available_for_error_previews() {
-        let redacted = redact_secret("kiro failed with token=abc123");
-        assert_eq!(redacted, "kiro failed with token=[REDACTED]");
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -638,6 +638,7 @@ pub fn create_provider_from_ai(ai: &AiSettings) -> Result<Arc<dyn AiProvider>> {
         p => bail!("Unsupported AI provider: {}", p),
     }
 }
+pub mod acp;
 pub mod backoff_provider;
 #[cfg(feature = "bedrock")]
 pub mod bedrock;

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -604,6 +604,21 @@ pub fn create_provider_from_ai(ai: &AiSettings) -> Result<Arc<dyn AiProvider>> {
                 timeout_secs: ai.api_timeout_secs,
             }))
         }
+        "goose" | "goose-cli" => {
+            let cfg = ai.goose_cli.as_ref();
+            Ok(Arc::new(goose_cli::GooseCliProvider {
+                model: ai.model.clone(),
+                binary: cfg
+                    .map(|c| c.binary.clone())
+                    .unwrap_or_else(|| "goose".to_string()),
+                goose_provider: cfg
+                    .map(|c| c.goose_provider.clone())
+                    .unwrap_or_else(|| "openai".to_string()),
+                env: cfg.map(|c| c.env.clone()).unwrap_or_default(),
+                context_window_size: cfg.map(|c| c.context_window_size).unwrap_or(128_000),
+                timeout_secs: ai.api_timeout_secs,
+            }))
+        }
         #[cfg(feature = "vertex")]
         "vertex" => {
             let model = ai.model.clone();
@@ -650,6 +665,7 @@ pub mod concurrency_limited_provider;
 pub mod copilot_cli;
 pub mod devin_cli;
 pub mod gemini;
+pub mod goose_cli;
 pub mod kiro_cli;
 pub mod logging_provider;
 pub mod ollama;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -308,6 +308,36 @@ fn default_kiro_cli_context_window() -> usize {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[allow(unused)]
+pub struct GooseCliSettings {
+    #[serde(default = "default_goose_cli_binary")]
+    pub binary: String,
+    /// Backend goose itself talks to, passed as GOOSE_PROVIDER. Use "openai"
+    /// with an OPENAI_HOST override for a local vLLM server.
+    #[serde(default = "default_goose_cli_provider")]
+    pub goose_provider: String,
+    /// Environment overrides for the goose child process, e.g. OPENAI_HOST.
+    /// goose inherits Sashiko's environment; these entries win.
+    #[serde(default)]
+    pub env: std::collections::BTreeMap<String, String>,
+    #[serde(default = "default_goose_cli_context_window")]
+    pub context_window_size: usize,
+}
+
+fn default_goose_cli_binary() -> String {
+    "goose".to_string()
+}
+
+fn default_goose_cli_provider() -> String {
+    "openai".to_string()
+}
+
+fn default_goose_cli_context_window() -> usize {
+    128_000
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[allow(unused)]
 pub struct ClaudeCliSettings {
     /// Effort level passed to `claude --effort`. Valid values per Claude Code:
     /// "low", "medium", "high", "xhigh", "max". Leave unset for the model default.
@@ -380,6 +410,7 @@ pub struct AiSettings {
     pub ollama: Option<OllamaSettings>,
     pub vllm: Option<VllmSettings>,
     pub kiro_cli: Option<KiroCliSettings>,
+    pub goose_cli: Option<GooseCliSettings>,
     pub claude_cli: Option<ClaudeCliSettings>,
     pub codex_cli: Option<CodexCliSettings>,
     pub devin_cli: Option<DevinCliSettings>,


### PR DESCRIPTION
Adds [goose](https://goose-docs.ai/) as a Sashiko LLM provider, and extracts the ACP transport it shares with the existing kiro-cli provider into its own module first.

goose is a fellow Linux Foundation project, under the [Agentic AI Foundation (AAIF)](https://aaif.io/), which makes it a natural provider for Sashiko to support directly.

goose speaks the Agent Client Protocol on stdio and fronts any backend it is configured with, so one provider covers every model goose can reach. The motivation is a fully local review: goose in front of a vLLM or Ollama server, no API key anywhere, no patch data leaving the machine.

## Commit 1: shared ACP transport

The kiro-cli provider carried its own JSON-RPC plumbing: spawn the child, `initialize`, `session/new`, one `session/prompt`, collect the streamed `agent_message_chunk` text, keep a redacted stderr preview for error messages. None of that is specific to kiro-cli. @anders-heimer 

`src/ai/acp.rs` now owns it behind an `AcpProcess` description of the child:
```rust
pub struct AcpProcess {
    pub label: String,              // error-message prefix
    pub binary: String,
    pub args: Vec<String>,
    pub working_dir: Option<PathBuf>,
    pub env: BTreeMap<String, String>,
    pub session_cwd: String,
}
```

`label` preserves the existing kiro-cli error wording verbatim. `session_cwd`, `working_dir` and `env` became parameters because goose rejects a relative session cwd and needs environment overrides, where kiro-cli sends `"."` and no extra environment. `run_prompt` returns the raw `session/prompt` result alongside the text, which commit 2 uses for token
accounting.

kiro-cli behaviour is unchanged: same arguments, same isolated no-tool agent, same deny-all hook, same relative session cwd. Its ACP helper unit tests moved to `ai::acp` along with the code; its provider-level tests, including the fake
ACP server test, stay and pass unmodified.

## Commit 2: the goose provider

`provider = "goose"` (or `"goose-cli"`) selects `GooseCliProvider`, which runs `goose acp`.

**Tool isolation.** Sashiko's ToolBox has to remain the only tool layer, so each request gets a throwaway `XDG_CONFIG_HOME` containing a `config.yaml` that pins `GOOSE_MODE: chat`. In chat mode goose answers with text and never executes a tool. The throwaway directory also keeps the user's own goose configuration, extensions and session history out of a review. This is the same intent as the kiro-cli isolated agent, expressed with the lever goose offers.

**Configuration.**
```toml
[ai]
provider = "goose"
model = "qwen3-8b-ov"

[ai.goose_cli]
binary = "goose"
goose_provider = "openai"
context_window_size = 32768

[ai.goose_cli.env]
OPENAI_HOST = "http://localhost:8000"
OPENAI_BASE_PATH = "v1/chat/completions"
OPENAI_API_KEY = "dummy"
```

`goose_provider` is any goose provider id. The `env` table is passed to the child; goose inherits Sashiko's environment, so the table is only needed for overrides, and the documentation asks for real API keys to stay in the environment rather than in the settings file.

**Token accounting.** goose reports usage in its `session/prompt` result, so `AiUsage` carries goose's own counts instead of estimates, with a fallback to `TokenBudget` estimates if a build omits them.

**Context overhead, documented.** goose prepends its own system prompt and platform tool schemas to every request. Measured against a local vLLM server, a one-line prompt still reports 4992 input tokens, and chat mode does not reduce this. `max_input_tokens` therefore has to stay well below `context_window_size`; both the provider guide and the example config say so.

## Files

| File | Change |
| --- | --- |
| `src/ai/acp.rs` | new: shared ACP stdio transport |
| `src/ai/goose_cli.rs` | new: the provider |
| `src/ai/mod.rs` | module declarations, `"goose"`/`"goose-cli"` factory arm |
| `src/settings.rs` | `GooseCliSettings`, `[ai.goose_cli]` |
| `docs/llm-providers.md` | goose section |
| `docs/configuration.md` | `[ai.goose_cli]` reference table |
| `docs/examples/Settings.goose-cli.toml` | new example |
| `README.md` | provider lists |

## Testing

`make check-pr` passes (sob, fmt, clippy, yamllint, tests).

New unit tests: 11 in `ai::goose_cli`, 5 in `ai::acp`.

- argument construction, isolated config contents, environment precedence
- usage parsing from a real `session/prompt` result, and its absence
- `cache_identity` distinguishes the backend goose fronts
- factory construction from settings
- end-to-end `generate_content` against a fake ACP agent script
- error path: agent exits early, and the reported stderr is redacted

Manual verification, goose 1.50 in front of vLLM 0.26.0 with the OpenVINO plugin on an Intel Arc 140V iGPU serving `OpenVINO/Qwen3-8B-int4-ov`:

- ACP handshake, session and prompt all succeed; usage is reported as  `{"totalTokens": 5114, "inputTokens": 4992, "outputTokens": 122}`
- `sashiko review HEAD~2..HEAD` with [patch-set](https://lore.kernel.org/all/20260820142429.2285172-1-kyle.swenson@est.tech/) on a stable tree first makes the provider pre-screen the patches and then plan the review.

For goose, approximately 5K tokens of the 32K context window are used for its prompt and tool definitions. Chat mode does not stop goose from advertising its platform tools to the backend, it only stops execution. If a future goose release grows a switch to skip platform extensions entirely, wiring it here would cut roughly 5k tokens per request.
